### PR TITLE
feat(settings): add ECC as a skill suite option

### DIFF
--- a/src/__tests__/settings-service.test.ts
+++ b/src/__tests__/settings-service.test.ts
@@ -1811,6 +1811,16 @@ describe('migration v22 — add-skill-suite-selector', () => {
     expect(getSettings().global.skillSuite).toBe('custom')
   })
 
+  it('updateGlobalSettings accepts skillSuite=ecc', () => {
+    updateGlobalSettings({ skillSuite: 'ecc' })
+    expect(getSettings().global.skillSuite).toBe('ecc')
+  })
+
+  it('updateGlobalSettings accepts skillSuite=superpowers+gstack+ecc', () => {
+    updateGlobalSettings({ skillSuite: 'superpowers+gstack+ecc' })
+    expect(getSettings().global.skillSuite).toBe('superpowers+gstack+ecc')
+  })
+
   it('updateGlobalSettings rejects invalid skillSuite values (previous value preserved)', () => {
     updateGlobalSettings({ skillSuite: 'gstack' })
     updateGlobalSettings({ skillSuite: 'not-a-suite' as never })

--- a/src/__tests__/skill-suite-prompts.test.ts
+++ b/src/__tests__/skill-suite-prompts.test.ts
@@ -1,14 +1,17 @@
 import { describe, expect, it } from 'vitest'
 import {
   AGNOSTIC_PROMPTS,
+  ALL_THREE_PROMPTS,
+  ECC_PROMPTS,
   GSTACK_PROMPTS,
   getSuitePrompts,
   SUPERPOWERS_PROMPTS,
 } from '../server/services/skill-suite-prompts.js'
+import { getGroomingIntro } from '../shared/skill-suite-prompts.js'
 
 describe('skill-suite-prompts', () => {
   it('every constant has all 5 fields populated', () => {
-    for (const c of [SUPERPOWERS_PROMPTS, GSTACK_PROMPTS, AGNOSTIC_PROMPTS]) {
+    for (const c of [SUPERPOWERS_PROMPTS, GSTACK_PROMPTS, ECC_PROMPTS, ALL_THREE_PROMPTS, AGNOSTIC_PROMPTS]) {
       expect(c.reviewTemplate).toBeTruthy()
       expect(c.autoLoopReviewGate).toBeTruthy()
       expect(c.autoLoopGroomingIntro).toBeTruthy()
@@ -28,6 +31,7 @@ describe('skill-suite-prompts', () => {
   it('agnostic prompts mention no specific suite by name', () => {
     for (const v of Object.values(AGNOSTIC_PROMPTS)) {
       expect(v).not.toMatch(/superpowers:/i)
+      expect(v).not.toMatch(/ecc:/i)
       expect(v).not.toMatch(/\/review\b|\/ship\b|\/qa\b|\/office-hours\b|\/autoplan\b|\/land-and-deploy\b/)
     }
   })
@@ -45,9 +49,27 @@ describe('skill-suite-prompts', () => {
     expect(GSTACK_PROMPTS.qaPromptTemplate).toMatch(/\/qa/)
   })
 
-  it('getSuitePrompts returns the right baked-in set for superpowers and gstack', () => {
+  it('ecc prompts mention ecc skills/agents', () => {
+    expect(ECC_PROMPTS.reviewTemplate).toMatch(/ecc:/)
+    expect(ECC_PROMPTS.autoLoopReviewGate).toMatch(/ecc:/)
+    expect(ECC_PROMPTS.autoLoopGroomingIntro).toMatch(/ecc:/)
+    expect(ECC_PROMPTS.qaPromptTemplate).toMatch(/ecc:/)
+    expect(ECC_PROMPTS.brainstormingInstruction).toMatch(/ecc:/)
+  })
+
+  it('getSuitePrompts returns the right baked-in set for superpowers, gstack, ecc, and the triple combo', () => {
     expect(getSuitePrompts('superpowers', {})).toEqual(SUPERPOWERS_PROMPTS)
     expect(getSuitePrompts('gstack', {})).toEqual(GSTACK_PROMPTS)
+    expect(getSuitePrompts('ecc', {})).toEqual(ECC_PROMPTS)
+    expect(getSuitePrompts('superpowers+gstack+ecc', {})).toEqual(ALL_THREE_PROMPTS)
+  })
+
+  it('all-three prompts mention superpowers, gstack, and ecc', () => {
+    for (const v of Object.values(ALL_THREE_PROMPTS)) {
+      expect(v).toMatch(/ecc:/)
+    }
+    expect(ALL_THREE_PROMPTS.reviewTemplate).toMatch(/superpowers:/)
+    expect(ALL_THREE_PROMPTS.reviewTemplate).toMatch(/\/review\b/)
   })
 
   it('getSuitePrompts in custom mode falls back to AGNOSTIC for missing overrides', () => {
@@ -68,5 +90,19 @@ describe('skill-suite-prompts', () => {
   it('getSuitePrompts ignores whitespace-only overrides in custom mode', () => {
     const result = getSuitePrompts('custom', { reviewTemplate: '   \n  ' })
     expect(result.reviewTemplate).toBe(AGNOSTIC_PROMPTS.reviewTemplate)
+  })
+
+  describe('getGroomingIntro', () => {
+    it('resolves ecc and the triple combo to distinct, ecc-aware intros', () => {
+      const eccIntro = getGroomingIntro('ecc')
+      const tripleIntro = getGroomingIntro('superpowers+gstack+ecc')
+      const superpowersIntro = getGroomingIntro('superpowers')
+      const combinedIntro = getGroomingIntro('superpowers+gstack')
+
+      expect(eccIntro).toMatch(/ecc:/)
+      expect(tripleIntro).toMatch(/ecc:/)
+      expect(tripleIntro).not.toBe(combinedIntro)
+      expect(eccIntro).not.toBe(superpowersIntro)
+    })
   })
 })

--- a/src/client/src/i18n/de.ts
+++ b/src/client/src/i18n/de.ts
@@ -397,6 +397,12 @@ export default {
   'settings.skillSuite.superpowersGstack': 'Superpowers + gstack',
   'settings.skillSuite.superpowersGstackHint':
     'Beide Suites lassen sich kombinieren — superpowers für Methodik (Brainstorm / TDD / Pläne / Prinzipien-Review), gstack für konkrete Workflows (/review, /qa, /browse, /design-review, /investigate).',
+  'settings.skillSuite.ecc': 'ECC',
+  'settings.skillSuite.eccHint':
+    'Agent-Harness-Framework von affaan-m — Agents, Skills, Rules und Hooks zum Planen, Testen, Implementieren, Reviewen und Speichern (github.com/affaan-m/ECC).',
+  'settings.skillSuite.allThree': 'Superpowers + gstack + ECC',
+  'settings.skillSuite.allThreeHint':
+    'Alle drei lassen sich kombinieren — superpowers für Methodik, gstack für konkrete Workflows, ECC für strukturierte Multi-Agent-Review-/Implementierungsdurchläufe.',
   'settings.skillSuite.customHint': 'Bearbeite die vier Prompts unten selbst. Beginnt mit der agnostischen Basis.',
   'settings.skillSuite.reloadDefaults': 'Standard wiederherstellen',
   'settings.skillSuite.reloadDefaultsConfirm':

--- a/src/client/src/i18n/en.ts
+++ b/src/client/src/i18n/en.ts
@@ -393,6 +393,12 @@ export default {
   'settings.skillSuite.superpowersGstack': 'Superpowers + gstack',
   'settings.skillSuite.superpowersGstackHint':
     'Both suites stack — superpowers for process discipline (brainstorm / TDD / plans / principles-level review), gstack for concrete workflows (/review, /qa, /browse, /design-review, /investigate).',
+  'settings.skillSuite.ecc': 'ECC',
+  'settings.skillSuite.eccHint':
+    "affaan-m's agent-harness framework — agents, skills, rules and hooks for planning, testing, implementing, reviewing and memorizing (github.com/affaan-m/ECC).",
+  'settings.skillSuite.allThree': 'Superpowers + gstack + ECC',
+  'settings.skillSuite.allThreeHint':
+    'All three stack — superpowers for process discipline, gstack for concrete workflows, ECC for structured multi-agent review/implementation passes.',
   'settings.skillSuite.customHint': 'Edit the four prompts below yourself. Starts from the agnostic baseline.',
   'settings.skillSuite.reloadDefaults': 'Reload defaults',
   'settings.skillSuite.reloadDefaultsConfirm': 'Replace the four custom prompts with the agnostic defaults?',

--- a/src/client/src/i18n/es.ts
+++ b/src/client/src/i18n/es.ts
@@ -396,6 +396,12 @@ export default {
   'settings.skillSuite.superpowersGstack': 'Superpowers + gstack',
   'settings.skillSuite.superpowersGstackHint':
     'Ambas suites se combinan — superpowers para la metodología (brainstorm / TDD / planes / revisión a nivel de principios), gstack para flujos concretos (/review, /qa, /browse, /design-review, /investigate).',
+  'settings.skillSuite.ecc': 'ECC',
+  'settings.skillSuite.eccHint':
+    'Framework de agentes de affaan-m — agents, skills, rules y hooks para planificar, probar, implementar, revisar y memorizar (github.com/affaan-m/ECC).',
+  'settings.skillSuite.allThree': 'Superpowers + gstack + ECC',
+  'settings.skillSuite.allThreeHint':
+    'Las tres suites se combinan — superpowers para la metodología, gstack para flujos concretos, ECC para pases de revisión/implementación multiagente estructurados.',
   'settings.skillSuite.customHint': 'Edita los cuatro prompts a continuación tú mismo. Parte de la base agnóstica.',
   'settings.skillSuite.reloadDefaults': 'Restaurar predeterminados',
   'settings.skillSuite.reloadDefaultsConfirm':

--- a/src/client/src/i18n/fr.ts
+++ b/src/client/src/i18n/fr.ts
@@ -399,6 +399,12 @@ export default {
   'settings.skillSuite.superpowersGstack': 'Superpowers + gstack',
   'settings.skillSuite.superpowersGstackHint':
     "Les deux suites s'empilent — superpowers pour la méthodo (brainstorm / TDD / plans / review au niveau principes), gstack pour les workflows concrets (/review, /qa, /browse, /design-review, /investigate).",
+  'settings.skillSuite.ecc': 'ECC',
+  'settings.skillSuite.eccHint':
+    "Framework agentique d'affaan-m — agents, skills, rules et hooks pour planifier, tester, implémenter, relire et mémoriser (github.com/affaan-m/ECC).",
+  'settings.skillSuite.allThree': 'Superpowers + gstack + ECC',
+  'settings.skillSuite.allThreeHint':
+    "Les trois suites s'empilent — superpowers pour la méthodo, gstack pour les workflows concrets, ECC pour des passes de relecture/implémentation multi-agents structurées.",
   'settings.skillSuite.customHint': 'Édite les quatre prompts ci-dessous toi-même. Démarre depuis la base agnostique.',
   'settings.skillSuite.reloadDefaults': 'Recharger les valeurs par défaut',
   'settings.skillSuite.reloadDefaultsConfirm':

--- a/src/client/src/i18n/it.ts
+++ b/src/client/src/i18n/it.ts
@@ -399,6 +399,12 @@ export default {
   'settings.skillSuite.superpowersGstack': 'Superpowers + gstack',
   'settings.skillSuite.superpowersGstackHint':
     'Le due suite si combinano — superpowers per la metodologia (brainstorm / TDD / piani / review a livello di principi), gstack per i flussi concreti (/review, /qa, /browse, /design-review, /investigate).',
+  'settings.skillSuite.ecc': 'ECC',
+  'settings.skillSuite.eccHint':
+    'Framework agentico di affaan-m — agents, skills, rules e hooks per pianificare, testare, implementare, rivedere e memorizzare (github.com/affaan-m/ECC).',
+  'settings.skillSuite.allThree': 'Superpowers + gstack + ECC',
+  'settings.skillSuite.allThreeHint':
+    'Le tre suite si combinano — superpowers per la metodologia, gstack per i flussi concreti, ECC per passaggi di review/implementazione multi-agente strutturati.',
   'settings.skillSuite.customHint': 'Modifica i quattro prompt qui sotto tu stesso. Parte dalla base agnostica.',
   'settings.skillSuite.reloadDefaults': 'Ripristina predefiniti',
   'settings.skillSuite.reloadDefaultsConfirm':

--- a/src/client/src/pages/SettingsPage.vue
+++ b/src/client/src/pages/SettingsPage.vue
@@ -80,7 +80,9 @@
                 :options="[
                   { label: $t('settings.skillSuite.superpowers'),         value: 'superpowers' },
                   { label: $t('settings.skillSuite.gstack'),              value: 'gstack' },
+                  { label: $t('settings.skillSuite.ecc'),                 value: 'ecc' },
                   { label: $t('settings.skillSuite.superpowersGstack'),   value: 'superpowers+gstack' },
+                  { label: $t('settings.skillSuite.allThree'),            value: 'superpowers+gstack+ecc' },
                   { label: $t('settings.skillSuite.custom'),              value: 'custom' },
                 ]"
                 type="radio"
@@ -2867,8 +2869,12 @@ const skillSuiteHintKey = computed(() => {
   switch (globalSkillSuite.value) {
     case 'gstack':
       return 'settings.skillSuite.gstackHint'
+    case 'ecc':
+      return 'settings.skillSuite.eccHint'
     case 'superpowers+gstack':
       return 'settings.skillSuite.superpowersGstackHint'
+    case 'superpowers+gstack+ecc':
+      return 'settings.skillSuite.allThreeHint'
     case 'custom':
       return 'settings.skillSuite.customHint'
     default:

--- a/src/server/routes/workspaces.ts
+++ b/src/server/routes/workspaces.ts
@@ -939,7 +939,11 @@ app.post('/', migrationGuard, async (c) => {
       // active skill suite includes gstack, and only if the user has actually
       // installed gstack locally (the binary may be absent — skip silently).
       // Fast + idempotent; safe to run on every workspace boot.
-      if (globalSettings.skillSuite === 'gstack' || globalSettings.skillSuite === 'superpowers+gstack') {
+      if (
+        globalSettings.skillSuite === 'gstack' ||
+        globalSettings.skillSuite === 'superpowers+gstack' ||
+        globalSettings.skillSuite === 'superpowers+gstack+ecc'
+      ) {
         brainstormPrompt += `\n\nIMPORTANT (gstack): Before brainstorming, check whether \`~/.claude/skills/gstack/bin/gstack-brain-sync\` exists. If it does, run it with \`--once\` to load gstack learnings (project-specific patterns, pitfalls, and preferences from prior sessions) into memory. If the binary is missing (gstack not installed in this environment), skip silently and continue — do NOT install anything and do NOT mention the absence. Fast and idempotent when present.`
       }
 

--- a/src/server/services/skill-suite-prompts.ts
+++ b/src/server/services/skill-suite-prompts.ts
@@ -4,7 +4,9 @@ import {
   AGNOSTIC_BRAINSTORMING_INSTRUCTION,
   AGNOSTIC_QA_PROMPT_TEMPLATE,
   AGNOSTIC_REVIEW_TEMPLATE,
+  GROOMING_INTRO_ALL,
   GROOMING_INTRO_COMBINED,
+  GROOMING_INTRO_ECC,
   GROOMING_INTRO_GSTACK,
   GROOMING_INTRO_SUPERPOWERS,
   type SkillSuite,
@@ -118,6 +120,24 @@ For reproducible regression coverage that runs on every PR, prefer **Cypress** s
     '4. Wait for explicit user approval on the final plan before announcing brainstorming is done.',
 }
 
+export const ECC_PROMPTS: SuitePrompts = {
+  reviewTemplate:
+    REVIEW_HEADER +
+    'If a code-review skill is available (e.g. `ecc:code-review`, or dispatch a subagent via the Task tool with `subagent_type: "ecc:code-reviewer"`), invoke it to drive this review. Otherwise follow the steps below directly.\n\n' +
+    REVIEW_BODY,
+  autoLoopReviewGate:
+    'Code review gate — BEFORE marking the task done, dispatch an independent code-reviewer subagent via the Task tool with `subagent_type: "ecc:code-reviewer"` (or run the `ecc:code-review` / `ecc:quality-gate` skill if you prefer a driven workflow over a bare subagent). Brief the reviewer with: what you just implemented, the task title, and the commit SHA (via `git rev-parse HEAD`). Ask specifically whether the change matches the task scope, whether edge cases are handled, and whether the commit is clean.',
+  autoLoopGroomingIntro: GROOMING_INTRO_ECC,
+  qaPromptTemplate:
+    'QA pass for workspace "{{workspace_name}}" in project {{project_name}}.\n\nBranch: {{branch_name}}\nStaging URL: {{staging_url}}\n\nIf a QA-style skill is available in this environment (e.g. `ecc:browser-qa`, or dispatch a subagent via the Task tool with `subagent_type: "ecc:e2e-runner"`), use it to exercise the staging URL. Otherwise, fall back to manually scripting the smoke checks and recording your findings as a bug report.',
+  brainstormingInstruction:
+    'Brainstorm the implementation approach using the ECC pipeline:\n' +
+    '1. Run the `ecc:plan` skill (or dispatch a subagent via the Task tool with `subagent_type: "ecc:planner"`) — it expands the request into a full spec with features, sprints, and evaluation criteria before any code. Ask clarifying questions and wait for explicit user approval on the design before moving on.\n' +
+    '2. Use `ecc:tdd-workflow` to shape the approved design into a test-first implementation plan.\n' +
+    '3. If you encounter a bug or unexpected behaviour during exploration, dispatch a subagent via the Task tool with `subagent_type: "ecc:architect"` (or the relevant language-specific `ecc:*-reviewer` agent) rather than guessing.\n' +
+    "Do NOT skip the skills or rationalise around them — that's how the rigour gets lost.",
+}
+
 export const AGNOSTIC_PROMPTS: SuitePrompts = {
   reviewTemplate: AGNOSTIC_REVIEW_TEMPLATE,
   autoLoopReviewGate: AGNOSTIC_AUTO_LOOP_REVIEW_GATE,
@@ -183,6 +203,65 @@ For reproducible regression coverage that runs on every PR, prefer **Cypress** s
     '5. Wait for explicit user approval on the final reviewed plan before announcing brainstorming is done.',
 }
 
+// ── Triple combo: superpowers + gstack + ecc ─────────────────────────────────
+// For users who install all three suites. Extends the two-suite COMBINED_PROMPTS
+// "pick by intent" pattern with a third branch per field.
+
+export const ALL_THREE_PROMPTS: SuitePrompts = {
+  reviewTemplate:
+    REVIEW_HEADER +
+    'Three complementary review paths are available — pick by intent:\n' +
+    '- `/review` (gstack Staff Engineer) for tactical bug-hunting that finds issues passing CI but blowing up in production. Auto-fixes the obvious ones.\n' +
+    '- `superpowers:requesting-code-review` for principles-level critique — silent failures, test-design soundness, surface-area discipline.\n' +
+    "- `ecc:code-review` (or a Task-dispatched `ecc:code-reviewer` subagent) for ECC's structured multi-agent review pass.\n" +
+    'You can run more than one on the same diff if the change is large. If none is available, fall back to the manual checklist below.\n\n' +
+    REVIEW_BODY,
+  autoLoopReviewGate:
+    'Code review gate — BEFORE marking the task done, pick the appropriate review path (three are installed):\n' +
+    '- Default to `/review` (gstack Staff Engineer) for tactical code-level bugs and auto-fixes.\n' +
+    '- Use `superpowers:requesting-code-review` instead when the task introduces tests, refactors, or design decisions worth a principles-level critique.\n' +
+    "- Use a Task-dispatched `ecc:code-reviewer` subagent (or the `ecc:quality-gate` skill) when you want ECC's structured multi-agent pass.\n\n" +
+    'Brief the chosen reviewer with: what you just implemented, the task title, and the commit SHA (via `git rev-parse HEAD`). Ask specifically whether the change matches the task scope, whether edge cases are handled, and whether the commit is clean. If the reviewer auto-fixes minor issues, accept the fixes via an amend or fix-up commit, then re-run step 3 checks.',
+  autoLoopGroomingIntro: GROOMING_INTRO_ALL,
+  qaPromptTemplate: `QA pass for workspace "{{workspace_name}}" in project {{project_name}}.
+
+Branch: {{branch_name}}
+Staging URL: {{staging_url}}
+
+Pick the right tool for the situation. gstack covers interactive QA, ECC covers structured/automated QA, superpowers covers low-level browser control as a fallback.
+
+gstack QA toolkit (preferred for interactive QA):
+- \`/browse\` — Headless navigation: URL → interactions → screenshots. Use for quick dogfooding a flow or sanity-checking a PR.
+- \`/qa {{staging_url}}\` — Systematic QA with automatic bug fixing. Three tiers (invoke as \`/qa Quick\`, \`/qa Standard\`, or \`/qa Exhaustive\`):
+  - **Quick** — critical and high-severity bugs only.
+  - **Standard** — adds medium-severity bugs.
+  - **Exhaustive** — adds cosmetic issues.
+- \`/qa-only {{staging_url}}\` — Same methodology as \`/qa\` but report only, no code changes.
+- \`/design-review\` — Visual audit (consistency, spacing, hierarchy, AI slop). Commits atomic fixes with before/after screenshots.
+
+ECC toolkit:
+- \`ecc:browser-qa\` skill — structured browser-driven QA pass.
+- Task-dispatched \`ecc:e2e-runner\` subagent — generates, maintains, and runs E2E tests; manages flaky-test quarantine and artifact capture.
+
+Superpowers alternative (low-level browser control):
+- \`superpowers-chrome:browsing\` — Direct Chrome DevTools Protocol control over an existing Chrome session: multi-tab management, form automation, content extraction. Use when you need fine-grained control beyond what \`/browse\` exposes.
+
+For reproducible regression coverage that runs on every PR, prefer **Cypress** specs in \`test/cypress/\` instead of any interactive QA skill. Reserve the tools above for exploration, dogfooding, and one-shot visual debugging.`,
+  brainstormingInstruction:
+    'Brainstorm using all three suites — each plays to its strength:\n' +
+    '1. Early product framing: prefer gstack `/office-hours` for product-shaped work (six forcing questions + design doc), or `ecc:plan` (or `subagent_type: "ecc:planner"`) for ECC-style spec expansion (features, sprints, evaluation criteria). Fall back to `superpowers:brainstorming` for purely infra/refactor work where neither product lens applies.\n' +
+    '2. Plan construction — pick whichever fits the work better:\n' +
+    '   - gstack `/autoplan` for the chained CEO/design/eng/DX pipeline (auto-detects which apply).\n' +
+    '   - `superpowers:writing-plans` for a TDD-shaped multi-step plan that maps cleanly onto subagent dispatch.\n' +
+    '   - `ecc:tdd-workflow` when the project follows ECC conventions and you want its test-first shaping.\n' +
+    '3. For debugging during exploration, prefer `/investigate` (gstack — root-cause methodology), `superpowers:systematic-debugging`, or a Task-dispatched `ecc:architect` subagent — whichever you reach for first.\n' +
+    '4. Plan review gate (MANDATORY before announcing brainstorming is done): once the plan is ready, it MUST pass the gstack plan-review skills before you proceed.\n' +
+    '   - If you built the plan via `/autoplan`, you have ALREADY passed the chained reviews — skip this step.\n' +
+    '   - Otherwise (plan came from `superpowers:writing-plans`, `ecc:tdd-workflow`, or any other path), run `/autoplan` now on the existing plan to chain the reviews, OR invoke the relevant ones individually: `/plan-ceo-review` (scope challenge), `/plan-eng-review` (architecture / edge cases / tests), `/plan-design-review` (UI / AI slop, when there is UI scope), `/plan-devex-review` (when the work has developer-facing surface).\n' +
+    '   - Apply any changes the reviews recommend before moving on.\n' +
+    '5. Wait for explicit user approval on the final reviewed plan before announcing brainstorming is done.',
+}
+
 /**
  * Resolve the suite prompts to use right now, given the global `skillSuite`
  * and the four user-editable `custom*` fields (only consulted in `custom` mode).
@@ -191,7 +270,9 @@ For reproducible regression coverage that runs on every PR, prefer **Cypress** s
 export function getSuitePrompts(suite: SkillSuite, overrides: Partial<SuitePrompts>): SuitePrompts {
   if (suite === 'superpowers') return SUPERPOWERS_PROMPTS
   if (suite === 'gstack') return GSTACK_PROMPTS
+  if (suite === 'ecc') return ECC_PROMPTS
   if (suite === 'superpowers+gstack') return COMBINED_PROMPTS
+  if (suite === 'superpowers+gstack+ecc') return ALL_THREE_PROMPTS
   // custom mode: per-field fallback to AGNOSTIC when the override is missing/blank
   const pick = <K extends keyof SuitePrompts>(k: K): string => {
     const value = overrides[k]

--- a/src/shared/skill-suite-prompts.ts
+++ b/src/shared/skill-suite-prompts.ts
@@ -13,10 +13,17 @@
  * - `custom`: prompts come from the user-editable `custom*` fields in settings,
  *    initialised to the AGNOSTIC defaults below.
  */
-export type SkillSuite = 'superpowers' | 'gstack' | 'superpowers+gstack' | 'custom'
+export type SkillSuite = 'superpowers' | 'gstack' | 'ecc' | 'superpowers+gstack' | 'superpowers+gstack+ecc' | 'custom'
 
 export function isValidSkillSuite(value: unknown): value is SkillSuite {
-  return value === 'superpowers' || value === 'gstack' || value === 'superpowers+gstack' || value === 'custom'
+  return (
+    value === 'superpowers' ||
+    value === 'gstack' ||
+    value === 'ecc' ||
+    value === 'superpowers+gstack' ||
+    value === 'superpowers+gstack+ecc' ||
+    value === 'custom'
+  )
 }
 
 // ── Agnostic prompt strings ───────────────────────────────────────────────────
@@ -90,6 +97,12 @@ export const GROOMING_INTRO_GSTACK =
 export const GROOMING_INTRO_COMBINED =
   'You are preparing this workspace for Kōbō auto-loop mode. This is a GROOMING session only — DO NOT implement anything, DO NOT write or edit code, DO NOT run tests or builds, DO NOT invoke `superpowers:executing-plans`, `/ship`, `/autoplan`, `/land-and-deploy`, or any other implementation, planning, or release skill. Your ONLY job is to curate the Kōbō task list via MCP tools.'
 
+export const GROOMING_INTRO_ECC =
+  'You are preparing this workspace for Kōbō auto-loop mode. This is a GROOMING session only — DO NOT implement anything, DO NOT write or edit code, DO NOT run tests or builds, DO NOT invoke `ecc:feature-dev`, `ecc:tdd-workflow`, `ecc:plan`, or any other implementation, planning, or release skill. Your ONLY job is to curate the Kōbō task list via MCP tools.'
+
+export const GROOMING_INTRO_ALL =
+  'You are preparing this workspace for Kōbō auto-loop mode. This is a GROOMING session only — DO NOT implement anything, DO NOT write or edit code, DO NOT run tests or builds, DO NOT invoke `superpowers:executing-plans`, `/ship`, `/autoplan`, `/land-and-deploy`, `ecc:feature-dev`, `ecc:tdd-workflow`, `ecc:plan`, or any other implementation, planning, or release skill. Your ONLY job is to curate the Kōbō task list via MCP tools.'
+
 /**
  * Resolve the grooming intro for the given suite. In `custom` mode, the
  * user-provided override is used (or AGNOSTIC if the override is empty/blank).
@@ -99,7 +112,9 @@ export function getGroomingIntro(suite: SkillSuite, customOverride?: string): st
     const trimmed = (customOverride ?? '').trim()
     return trimmed || AGNOSTIC_AUTO_LOOP_GROOMING_INTRO
   }
+  if (suite === 'superpowers+gstack+ecc') return GROOMING_INTRO_ALL
   if (suite === 'superpowers+gstack') return GROOMING_INTRO_COMBINED
+  if (suite === 'ecc') return GROOMING_INTRO_ECC
   if (suite === 'gstack') return GROOMING_INTRO_GSTACK
   return GROOMING_INTRO_SUPERPOWERS
 }


### PR DESCRIPTION
## Summary
- Adds ECC (github.com/affaan-m/ECC) as a fifth `SkillSuite` option in Settings → Skills, alongside superpowers/gstack/custom
- Adds a new `superpowers+gstack+ecc` triple-combo option for users running all three suites
- Updates the auto-generated agent prompts (code review, auto-loop review gate, grooming intro, QA pass, brainstorming instruction) to reference ECC's agents/skills when selected
- Adds the corresponding i18n strings across all 5 supported locales (en/fr/de/es/it)

## Test plan
- [x] `npm test` — 116 test files / 2215 tests passing
- [x] `npm run test:client` — 57 test files / 589 tests passing
- [x] `npx tsc --noEmit` — clean
- [x] `make ci` — full local pipeline (install, audit, lint, typecheck, test) passing
- [ ] Manual: Settings → Skills shows the 6 radio options in order and the ECC / triple-combo hints render translated text in each locale