### PR TITLE
fix(tests): make macOS tests portable

### DIFF
--- a/src/__tests__/usage-claude-code-provider.test.ts
+++ b/src/__tests__/usage-claude-code-provider.test.ts
@@ -14,6 +14,15 @@ describe('claude-code usage provider', () => {
   beforeEach(async () => {
     tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'kobo-claude-creds-'))
     process.env.CLAUDE_CONFIG_DIR = tmpDir
+    vi.mocked(execFile).mockImplementation(((
+      _cmd: string,
+      _args: readonly string[],
+      _opts: unknown,
+      cb: (e: Error | null, stdout: string) => void,
+    ) => {
+      cb(new Error('SecKeychainSearchCopyNext: item not found'), '')
+      return {} as never
+    }) as never)
   })
 
   afterEach(async () => {

--- a/src/__tests__/worktree-service.test.ts
+++ b/src/__tests__/worktree-service.test.ts
@@ -233,7 +233,7 @@ describe('listOrphanWorktrees(projectPath, attachedPaths)', () => {
     const orphans = listOrphanWorktrees(projectPath, attached)
 
     expect(orphans).toHaveLength(1)
-    expect(orphans[0].path).toBe(wt2)
+    expect(fs.realpathSync(orphans[0].path)).toBe(fs.realpathSync(wt2))
     expect(orphans[0].branch).toBe('feature/bar')
     expect(orphans[0].head).toBeTruthy()
     expect(orphans[0].suggestedSourceBranch).toBe('main') // origin/HEAD fallback
@@ -245,7 +245,7 @@ describe('listOrphanWorktrees(projectPath, attachedPaths)', () => {
 
     const orphans = listOrphanWorktrees(projectPath, new Set())
     expect(orphans).toHaveLength(1)
-    expect(orphans[0].path).toBe(wt1)
+    expect(fs.realpathSync(orphans[0].path)).toBe(fs.realpathSync(wt1))
   })
 
   it('excludes detached HEAD worktrees', () => {


### PR DESCRIPTION
## Summary

- make the Claude Code credentials tests deterministic on macOS by giving the mocked Keychain command a callback-based "item not found" default
- compare canonical worktree paths so macOS's `/var` to `/private/var` alias does not break assertions
- keep the change test-only: no production behavior, timeout, CI configuration, or paid macOS runner changes

## Root causes

The Claude Code provider falls back to the macOS Keychain when the temporary
credentials file is missing or unusable. The suite mocked `execFile` without
ever invoking its callback, leaving the provider promise pending until Vitest's
five-second timeout.

Git canonicalizes temporary worktree paths to `/private/var/...` on macOS,
while Node can construct the same paths as `/var/...`. Direct string equality
therefore compared two spellings of the same directory.

## Verification

- `npx vitest run src/__tests__/usage-claude-code-provider.test.ts src/__tests__/worktree-service.test.ts --config vitest.config.ts --root .` — 34/34 passed
- `npx tsc --noEmit` — passed
- `npm run lint` — passed with five pre-existing `${UID}:${GID}` warnings in the locale files
- `npm test` — 109/109 files, 2011/2011 tests passed
- `npm run build` — passed; existing Vite chunk-size warning only

## Scope

Only test files are changed. Linux behavior remains covered, and the dedicated
Keychain tests still override the default mock for success and failure cases.
