### PR TITLE
fix(codex): allow git writes in bypass mode

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -691,11 +691,12 @@ Each engine maps Kōbō's four modes onto its own sandbox + approval flags. The 
 | Kōbō mode | Codex sandbox | Codex approval | `collaborationMode` |
 |---|---|---|---|
 | `plan` | `read-only` | `never` | `plan` (enables `request_user_input`) |
-| `bypass` | `workspace-write` | `never` | `default` |
+| `bypass` | `danger-full-access` | `never` | `default` |
 | `strict` | `workspace-write` | `on-request` | `default` |
 | `interactive` | `workspace-write` | `unless-trusted` | `default` |
 
 Interactive Q&A (`request_user_input`) is only available in `plan` for Codex, a constraint of Codex itself.
+Full access in `bypass` is required for linked-worktree Git metadata under the repository's shared `.git` directory.
 
 ## Dev server
 

--- a/src/__tests__/codex/options-builder.test.ts
+++ b/src/__tests__/codex/options-builder.test.ts
@@ -16,9 +16,9 @@ describe('buildCodexOptions — permission mode mapping', () => {
     expect(threadParams.approvalPolicy).toBe('never')
   })
 
-  it('bypass → sandbox: workspace-write, approvalPolicy: never', () => {
+  it('bypass → sandbox: danger-full-access, approvalPolicy: never', () => {
     const { threadParams } = buildCodexOptions({ ...BASE_INPUT, agentPermissionMode: 'bypass' })
-    expect(threadParams.sandbox).toBe('workspace-write')
+    expect(threadParams.sandbox).toBe('danger-full-access')
     expect(threadParams.approvalPolicy).toBe('never')
   })
 

--- a/src/server/services/agent/engines/codex/options-builder.ts
+++ b/src/server/services/agent/engines/codex/options-builder.ts
@@ -57,7 +57,7 @@ export function buildCodexOptions(input: BuildCodexOptionsInput): BuildCodexOpti
       threadParams.approvalPolicy = 'never'
       break
     case 'bypass':
-      threadParams.sandbox = 'workspace-write'
+      threadParams.sandbox = 'danger-full-access'
       threadParams.approvalPolicy = 'never'
       break
     case 'strict':


### PR DESCRIPTION
## Summary

- map Kōbō's Codex `bypass` mode to `danger-full-access`
- keep `approvalPolicy: never`
- update the regression test and Codex permission-mode documentation

## Problem

Codex agents running inside linked Git worktrees could edit workspace files in
`bypass` mode, but commits failed while creating the shared Git lock file:

```text
.git/worktrees/<name>/index.lock: Operation not permitted
```

Kōbō translated `bypass` to Codex's `workspace-write` sandbox. That sandbox
protects paths outside the worktree root, including the repository's shared
`.git` directory where linked-worktree metadata and `index.lock` live.

`danger-full-access` matches Kōbō's documented `bypass` semantics: the mode
already promises full autonomy and uses `approvalPolicy: never`. Allowing
access to the shared Git metadata lets the agent create commits from a linked
worktree instead of failing after successfully editing the source tree.

The other modes are unchanged:

- `plan`: `read-only` + `never`
- `strict`: `workspace-write` + `on-request`
- `interactive`: `workspace-write` + `unless-trusted`

## Verification

- `npx vitest run src/__tests__/codex/options-builder.test.ts --config vitest.config.ts --root .`
  - PASS — 27/27 tests
- `npx tsc --noEmit`
  - PASS
- `npm run lint`
  - PASS — exit 0; 5 pre-existing i18n warnings for literal `${UID}:${GID}` placeholders
- `npm test`
  - 2,005/2,011 tests pass
  - 6 pre-existing, unrelated failures:
    - 4 five-second timeouts in `usage-claude-code-provider.test.ts` for missing or malformed credentials
    - 2 macOS path assertions in `worktree-service.test.ts` comparing `/var/...` with `/private/var/...`
  - the pre-change baseline had the same failures plus one unrelated health-route timeout
- `npm run build`
  - PASS — existing Vite chunk-size advisory only
- independent code review
  - APPROVED — no Critical, Important, or Minor findings
