### PR TITLE
feat: fall back to local source branch when origin is unreachable

### DIFF
--- a/src/__tests__/git-ops.test.ts
+++ b/src/__tests__/git-ops.test.ts
@@ -32,6 +32,7 @@ import {
   listBranches,
   listCommitsBehind,
   listRemoteBranches,
+  localBranchExists,
   mergeBranch,
   pullBranch,
   pushBranch,
@@ -82,6 +83,16 @@ describe('listBranches(repoPath)', () => {
     branches.forEach((b) => {
       expect(typeof b).toBe('string')
     })
+  })
+})
+
+describe('localBranchExists', () => {
+  it('returns true for an existing local branch', () => {
+    expect(localBranchExists(repoDir, 'main')).toBe(true)
+  })
+
+  it('returns false for a branch that does not exist locally', () => {
+    expect(localBranchExists(repoDir, 'does-not-exist')).toBe(false)
   })
 })
 

--- a/src/__tests__/routes-workspaces.test.ts
+++ b/src/__tests__/routes-workspaces.test.ts
@@ -522,7 +522,10 @@ describe('POST /api/workspaces', () => {
       worktreesPrefixByProject: false,
     })
     vi.mocked(workspaceService.createWorkspace).mockReturnValue(fakeWorkspace)
-    vi.mocked(worktreeService.createWorktree).mockReturnValue({ worktreePath: '/home/test/kobo/worktress/feature/test', base: 'origin' })
+    vi.mocked(worktreeService.createWorktree).mockReturnValue({
+      worktreePath: '/home/test/kobo/worktress/feature/test',
+      base: 'origin',
+    })
     vi.mocked(workspaceService.listTasks).mockReturnValue([])
     vi.mocked(workspaceService.getWorkspaceWithTasks).mockReturnValue(fakeWorkspaceWithTasks)
 
@@ -4746,7 +4749,10 @@ describe('POST /api/workspaces — worktree path collision', () => {
     } as never)
     vi.mocked(fs.existsSync).mockReturnValue(false)
     vi.mocked(workspaceService.createWorkspace).mockReturnValue(fakeWorkspace)
-    vi.mocked(worktreeService.createWorktree).mockReturnValue({ worktreePath: '/tmp/project/.worktrees/sekur/feature/test', base: 'origin' })
+    vi.mocked(worktreeService.createWorktree).mockReturnValue({
+      worktreePath: '/tmp/project/.worktrees/sekur/feature/test',
+      base: 'origin',
+    })
     vi.mocked(workspaceService.listTasks).mockReturnValue([])
     vi.mocked(workspaceService.getWorkspaceWithTasks).mockReturnValue(fakeWorkspaceWithTasks)
 

--- a/src/__tests__/routes-workspaces.test.ts
+++ b/src/__tests__/routes-workspaces.test.ts
@@ -123,6 +123,7 @@ vi.mock('../server/services/sentry-service.js', () => ({
 
 vi.mock('../server/utils/git-ops.js', () => ({
   fetchSourceBranch: vi.fn(),
+  localBranchExists: vi.fn(),
   // Mirror the real branch-segment sanitizer so ticket-id branch composition works.
   slugifyBranchSegment: (input: string, maxLen = 50) =>
     input
@@ -448,7 +449,7 @@ describe('GET /api/workspaces', () => {
 describe('POST /api/workspaces', () => {
   it('creates workspace without Notion URL', async () => {
     vi.mocked(workspaceService.createWorkspace).mockReturnValue(fakeWorkspace)
-    vi.mocked(worktreeService.createWorktree).mockReturnValue('/tmp/worktree')
+    vi.mocked(worktreeService.createWorktree).mockReturnValue({ worktreePath: '/tmp/worktree', base: 'origin' })
     vi.mocked(workspaceService.listTasks).mockReturnValue([])
     vi.mocked(workspaceService.getWorkspaceWithTasks).mockReturnValue(fakeWorkspaceWithTasks)
 
@@ -470,7 +471,7 @@ describe('POST /api/workspaces', () => {
     expect(worktreeService.createWorktree).toHaveBeenCalledWith(
       '/tmp/project',
       'feature/test',
-      'main',
+      'origin/main',
       '.worktrees',
       undefined,
     )
@@ -521,7 +522,7 @@ describe('POST /api/workspaces', () => {
       worktreesPrefixByProject: false,
     })
     vi.mocked(workspaceService.createWorkspace).mockReturnValue(fakeWorkspace)
-    vi.mocked(worktreeService.createWorktree).mockReturnValue('/home/test/kobo/worktress/feature/test')
+    vi.mocked(worktreeService.createWorktree).mockReturnValue({ worktreePath: '/home/test/kobo/worktress/feature/test', base: 'origin' })
     vi.mocked(workspaceService.listTasks).mockReturnValue([])
     vi.mocked(workspaceService.getWorkspaceWithTasks).mockReturnValue(fakeWorkspaceWithTasks)
 
@@ -543,7 +544,7 @@ describe('POST /api/workspaces', () => {
     expect(worktreeService.createWorktree).toHaveBeenCalledWith(
       '/tmp/project',
       'feature/test',
-      'main',
+      'origin/main',
       '$HOME/kobo/worktress',
       undefined,
     )
@@ -575,7 +576,7 @@ describe('POST /api/workspaces', () => {
       name: 'Notion Page Title',
       workingBranch: 'feature/TK-123--notion-page-title',
     } as never)
-    vi.mocked(worktreeService.createWorktree).mockReturnValue('/tmp/worktree')
+    vi.mocked(worktreeService.createWorktree).mockReturnValue({ worktreePath: '/tmp/worktree', base: 'origin' })
     vi.mocked(workspaceService.listTasks).mockReturnValue([])
     vi.mocked(workspaceService.getWorkspaceWithTasks).mockReturnValue(fakeWorkspaceWithTasks)
 
@@ -607,7 +608,7 @@ describe('POST /api/workspaces', () => {
 
   it('calls fetchSourceBranch before createWorkspace on workspace creation', async () => {
     vi.mocked(workspaceService.createWorkspace).mockReturnValue(fakeWorkspace)
-    vi.mocked(worktreeService.createWorktree).mockReturnValue('/tmp/worktree')
+    vi.mocked(worktreeService.createWorktree).mockReturnValue({ worktreePath: '/tmp/worktree', base: 'origin' })
     vi.mocked(workspaceService.listTasks).mockReturnValue([])
     vi.mocked(workspaceService.getWorkspaceWithTasks).mockReturnValue(fakeWorkspaceWithTasks)
 
@@ -658,6 +659,139 @@ describe('POST /api/workspaces', () => {
     expect(workspaceService.createWorkspace).not.toHaveBeenCalled()
   })
 
+  it('bases the worktree on origin and sets no fallback header when fetch succeeds', async () => {
+    vi.mocked(workspaceService.createWorkspace).mockReturnValue(fakeWorkspace)
+    vi.mocked(gitOps.fetchSourceBranch).mockImplementation(() => {})
+    vi.mocked(worktreeService.createWorktree).mockReturnValue({ worktreePath: '/tmp/wt', base: 'origin' })
+    vi.mocked(workspaceService.listTasks).mockReturnValue([])
+    vi.mocked(workspaceService.getWorkspaceWithTasks).mockReturnValue(fakeWorkspaceWithTasks)
+
+    const res = await app.request('/api/workspaces', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        name: 'Test Workspace',
+        projectPath: '/tmp/project',
+        sourceBranch: 'main',
+        workingBranch: 'feature/test',
+      }),
+    })
+
+    expect(res.status).toBe(201)
+    expect(res.headers.get('X-Kobo-Source-Fallback')).toBeNull()
+    expect(worktreeService.createWorktree).toHaveBeenCalledWith(
+      '/tmp/project',
+      'feature/test',
+      'origin/main',
+      '.worktrees',
+      undefined,
+    )
+  })
+
+  it('falls back to the local branch and sets the header when origin fetch fails but the local branch exists', async () => {
+    vi.mocked(workspaceService.createWorkspace).mockReturnValue(fakeWorkspace)
+    vi.mocked(gitOps.fetchSourceBranch).mockImplementation(() => {
+      throw new Error('no origin')
+    })
+    vi.mocked(gitOps.localBranchExists).mockReturnValue(true)
+    vi.mocked(worktreeService.createWorktree).mockReturnValue({ worktreePath: '/tmp/wt', base: 'local' })
+    vi.mocked(workspaceService.listTasks).mockReturnValue([])
+    vi.mocked(workspaceService.getWorkspaceWithTasks).mockReturnValue(fakeWorkspaceWithTasks)
+
+    const res = await app.request('/api/workspaces', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        name: 'Test Workspace',
+        projectPath: '/tmp/project',
+        sourceBranch: 'main',
+        workingBranch: 'feature/test',
+      }),
+    })
+
+    expect(res.status).toBe(201)
+    expect(res.headers.get('X-Kobo-Source-Fallback')).toBe('local')
+    expect(worktreeService.createWorktree).toHaveBeenCalledWith(
+      '/tmp/project',
+      'feature/test',
+      'main',
+      '.worktrees',
+      undefined,
+    )
+  })
+
+  it('returns 422 when origin fetch fails and no local branch exists', async () => {
+    vi.mocked(gitOps.fetchSourceBranch).mockImplementation(() => {
+      throw new Error('no origin')
+    })
+    vi.mocked(gitOps.localBranchExists).mockReturnValue(false)
+
+    const res = await app.request('/api/workspaces', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        name: 'Test Workspace',
+        projectPath: '/tmp/project',
+        sourceBranch: 'main',
+        workingBranch: 'feature/test',
+      }),
+    })
+
+    expect(res.status).toBe(422)
+    expect(worktreeService.createWorktree).not.toHaveBeenCalled()
+  })
+
+  it('does not block reuse of an existing worktree when origin fetch fails', async () => {
+    vi.mocked(gitOps.fetchSourceBranch).mockImplementation(() => {
+      throw new Error('no origin')
+    })
+    vi.mocked(gitOps.localBranchExists).mockReturnValue(false)
+    // Reuse path: body carries a worktreePath, mirroring the reuse happy-path
+    // test's fixtures (fs/git mocked so the reuse validation passes).
+    vi.mocked(fs.existsSync).mockReturnValue(true)
+    vi.mocked(execFileSync)
+      .mockImplementationOnce(() => '/tmp/project/.git\n' as never)
+      .mockImplementationOnce(() => 'feature/derived\n' as never)
+    vi.mocked(getDb).mockReturnValue({
+      prepare: vi.fn().mockReturnValue({
+        run: vi.fn(),
+        get: vi.fn().mockReturnValue(undefined),
+        all: vi.fn().mockReturnValue([]),
+      }),
+    } as never)
+    vi.mocked(workspaceService.createWorkspace).mockReturnValue(fakeWorkspace)
+    vi.mocked(workspaceService.listTasks).mockReturnValue([])
+    vi.mocked(workspaceService.getWorkspaceWithTasks).mockReturnValue(fakeWorkspaceWithTasks)
+
+    const res = await app.request('/api/workspaces', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        name: 'reuse-test',
+        projectPath: '/tmp/project',
+        sourceBranch: 'main',
+        workingBranch: 'feature/placeholder',
+        worktreePath: '/tmp/project/.worktrees/feature/derived',
+      }),
+    })
+
+    expect(res.status).toBe(201)
+    expect(worktreeService.createWorktree).not.toHaveBeenCalled()
+
+    // This test permanently overrides fs.existsSync / getDb (vi.clearAllMocks
+    // clears call history but not implementations) — restore the file-wide
+    // defaults so later tests in this file aren't affected by the reuse-path
+    // fixtures used here.
+    vi.mocked(fs.existsSync).mockReturnValue(false)
+    vi.mocked(getDb).mockReturnValue({
+      prepare: vi.fn().mockReturnValue({
+        run: vi.fn(),
+        get: vi.fn(),
+        all: vi.fn().mockReturnValue([]),
+      }),
+    } as never)
+  })
+
   it('returns 400 when required fields are missing', async () => {
     const res = await app.request('/api/workspaces', {
       method: 'POST',
@@ -696,7 +830,7 @@ describe('POST /api/workspaces', () => {
 
   it('crée des tasks et critères manuels quand pas de Notion', async () => {
     vi.mocked(workspaceService.createWorkspace).mockReturnValue({ id: 'ws-1', name: 'workspace' } as never)
-    vi.mocked(worktreeService.createWorktree).mockReturnValue('/tmp/wt' as never)
+    vi.mocked(worktreeService.createWorktree).mockReturnValue({ worktreePath: '/tmp/wt', base: 'origin' } as never)
     vi.mocked(workspaceService.listTasks).mockReturnValue([])
     vi.mocked(workspaceService.getWorkspaceWithTasks).mockReturnValue({ id: 'ws-1' } as never)
 
@@ -731,7 +865,7 @@ describe('POST /api/workspaces', () => {
 
   it('runs setup script when configured and continues on success', async () => {
     vi.mocked(workspaceService.createWorkspace).mockReturnValue(fakeWorkspace)
-    vi.mocked(worktreeService.createWorktree).mockReturnValue('/tmp/worktree')
+    vi.mocked(worktreeService.createWorktree).mockReturnValue({ worktreePath: '/tmp/worktree', base: 'origin' })
     vi.mocked(workspaceService.listTasks).mockReturnValue([])
     vi.mocked(workspaceService.getWorkspaceWithTasks).mockReturnValue(fakeWorkspaceWithTasks)
     vi.mocked(settingsService.getEffectiveSettings).mockReturnValue({
@@ -764,7 +898,7 @@ describe('POST /api/workspaces', () => {
 
   it('returns workspace in error status when setup script fails', async () => {
     vi.mocked(workspaceService.createWorkspace).mockReturnValue(fakeWorkspace)
-    vi.mocked(worktreeService.createWorktree).mockReturnValue('/tmp/worktree')
+    vi.mocked(worktreeService.createWorktree).mockReturnValue({ worktreePath: '/tmp/worktree', base: 'origin' })
     vi.mocked(workspaceService.listTasks).mockReturnValue([])
     vi.mocked(workspaceService.getWorkspaceWithTasks).mockReturnValue(fakeWorkspaceWithTasks)
     vi.mocked(settingsService.getEffectiveSettings).mockReturnValue({
@@ -799,7 +933,7 @@ describe('POST /api/workspaces', () => {
 
   it('does not run setup script when not configured', async () => {
     vi.mocked(workspaceService.createWorkspace).mockReturnValue(fakeWorkspace)
-    vi.mocked(worktreeService.createWorktree).mockReturnValue('/tmp/worktree')
+    vi.mocked(worktreeService.createWorktree).mockReturnValue({ worktreePath: '/tmp/worktree', base: 'origin' })
     vi.mocked(workspaceService.listTasks).mockReturnValue([])
     vi.mocked(workspaceService.getWorkspaceWithTasks).mockReturnValue(fakeWorkspaceWithTasks)
     vi.mocked(settingsService.getEffectiveSettings).mockReturnValue({
@@ -831,7 +965,7 @@ describe('POST /api/workspaces', () => {
 
   it('POST / brainstorm prompt advertises kobo__set_workspace_agent_description with the user-description boundary', async () => {
     vi.mocked(workspaceService.createWorkspace).mockReturnValue(fakeWorkspace)
-    vi.mocked(worktreeService.createWorktree).mockReturnValue('/tmp/worktree')
+    vi.mocked(worktreeService.createWorktree).mockReturnValue({ worktreePath: '/tmp/worktree', base: 'origin' })
     vi.mocked(workspaceService.listTasks).mockReturnValue([])
     vi.mocked(workspaceService.getWorkspaceWithTasks).mockReturnValue(fakeWorkspaceWithTasks)
 
@@ -864,7 +998,7 @@ describe('POST /api/workspaces', () => {
       brainstormModel: 'claude-opus-4-8',
       autoLoop: true,
     })
-    vi.mocked(worktreeService.createWorktree).mockReturnValue('/tmp/worktree')
+    vi.mocked(worktreeService.createWorktree).mockReturnValue({ worktreePath: '/tmp/worktree', base: 'origin' })
     vi.mocked(workspaceService.listTasks).mockReturnValue([])
     vi.mocked(workspaceService.getWorkspaceWithTasks).mockReturnValue(fakeWorkspaceWithTasks)
 
@@ -900,7 +1034,7 @@ describe('POST /api/workspaces', () => {
       brainstormModel: null,
       autoLoop: true,
     })
-    vi.mocked(worktreeService.createWorktree).mockReturnValue('/tmp/worktree')
+    vi.mocked(worktreeService.createWorktree).mockReturnValue({ worktreePath: '/tmp/worktree', base: 'origin' })
     vi.mocked(workspaceService.listTasks).mockReturnValue([])
     vi.mocked(workspaceService.getWorkspaceWithTasks).mockReturnValue(fakeWorkspaceWithTasks)
 
@@ -931,7 +1065,7 @@ describe('POST /api/workspaces', () => {
       brainstormModel: 'claude-opus-4-8',
       autoLoop: false,
     })
-    vi.mocked(worktreeService.createWorktree).mockReturnValue('/tmp/worktree')
+    vi.mocked(worktreeService.createWorktree).mockReturnValue({ worktreePath: '/tmp/worktree', base: 'origin' })
     vi.mocked(workspaceService.listTasks).mockReturnValue([])
     vi.mocked(workspaceService.getWorkspaceWithTasks).mockReturnValue(fakeWorkspaceWithTasks)
 
@@ -956,7 +1090,7 @@ describe('POST /api/workspaces', () => {
 
   it('accepts engine: codex on creation', async () => {
     vi.mocked(workspaceService.createWorkspace).mockReturnValue(fakeWorkspace)
-    vi.mocked(worktreeService.createWorktree).mockReturnValue('/tmp/worktree')
+    vi.mocked(worktreeService.createWorktree).mockReturnValue({ worktreePath: '/tmp/worktree', base: 'origin' })
     vi.mocked(workspaceService.listTasks).mockReturnValue([])
     vi.mocked(workspaceService.getWorkspaceWithTasks).mockReturnValue(fakeWorkspaceWithTasks)
 
@@ -1098,7 +1232,7 @@ describe('POST /api/workspaces — Notion/Sentry initial prompt injection', () =
       ...fakeWorkspace,
       name: 'Renamed by Notion/Sentry',
     } as never)
-    vi.mocked(worktreeService.createWorktree).mockReturnValue('/tmp/wt')
+    vi.mocked(worktreeService.createWorktree).mockReturnValue({ worktreePath: '/tmp/wt', base: 'origin' })
     vi.mocked(workspaceService.listTasks).mockReturnValue([])
     vi.mocked(workspaceService.getWorkspaceWithTasks).mockReturnValue(fakeWorkspaceWithTasks)
   }
@@ -2154,7 +2288,7 @@ describe('DELETE /api/workspaces/archived', () => {
 describe('git conventions file creation on workspace create', () => {
   beforeEach(() => {
     vi.mocked(workspaceService.createWorkspace).mockReturnValue(fakeWorkspace as never)
-    vi.mocked(worktreeService.createWorktree).mockReturnValue('/tmp/worktree')
+    vi.mocked(worktreeService.createWorktree).mockReturnValue({ worktreePath: '/tmp/worktree', base: 'origin' })
     vi.mocked(workspaceService.listTasks).mockReturnValue([])
     vi.mocked(workspaceService.getWorkspaceWithTasks).mockReturnValue(fakeWorkspaceWithTasks as never)
     vi.mocked(workspaceService.updateWorkspaceStatus).mockReturnValue(fakeWorkspace as never)
@@ -4261,7 +4395,7 @@ describe('POST /api/workspaces — pre-flight URL validation', () => {
       sentryUrl: 'https://my-org.sentry.io/issues/99/',
     })
     vi.mocked(wsService.getWorkspaceWithTasks).mockReturnValue(fakeWorkspaceWithTasks)
-    vi.mocked(worktreeService.createWorktree).mockReturnValue('/tmp/wt')
+    vi.mocked(worktreeService.createWorktree).mockReturnValue({ worktreePath: '/tmp/wt', base: 'origin' })
 
     await app.request('/api/workspaces', {
       method: 'POST',
@@ -4538,7 +4672,10 @@ describe('POST /api/workspaces — worktree path collision', () => {
       return false
     })
     vi.mocked(workspaceService.createWorkspace).mockReturnValue(fakeWorkspace)
-    vi.mocked(worktreeService.createWorktree).mockImplementation((_p, branch) => `/tmp/project/.worktrees/${branch}`)
+    vi.mocked(worktreeService.createWorktree).mockImplementation((_p, branch) => ({
+      worktreePath: `/tmp/project/.worktrees/${branch}`,
+      base: 'origin',
+    }))
     vi.mocked(workspaceService.listTasks).mockReturnValue([])
     vi.mocked(workspaceService.getWorkspaceWithTasks).mockReturnValue(fakeWorkspaceWithTasks)
 
@@ -4609,7 +4746,7 @@ describe('POST /api/workspaces — worktree path collision', () => {
     } as never)
     vi.mocked(fs.existsSync).mockReturnValue(false)
     vi.mocked(workspaceService.createWorkspace).mockReturnValue(fakeWorkspace)
-    vi.mocked(worktreeService.createWorktree).mockReturnValue('/tmp/project/.worktrees/sekur/feature/test')
+    vi.mocked(worktreeService.createWorktree).mockReturnValue({ worktreePath: '/tmp/project/.worktrees/sekur/feature/test', base: 'origin' })
     vi.mocked(workspaceService.listTasks).mockReturnValue([])
     vi.mocked(workspaceService.getWorkspaceWithTasks).mockReturnValue(fakeWorkspaceWithTasks)
 
@@ -4638,7 +4775,7 @@ describe('POST /api/workspaces — Working directory in brainstorm prompt', () =
   it('passes "Working directory: <path>" to agentManager.startAgent', async () => {
     vi.mocked(fs.existsSync).mockReturnValue(false)
     vi.mocked(workspaceService.createWorkspace).mockReturnValue(fakeWorkspace)
-    vi.mocked(worktreeService.createWorktree).mockReturnValue('/tmp/worktree')
+    vi.mocked(worktreeService.createWorktree).mockReturnValue({ worktreePath: '/tmp/worktree', base: 'origin' })
     vi.mocked(workspaceService.listTasks).mockReturnValue([])
     vi.mocked(workspaceService.getWorkspaceWithTasks).mockReturnValue(fakeWorkspaceWithTasks)
 

--- a/src/__tests__/routes-workspaces.test.ts
+++ b/src/__tests__/routes-workspaces.test.ts
@@ -742,6 +742,8 @@ describe('POST /api/workspaces', () => {
 
     expect(res.status).toBe(422)
     expect(worktreeService.createWorktree).not.toHaveBeenCalled()
+    // The hard-block happens before any DB write, so no orphan workspace row is left behind.
+    expect(workspaceService.createWorkspace).not.toHaveBeenCalled()
   })
 
   it('does not block reuse of an existing worktree when origin fetch fails', async () => {

--- a/src/__tests__/worktree-service.test.ts
+++ b/src/__tests__/worktree-service.test.ts
@@ -51,16 +51,16 @@ afterAll(() => {
   }
 })
 
-describe('createWorktree(projectPath, branchName, sourceBranch)', () => {
-  it('crée un worktree et retourne le chemin', () => {
-    const worktreePath = createWorktree(repoDir, 'feature/wt-test', 'main')
-    expect(worktreePath).toBeTruthy()
+describe('createWorktree(projectPath, branchName, baseRef)', () => {
+  it('creates a worktree directory for the branch', () => {
+    const { worktreePath, base } = createWorktree(repoDir, 'feature/wt-test', 'origin/main')
     expect(fs.existsSync(worktreePath)).toBe(true)
+    expect(base).toBe('origin')
   })
 
   it('le chemin du worktree est <projectPath>/.worktrees/<branchName>', () => {
     const branchName = 'feature/path-check'
-    const worktreePath = createWorktree(repoDir, branchName, 'main')
+    const { worktreePath } = createWorktree(repoDir, branchName, 'origin/main')
     const expected = path.join(repoDir, '.worktrees', branchName)
     expect(worktreePath).toBe(expected)
     expect(fs.existsSync(worktreePath)).toBe(true)
@@ -68,7 +68,7 @@ describe('createWorktree(projectPath, branchName, sourceBranch)', () => {
 
   it('accepte une racine de worktrees relative personnalisée', () => {
     const branchName = 'feature/custom-root'
-    const worktreePath = createWorktree(repoDir, branchName, 'main', 'kobo-worktrees')
+    const { worktreePath } = createWorktree(repoDir, branchName, 'origin/main', 'kobo-worktrees')
     const expected = path.join(repoDir, 'kobo-worktrees', branchName)
     expect(worktreePath).toBe(expected)
     expect(fs.existsSync(worktreePath)).toBe(true)
@@ -76,7 +76,7 @@ describe('createWorktree(projectPath, branchName, sourceBranch)', () => {
 
   it('ajoute le worktree à .git/info/exclude', () => {
     const branchName = 'feature/exclude-test'
-    const worktreePath = createWorktree(repoDir, branchName, 'main')
+    const { worktreePath } = createWorktree(repoDir, branchName, 'origin/main')
     const excludeFile = path.join(repoDir, '.git', 'info', 'exclude')
     const content = fs.readFileSync(excludeFile, 'utf-8')
     const relativePath = path.relative(repoDir, worktreePath)
@@ -89,7 +89,7 @@ describe('createWorktree(projectPath, branchName, sourceBranch)', () => {
     let worktreePath = ''
 
     try {
-      worktreePath = createWorktree(repoDir, branchName, 'main', externalRoot)
+      ;({ worktreePath } = createWorktree(repoDir, branchName, 'origin/main', externalRoot))
       expect(worktreePath).toBe(path.join(externalRoot, branchName))
       expect(fs.existsSync(worktreePath)).toBe(true)
 
@@ -109,8 +109,19 @@ describe('createWorktree(projectPath, branchName, sourceBranch)', () => {
     // Create branch first without a worktree
     gitSetup(repoDir, ['branch', 'feature/existing-branch'])
     // createWorktree should fall back to 'git worktree add <path> <branch>'
-    const worktreePath = createWorktree(repoDir, 'feature/existing-branch', 'main')
+    const { worktreePath } = createWorktree(repoDir, 'feature/existing-branch', 'origin/main')
     expect(fs.existsSync(worktreePath)).toBe(true)
+  })
+
+  it('creates a worktree from a local branch when base ref has no origin/ prefix', () => {
+    // `main` exists locally in repoDir (the clone). Base directly off it.
+    const { worktreePath, base } = createWorktree(repoDir, 'feature/local-base', 'main')
+    expect(fs.existsSync(worktreePath)).toBe(true)
+    expect(base).toBe('local')
+    // The new branch points at the same commit as local main.
+    const head = execFileSync('git', ['-C', worktreePath, 'rev-parse', 'HEAD'], { encoding: 'utf-8' }).trim()
+    const mainHead = execFileSync('git', ['-C', repoDir, 'rev-parse', 'main'], { encoding: 'utf-8' }).trim()
+    expect(head).toBe(mainHead)
   })
 })
 
@@ -133,7 +144,7 @@ describe('listWorktrees(projectPath)', () => {
 
   it('inclut les worktrees créés', () => {
     const branchName = 'feature/list-check'
-    createWorktree(repoDir, branchName, 'main')
+    createWorktree(repoDir, branchName, 'origin/main')
     const worktrees = listWorktrees(repoDir)
     const found = worktrees.some((wt) => wt.branch === branchName)
     expect(found).toBe(true)
@@ -143,7 +154,7 @@ describe('listWorktrees(projectPath)', () => {
 describe('worktreeExists(projectPath, branchName)', () => {
   it('retourne true si le worktree existe', () => {
     const branchName = 'feature/exists-true'
-    createWorktree(repoDir, branchName, 'main')
+    createWorktree(repoDir, branchName, 'origin/main')
     expect(worktreeExists(repoDir, branchName)).toBe(true)
   })
 
@@ -155,7 +166,7 @@ describe('worktreeExists(projectPath, branchName)', () => {
 describe('removeWorktree(projectPath, worktreePath)', () => {
   it('supprime le worktree et son dossier', () => {
     const branchName = 'feature/remove-test'
-    const worktreePath = createWorktree(repoDir, branchName, 'main')
+    const { worktreePath } = createWorktree(repoDir, branchName, 'origin/main')
     expect(fs.existsSync(worktreePath)).toBe(true)
 
     removeWorktree(repoDir, worktreePath)
@@ -164,7 +175,7 @@ describe('removeWorktree(projectPath, worktreePath)', () => {
 
   it("retire l'entrée de .git/info/exclude après suppression", () => {
     const branchName = 'feature/remove-exclude'
-    const worktreePath = createWorktree(repoDir, branchName, 'main')
+    const { worktreePath } = createWorktree(repoDir, branchName, 'origin/main')
     removeWorktree(repoDir, worktreePath)
 
     const excludeFile = path.join(repoDir, '.git', 'info', 'exclude')
@@ -177,7 +188,7 @@ describe('removeWorktree(projectPath, worktreePath)', () => {
 
   it("le worktree n'apparaît plus dans listWorktrees après suppression", () => {
     const branchName = 'feature/remove-list-check'
-    const worktreePath = createWorktree(repoDir, branchName, 'main')
+    const { worktreePath } = createWorktree(repoDir, branchName, 'origin/main')
     removeWorktree(repoDir, worktreePath)
 
     const worktrees = listWorktrees(repoDir)

--- a/src/client/src/i18n/de.ts
+++ b/src/client/src/i18n/de.ts
@@ -312,6 +312,8 @@ export default {
   'createPage.errorCreating': 'Fehler beim Erstellen des Arbeitsbereichs.',
   'createPage.branchAdjusted':
     'Branch existierte bereits — stattdessen `{branch}` erstellt. Der zugehörige Worktree-Ordner verwendet das gleiche Suffix.',
+  'createPage.localSourceFallback':
+    'Workspace vom lokalen Branch erstellt (origin nicht erreichbar) — die Basis ist möglicherweise veraltet.',
   'createPage.validationNotionUrl':
     'Bitte eine gültige Notion-URL einfügen (https://www.notion.so/... oder https://app.notion.com/...).',
   'createPage.validationDescription': 'Bitte beschreiben Sie die Aufgabe.',

--- a/src/client/src/i18n/en.ts
+++ b/src/client/src/i18n/en.ts
@@ -308,6 +308,8 @@ export default {
   'createPage.errorCreating': 'Error creating workspace.',
   'createPage.branchAdjusted':
     'Branch already existed — created `{branch}` instead. The matching worktree folder uses the same suffix.',
+  'createPage.localSourceFallback':
+    'Workspace created from the local branch (origin unreachable) — the base may be stale.',
   'createPage.validationNotionUrl':
     'Please paste a valid Notion URL (https://www.notion.so/... or https://app.notion.com/...).',
   'createPage.validationDescription': 'Please describe the task.',

--- a/src/client/src/i18n/es.ts
+++ b/src/client/src/i18n/es.ts
@@ -312,6 +312,8 @@ export default {
   'createPage.errorCreating': 'Error al crear el workspace.',
   'createPage.branchAdjusted':
     'La rama ya existía — se creó `{branch}` en su lugar. La carpeta worktree correspondiente usa el mismo sufijo.',
+  'createPage.localSourceFallback':
+    'Workspace creado desde la rama local (origin inalcanzable) — la base puede estar desactualizada.',
   'createPage.validationNotionUrl':
     'Introduce una URL de Notion válida (https://www.notion.so/... o https://app.notion.com/...).',
   'createPage.validationDescription': 'Describe la tarea.',

--- a/src/client/src/i18n/fr.ts
+++ b/src/client/src/i18n/fr.ts
@@ -314,6 +314,8 @@ export default {
   'createPage.errorCreating': "Erreur lors de la création de l'espace de travail.",
   'createPage.branchAdjusted':
     'Branche déjà existante — création de `{branch}` à la place. Le dossier worktree correspondant utilise le même suffixe.',
+  'createPage.localSourceFallback':
+    'Workspace créé à partir de la branche locale (origin injoignable) — la base peut être périmée.',
   'createPage.validationNotionUrl':
     'Veuillez coller une URL Notion valide (https://www.notion.so/... ou https://app.notion.com/...).',
   'createPage.validationDescription': 'Veuillez décrire la tâche.',

--- a/src/client/src/i18n/it.ts
+++ b/src/client/src/i18n/it.ts
@@ -314,6 +314,8 @@ export default {
   'createPage.errorCreating': 'Errore durante la creazione del workspace.',
   'createPage.branchAdjusted':
     'Il branch esisteva già — creato `{branch}` al suo posto. La cartella worktree corrispondente usa lo stesso suffisso.',
+  'createPage.localSourceFallback':
+    'Workspace creato dal branch locale (origin non raggiungibile) — la base potrebbe essere obsoleta.',
   'createPage.validationNotionUrl':
     'Inserisci un URL Notion valido (https://www.notion.so/... o https://app.notion.com/...).',
   'createPage.validationDescription': 'Descrivi il task.',

--- a/src/client/src/pages/CreatePage.vue
+++ b/src/client/src/pages/CreatePage.vue
@@ -1637,6 +1637,15 @@ async function handleCreate() {
       })
     }
 
+    if ((workspace as { _sourceFallback?: boolean })._sourceFallback) {
+      $q.notify({
+        type: 'warning',
+        message: t('createPage.localSourceFallback'),
+        position: 'top',
+        timeout: 6000,
+      })
+    }
+
     // Persist last-used inputs so the next Create-workspace visit pre-fills
     // them. Run only after a successful create — failures keep the previous
     // saved values intact.

--- a/src/client/src/stores/workspace.ts
+++ b/src/client/src/stores/workspace.ts
@@ -597,6 +597,7 @@ export const useWorkspaceStore = defineStore('workspace', {
         // The header is the cheapest way to signal that without changing the
         // JSON shape — the resolved branch is already on the returned workspace.
         const branchAdjusted = res.headers.get('X-Kobo-Branch-Adjusted') === '1'
+        const sourceFallback = res.headers.get('X-Kobo-Source-Fallback') === 'local'
         const data = await res.json()
         const workspace = data.workspace ?? data
         // Dedup against a concurrent fetchWorkspaces() that may have already
@@ -617,6 +618,7 @@ export const useWorkspaceStore = defineStore('workspace', {
           void this.fetchAutoLoopStates()
         }
         ;(workspace as Workspace & { _branchAdjusted?: boolean })._branchAdjusted = branchAdjusted
+        ;(workspace as Workspace & { _sourceFallback?: boolean })._sourceFallback = sourceFallback
         return workspace as Workspace
       } catch (err) {
         console.error('[workspace store] createWorkspace failed:', err)

--- a/src/server/routes/workspaces.ts
+++ b/src/server/routes/workspaces.ts
@@ -160,13 +160,30 @@ app.post('/', migrationGuard, async (c) => {
       }
     }
 
-    // Fetch the source branch from origin first — if this fails, block creation
-    // immediately (no DB records created, user stays on the create page).
+    // Fetch the source branch from origin first. On failure this is non-fatal:
+    // fall back to the local source branch if it exists (offline / no remote),
+    // and only hard-block (422) when neither origin nor a local branch is usable.
+    // The reuse path (body.worktreePath) needs no base ref, so a failed fetch is
+    // simply logged there.
+    const isReuseRequest = !!body.worktreePath
+    let baseRef = `origin/${body.sourceBranch}`
+    let usedLocalFallback = false
     try {
       gitOps.fetchSourceBranch(body.projectPath, body.sourceBranch)
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err)
-      return c.json({ error: message }, 422)
+      if (isReuseRequest) {
+        console.warn(`[workspaces] fetch of '${body.sourceBranch}' from origin failed; reusing existing worktree, ignoring: ${message}`)
+      } else if (gitOps.localBranchExists(body.projectPath, body.sourceBranch)) {
+        baseRef = body.sourceBranch
+        usedLocalFallback = true
+        console.warn(`[workspaces] fetch of '${body.sourceBranch}' from origin failed; falling back to local branch: ${message}`)
+      } else {
+        return c.json(
+          { error: `${message} — and no local branch '${body.sourceBranch}' exists to fall back on` },
+          422,
+        )
+      }
     }
 
     // Reuse-existing-worktree path. When the caller passes `worktreePath`,
@@ -442,13 +459,14 @@ app.post('/', migrationGuard, async (c) => {
       worktreePath = body.worktreePath as string
     } else {
       try {
-        worktreePath = worktreeService.createWorktree(
+        const created = worktreeService.createWorktree(
           body.projectPath,
           workingBranch,
-          body.sourceBranch,
+          baseRef,
           globalSettings.worktreesPath,
           projectSlug,
         )
+        worktreePath = created.worktreePath
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err)
         // Roll back the half-created workspace: a failed worktree creation must NOT
@@ -931,6 +949,9 @@ Once the brainstorming + planning steps above are complete and you have a saved 
       // "Branch already existed — created <new-branch> instead". The actual
       // resolved branch is on the returned workspace already.
       c.header('X-Kobo-Branch-Adjusted', '1')
+    }
+    if (usedLocalFallback) {
+      c.header('X-Kobo-Source-Fallback', 'local')
     }
     return c.json(workspaceWithTasks, 201)
   } catch (err) {

--- a/src/server/routes/workspaces.ts
+++ b/src/server/routes/workspaces.ts
@@ -173,16 +173,17 @@ app.post('/', migrationGuard, async (c) => {
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err)
       if (isReuseRequest) {
-        console.warn(`[workspaces] fetch of '${body.sourceBranch}' from origin failed; reusing existing worktree, ignoring: ${message}`)
+        console.warn(
+          `[workspaces] fetch of '${body.sourceBranch}' from origin failed; reusing existing worktree, ignoring: ${message}`,
+        )
       } else if (gitOps.localBranchExists(body.projectPath, body.sourceBranch)) {
         baseRef = body.sourceBranch
         usedLocalFallback = true
-        console.warn(`[workspaces] fetch of '${body.sourceBranch}' from origin failed; falling back to local branch: ${message}`)
-      } else {
-        return c.json(
-          { error: `${message} — and no local branch '${body.sourceBranch}' exists to fall back on` },
-          422,
+        console.warn(
+          `[workspaces] fetch of '${body.sourceBranch}' from origin failed; falling back to local branch: ${message}`,
         )
+      } else {
+        return c.json({ error: `${message} — and no local branch '${body.sourceBranch}' exists to fall back on` }, 422)
       }
     }
 

--- a/src/server/services/worktree-service.ts
+++ b/src/server/services/worktree-service.ts
@@ -112,25 +112,27 @@ function removeFromExclude(projectPath: string, worktreePath: string): void {
   fs.writeFileSync(excludeFile, trimmed ? `${trimmed}\n` : '', 'utf-8')
 }
 
-/** Create a git worktree for the given branch. Returns the worktree path. */
+/** Create a git worktree for the given branch, based on `baseRef`.
+ * `baseRef` is passed explicitly by the caller: `origin/<sourceBranch>` in the
+ * nominal path, or the local `<sourceBranch>` when origin is unreachable.
+ * Returns the worktree path and which base was used. */
 export function createWorktree(
   projectPath: string,
   branchName: string,
-  sourceBranch: string,
+  baseRef: string,
   worktreesPath?: string | null,
   projectSlug?: string,
-): string {
+): { worktreePath: string; base: 'origin' | 'local' } {
   const worktreesDir = resolveWorktreesRoot(projectPath, worktreesPath)
   if (!fs.existsSync(worktreesDir)) {
     fs.mkdirSync(worktreesDir, { recursive: true })
   }
 
   const worktreePath = resolveWorkspaceWorktreePath(projectPath, branchName, worktreesPath, projectSlug)
+  const base: 'origin' | 'local' = baseRef.startsWith('origin/') ? 'origin' : 'local'
 
   try {
-    // Use origin/<sourceBranch> as the base so the worktree starts from the
-    // freshly-fetched remote ref (fetchSourceBranch is always called first).
-    git(projectPath, ['worktree', 'add', '-b', branchName, worktreePath, `origin/${sourceBranch}`])
+    git(projectPath, ['worktree', 'add', '-b', branchName, worktreePath, baseRef])
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err)
 
@@ -144,7 +146,7 @@ export function createWorktree(
 
   addToExclude(projectPath, worktreePath)
 
-  return worktreePath
+  return { worktreePath, base }
 }
 
 /** Remove a git worktree and clean up the .git/info/exclude entry.

--- a/src/server/utils/git-ops.ts
+++ b/src/server/utils/git-ops.ts
@@ -637,6 +637,20 @@ export function branchExists(repoPath: string, name: string, remote = 'origin'):
 }
 
 /**
+ * Check whether a branch name exists as a LOCAL branch (refs/heads only,
+ * ignoring remote-tracking refs). Used to decide whether worktree creation can
+ * fall back to the local source branch when `origin` is unreachable.
+ */
+export function localBranchExists(repoPath: string, name: string): boolean {
+  try {
+    git(repoPath, ['rev-parse', '--verify', '--quiet', `refs/heads/${name}`])
+    return true
+  } catch {
+    return false
+  }
+}
+
+/**
  * Move a worktree directory on disk via `git worktree move`. Both the
  * filesystem layout and the `worktrees` metadata file are updated atomically.
  * Throws if the destination exists, the worktree is dirty, or the source


### PR DESCRIPTION
## Summary

Workspace creation (`POST /api/workspaces`) currently hard-requires a reachable `origin`. If `git fetch origin <sourceBranch>` fails — no remote configured, offline, or the branch is absent from the remote — the route returns **422** and no workspace can be created, even when a perfectly usable **local** source branch exists.

This PR makes the pre-fetch **non-fatal** and falls back to basing the worktree on the local branch:

- **Fetch succeeds** → worktree is based on `origin/<sourceBranch>` (unchanged behavior).
- **Fetch fails + local branch exists** → worktree is based on the local `<sourceBranch>`, and the response carries an `X-Kobo-Source-Fallback: local` header that surfaces a non-blocking warning toast on the Create page ("created from the local branch — the base may be stale").
- **Fetch fails + no local branch** → still a clean **422** with a clear message, before any DB record is written (no orphan row).

It also fixes a latent issue on the **reuse-existing-worktree** path: that path ran *after* the fatal pre-fetch, so reusing a worktree offline failed too. The pre-fetch is now non-fatal there as well (reuse needs no base ref).

## Changes

- **`git-ops`**: new `localBranchExists(repoPath, name)` helper (`refs/heads` only, mirrors `branchExists` but strictly local).
- **`worktree-service`**: `createWorktree` now takes an explicit `baseRef` (instead of hard-coding `origin/<sourceBranch>`) and returns `{ worktreePath, base: 'origin' | 'local' }`.
- **`routes/workspaces`**: centralizes the fetch-OK / local-fallback / 422 decision and sets the fallback header.
- **client**: store reads the header (mirroring the existing `X-Kobo-Branch-Adjusted` pattern); Create page shows the warning toast.
- **i18n**: `createPage.localSourceFallback` added to all 5 locales (en/fr/de/es/it).

## Testing

- New/updated unit tests in `git-ops.test.ts`, `worktree-service.test.ts`, and `routes-workspaces.test.ts` cover: local helper true/false, worktree creation off a local vs `origin/` base, and the four route behaviors (origin success / local fallback + header / 422 no-orphan / reuse not blocked).
- Backend suite: 2011 passing. Client suite: 380 passing (incl. i18n parity). `tsc --noEmit` and `biome check` clean.
- End-to-end smoke on a scratch repo with **no** `origin`: fetch throws → local branch detected → worktree created off local `main`'s HEAD, base reported as `local`.

## Notes

- No schema change, so no migration.
- The fallback is automatic (no new UI toggle).
