### PR TITLE
fix: preserve whip delivery and shortcut handling

### DIFF
--- a/src/client/src/__tests__/WhipOverlay.test.ts
+++ b/src/client/src/__tests__/WhipOverlay.test.ts
@@ -140,10 +140,12 @@ describe('WhipOverlay', () => {
     expect(document.activeElement).toBe(dialog)
     expect(document.querySelector('canvas')?.getAttribute('aria-hidden')).toBe('true')
 
-    dialog.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }))
+    const enter = new KeyboardEvent('keydown', { key: 'Enter', bubbles: true, cancelable: true })
+    dialog.dispatchEvent(enter)
 
     expect(playWhipCrack).toHaveBeenCalledOnce()
     expect(wrapper.emitted('crack')).toHaveLength(1)
+    expect(enter.defaultPrevented).toBe(true)
 
     unmountOverlay(wrapper)
 
@@ -184,6 +186,26 @@ describe('WhipOverlay', () => {
     expect(firstSpace.defaultPrevented).toBe(true)
     expect(repeatedSpace.defaultPrevented).toBe(true)
     expect(cooldownSpace.defaultPrevented).toBe(true)
+  })
+
+  it('prevents repeated Enter keys without emitting another crack', () => {
+    const wrapper = mountOverlay()
+    const dialog = document.querySelector<HTMLElement>('[role="dialog"]')!
+
+    const firstEnter = new KeyboardEvent('keydown', { key: 'Enter', bubbles: true, cancelable: true })
+    dialog.dispatchEvent(firstEnter)
+    const repeatedEnter = new KeyboardEvent('keydown', {
+      key: 'Enter',
+      repeat: true,
+      bubbles: true,
+      cancelable: true,
+    })
+    dialog.dispatchEvent(repeatedEnter)
+
+    expect(playWhipCrack).toHaveBeenCalledOnce()
+    expect(wrapper.emitted('crack')).toHaveLength(1)
+    expect(firstEnter.defaultPrevented).toBe(true)
+    expect(repeatedEnter.defaultPrevented).toBe(true)
   })
 
   it('shares the keyboard crack cooldown with the next physics frame', () => {

--- a/src/client/src/__tests__/WorkspaceWhipControl.test.ts
+++ b/src/client/src/__tests__/WorkspaceWhipControl.test.ts
@@ -38,8 +38,10 @@ const WhipOverlayStub = defineComponent({
 
 const i18n = createI18n({ legacy: false, locale: 'en', messages: { en } })
 const wrappers: VueWrapper[] = []
+type WhipControlProps = { workspaceId: string; sessionId: string | null; running: boolean }
+type WhipControlWrapper = VueWrapper<{ $props: WhipControlProps }>
 
-function mountControl(props: { workspaceId: string; sessionId: string | null; running: boolean }, whipEnabled = true) {
+function mountControl(props: WhipControlProps, whipEnabled = true): WhipControlWrapper {
   const settings = useSettingsStore()
   settings.global.whipEnabled = whipEnabled
   settings.global.whipShortcut = 'mod+shift+x'
@@ -49,7 +51,7 @@ function mountControl(props: { workspaceId: string; sessionId: string | null; ru
       plugins: [i18n],
       stubs: { WhipOverlay: WhipOverlayStub },
     },
-  })
+  }) as unknown as WhipControlWrapper
   wrappers.push(wrapper)
   return wrapper
 }
@@ -100,11 +102,11 @@ describe('WorkspaceWhipControl', () => {
     expect(wrapper.find('button').exists()).toBe(false)
 
     const stoppedEvent = dispatchShortcut()
-    expect(stoppedEvent.defaultPrevented).toBe(false)
+    expect(stoppedEvent.defaultPrevented).toBe(true)
 
     await wrapper.setProps({ running: true, sessionId: null })
     const missingSessionEvent = dispatchShortcut()
-    expect(missingSessionEvent.defaultPrevented).toBe(false)
+    expect(missingSessionEvent.defaultPrevented).toBe(true)
 
     await wrapper.setProps({ sessionId: 'session-1' })
     const eligibleEvent = dispatchShortcut()
@@ -135,23 +137,23 @@ describe('WorkspaceWhipControl', () => {
 
       const repeated = dispatchShortcut({ repeat: true })
       await wrapper.vm.$nextTick()
-      expect(repeated.defaultPrevented).toBe(false)
-      expect(competingHandler).toHaveBeenCalledTimes(1)
+      expect(repeated.defaultPrevented).toBe(true)
+      expect(competingHandler).not.toHaveBeenCalled()
       expect(wrapper.findComponent(WhipOverlayStub).exists()).toBe(true)
 
       useSettingsStore().global.whipEnabled = false
       await wrapper.vm.$nextTick()
       dispatchShortcut()
-      expect(competingHandler).toHaveBeenCalledTimes(2)
+      expect(competingHandler).toHaveBeenCalledOnce()
 
       useSettingsStore().global.whipEnabled = true
       await wrapper.vm.$nextTick()
       dispatchShortcut({ key: 'j' })
-      expect(competingHandler).toHaveBeenCalledTimes(3)
+      expect(competingHandler).toHaveBeenCalledTimes(2)
 
       await wrapper.setProps({ running: false })
       dispatchShortcut()
-      expect(competingHandler).toHaveBeenCalledTimes(4)
+      expect(competingHandler).toHaveBeenCalledTimes(2)
     } finally {
       window.removeEventListener('keydown', competingHandler, true)
     }
@@ -198,7 +200,7 @@ describe('WorkspaceWhipControl', () => {
     const repeated = dispatchShortcut({ repeat: true })
     const nonMatching = dispatchShortcut({ key: 'j' })
 
-    expect(repeated.defaultPrevented).toBe(false)
+    expect(repeated.defaultPrevented).toBe(true)
     expect(nonMatching.defaultPrevented).toBe(false)
     expect(wrapper.findComponent(WhipOverlayStub).exists()).toBe(false)
   })
@@ -332,6 +334,25 @@ describe('WorkspaceWhipControl', () => {
 
     expect(doubles.dispose).toHaveBeenCalledOnce()
     expect(wrapper.findComponent(WhipOverlayStub).exists()).toBe(false)
+  })
+
+  it('keeps a pending crack alive while the stopped session id is cleared', async () => {
+    const deferred = deferredPromise()
+    doubles.enqueue.mockReturnValueOnce(deferred.promise)
+    const wrapper = mountControl({ workspaceId: 'ws-1', sessionId: 'session-1', running: true })
+    await openWhip(wrapper)
+    wrapper.getComponent(WhipOverlayStub).vm.$emit('crack')
+
+    await wrapper.setProps({ sessionId: null, running: false })
+
+    expect(doubles.dispose).not.toHaveBeenCalled()
+    expect(wrapper.findComponent(WhipOverlayStub).exists()).toBe(false)
+
+    deferred.resolve()
+    await deferred.promise
+    await wrapper.vm.$nextTick()
+
+    expect(doubles.dispose).toHaveBeenCalledOnce()
   })
 
   it('keeps a stopped overlay alive beyond one second until all accepted crack work settles', async () => {

--- a/src/client/src/components/WhipOverlay.vue
+++ b/src/client/src/components/WhipOverlay.vue
@@ -133,14 +133,14 @@ function handleKeydown(event: KeyboardEvent): void {
     return
   }
 
-  const isSpace = event.key === ' '
-  if (isSpace) event.preventDefault()
-  if (event.repeat || (event.key !== 'Enter' && !isSpace)) return
+  const isCrackKey = event.key === 'Enter' || event.key === ' '
+  if (!isCrackKey) return
+  event.preventDefault()
+  if (event.repeat) return
 
   const now = performance.now()
   if (state && now - state.lastCrackAt < WHIP_CONFIG.crackCooldownMs) return
 
-  if (!isSpace) event.preventDefault()
   if (state) state.lastCrackAt = now
   emitCrack()
 }

--- a/src/client/src/components/WorkspaceWhipControl.vue
+++ b/src/client/src/components/WorkspaceWhipControl.vue
@@ -48,6 +48,17 @@ function deactivate(): void {
   coordinator = null
 }
 
+function suspendAfterSessionEnd(): void {
+  active.value = false
+  const currentCoordinator = coordinator
+  const lifecycle = currentCoordinator ? coordinatorLifecycles.get(currentCoordinator) : undefined
+  if (!currentCoordinator || !lifecycle || lifecycle.pendingActions.size === 0) {
+    deactivate()
+    return
+  }
+  lifecycle.closeOnSettle = true
+}
+
 function trackAction(owner: WhipCrackCoordinator, action: Promise<void>): void {
   const lifecycle = coordinatorLifecycles.get(owner)
   if (!lifecycle || lifecycle.pendingActions.has(action)) return
@@ -103,11 +114,11 @@ function toggleWhip(): void {
 }
 
 function onShortcutKeydown(event: KeyboardEvent): void {
-  if (event.repeat || !settingsStore.global.whipEnabled) return
+  if (!settingsStore.global.whipEnabled) return
   if (!matchesWhipShortcut(event, settingsStore.global.whipShortcut, shortcutPlatform)) return
-  if (!active.value && (!props.running || !props.sessionId)) return
   event.preventDefault()
   event.stopImmediatePropagation()
+  if (event.repeat || (!active.value && (!props.running || !props.sessionId))) return
   toggleWhip()
 }
 
@@ -128,7 +139,16 @@ function handleCrack(): void {
 watch(
   () => [props.workspaceId, props.sessionId] as const,
   ([workspaceId, sessionId], [previousWorkspaceId, previousSessionId]) => {
-    if (workspaceId !== previousWorkspaceId || sessionId !== previousSessionId) deactivate()
+    if (workspaceId !== previousWorkspaceId) {
+      deactivate()
+      return
+    }
+    if (sessionId === previousSessionId) return
+    if (sessionId === null && previousSessionId !== null) {
+      suspendAfterSessionEnd()
+      return
+    }
+    deactivate()
   },
 )
 

--- a/src/client/src/i18n/de.ts
+++ b/src/client/src/i18n/de.ts
@@ -472,6 +472,8 @@ export default {
     'Modus bei der Erstellung eines neuen Workspaces. Plan = nur lesen, Bypass = keine Nachfragen, Strict = Edits automatisch akzeptieren mit allow-list, Interaktiv = vor jedem Tool fragen.',
   'settings.activityFeed': 'Aktivitätsfeed',
   'settings.showThinkingBlocks': 'Denkblöcke der Agenten anzeigen',
+  'settings.whipSettings': 'Peitsche',
+  'settings.whipSettingsHint': 'Konfiguriere den optionalen Peitschen-Kurzbefehl und die Lautstärke.',
   'settings.whipEnabled': 'Peitsche aktivieren',
   'settings.whipEnabledHint': 'Zeigt die interaktive Peitsche in geeigneten laufenden Workspaces an.',
   'settings.whipVolume': 'Peitschenlautstärke',

--- a/src/client/src/i18n/en.ts
+++ b/src/client/src/i18n/en.ts
@@ -466,6 +466,8 @@ export default {
   'settings.activityFeed': 'Activity feed',
   'settings.verboseMessages': 'Show verbose system messages (task_progress, task_started)',
   'settings.showThinkingBlocks': 'Show agent thinking blocks',
+  'settings.whipSettings': 'Whip',
+  'settings.whipSettingsHint': 'Configure the optional whip shortcut and volume.',
   'settings.whipEnabled': 'Enable whip',
   'settings.whipEnabledHint': 'Shows the interactive whip control in eligible running workspaces.',
   'settings.whipVolume': 'Whip volume',

--- a/src/client/src/i18n/es.ts
+++ b/src/client/src/i18n/es.ts
@@ -471,6 +471,8 @@ export default {
     'Modo aplicado al crear un workspace. Plan = solo lectura, Bypass = sin avisos, Estricto = auto-aceptar ediciones con allow-list, Interactivo = preguntar antes de cada herramienta.',
   'settings.activityFeed': 'Feed de actividad',
   'settings.showThinkingBlocks': 'Mostrar bloques de razonamiento de los agentes',
+  'settings.whipSettings': 'Látigo',
+  'settings.whipSettingsHint': 'Configura el atajo y el volumen opcionales del látigo.',
   'settings.whipEnabled': 'Activar el látigo',
   'settings.whipEnabledHint': 'Muestra el látigo interactivo en los workspaces activos compatibles.',
   'settings.whipVolume': 'Volumen del látigo',

--- a/src/client/src/i18n/fr.ts
+++ b/src/client/src/i18n/fr.ts
@@ -475,6 +475,8 @@ export default {
   'settings.activityFeed': "Flux d'activité",
   'settings.verboseMessages': 'Afficher les messages système détaillés (task_progress, task_started)',
   'settings.showThinkingBlocks': 'Afficher les blocs de réflexion des agents',
+  'settings.whipSettings': 'Fouet',
+  'settings.whipSettingsHint': 'Configurez le raccourci et le volume du fouet optionnel.',
   'settings.whipEnabled': 'Activer le fouet',
   'settings.whipEnabledHint': 'Affiche le fouet interactif dans les workspaces actifs compatibles.',
   'settings.whipVolume': 'Volume du fouet',

--- a/src/client/src/i18n/it.ts
+++ b/src/client/src/i18n/it.ts
@@ -474,6 +474,8 @@ export default {
     'Modalità applicata alla creazione di un workspace. Piano = sola lettura, Bypass = senza richieste, Stretto = auto-accetta le edit con allow-list, Interattivo = chiedi prima di ogni strumento.',
   'settings.activityFeed': 'Feed attività',
   'settings.showThinkingBlocks': 'Mostra i blocchi di ragionamento degli agenti',
+  'settings.whipSettings': 'Frusta',
+  'settings.whipSettingsHint': 'Configura la scorciatoia e il volume opzionali della frusta.',
   'settings.whipEnabled': 'Attiva la frusta',
   'settings.whipEnabledHint': 'Mostra la frusta interattiva nei workspace attivi compatibili.',
   'settings.whipVolume': 'Volume della frusta',

--- a/src/client/src/pages/SettingsPage.vue
+++ b/src/client/src/pages/SettingsPage.vue
@@ -233,41 +233,47 @@
                   color="indigo-4"
                   class="text-grey-5 text-caption"
                 />
-                <q-toggle
-                  v-model="globalWhipEnabled"
-                  :label="$t('settings.whipEnabled')"
-                  dark
-                  dense
-                  color="indigo-4"
-                  class="text-grey-5 text-caption"
-                >
-                  <q-tooltip>{{ $t('settings.whipEnabledHint') }}</q-tooltip>
-                </q-toggle>
-                <div v-if="globalWhipEnabled" class="column q-gutter-sm col">
-                  <WhipShortcutRecorder v-model="globalWhipShortcut" />
-                  <div class="row items-center q-gutter-sm">
-                    <div class="text-grey-5 text-caption" style="min-width: 58px;">
-                      {{ $t('settings.whipVolume') }}
-                    </div>
-                    <q-slider
-                      v-model="globalWhipVolume"
-                      :min="0"
-                      :max="1"
-                      :step="0.05"
-                      :disable="whipVolumeAvailability.disabled"
-                      :aria-label="$t('settings.whipVolume')"
-                      dark
-                      dense
-                      color="indigo-4"
-                      class="col"
-                    />
-                    <div class="text-grey-5 text-caption" style="min-width: 40px; text-align: right;">
-                      {{ Math.round(globalWhipVolume * 100) }}%
-                    </div>
+              </div>
+            </div>
+
+            <!-- Whip settings -->
+            <div v-show="activeTab === 'general'" class="settings-subcard q-pa-md rounded-borders q-pb-sm q-mb-md">
+              <div class="text-subtitle2 q-mb-xs">{{ $t('settings.whipSettings') }}</div>
+              <div class="text-grey-6 text-caption q-mb-md">{{ $t('settings.whipSettingsHint') }}</div>
+              <q-toggle
+                v-model="globalWhipEnabled"
+                :label="$t('settings.whipEnabled')"
+                dark
+                dense
+                color="indigo-4"
+                class="text-grey-5 text-caption"
+              >
+                <q-tooltip>{{ $t('settings.whipEnabledHint') }}</q-tooltip>
+              </q-toggle>
+              <div v-if="globalWhipEnabled" class="column q-gutter-sm q-mt-md">
+                <WhipShortcutRecorder v-model="globalWhipShortcut" />
+                <div class="row items-center q-gutter-sm">
+                  <div class="text-grey-5 text-caption" style="min-width: 58px;">
+                    {{ $t('settings.whipVolume') }}
                   </div>
-                  <div v-if="whipVolumeAvailability.hintKey" class="text-grey-6 text-caption">
-                    {{ $t(whipVolumeAvailability.hintKey) }}
+                  <q-slider
+                    v-model="globalWhipVolume"
+                    :min="0"
+                    :max="1"
+                    :step="0.05"
+                    :disable="whipVolumeAvailability.disabled"
+                    :aria-label="$t('settings.whipVolume')"
+                    dark
+                    dense
+                    color="indigo-4"
+                    class="col"
+                  />
+                  <div class="text-grey-5 text-caption" style="min-width: 40px; text-align: right;">
+                    {{ Math.round(globalWhipVolume * 100) }}%
                   </div>
+                </div>
+                <div v-if="whipVolumeAvailability.hintKey" class="text-grey-6 text-caption">
+                  {{ $t(whipVolumeAvailability.hintKey) }}
                 </div>
               </div>
             </div>


### PR DESCRIPTION
## Summary
- preserve pending whip messages when the interrupted session disappears
- prevent matching whip shortcuts from triggering browser or Kōbō shortcuts
- isolate whip activation, shortcut, and volume controls in a dedicated settings card

## Verification
- client tests: 560 passed
- backend tests: 2171 passed
- Biome lint, TypeScript checks, and full build passed