### PR TITLE
feat(client): responsive mobile layout for drawer, settings nav and workspace toolbar

### DIFF
--- a/src/client/src/__tests__/use-is-mobile.test.ts
+++ b/src/client/src/__tests__/use-is-mobile.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it, vi } from 'vitest'
 import { reactive } from 'vue'
 
-// Mutable reactive stand-in for $q.screen; each test controls lt.sm.
-const screen = reactive({ lt: { sm: false } })
+// Mutable reactive stand-in for $q.screen; each test controls lt.sm and lt.md.
+const screen = reactive({ lt: { sm: false, md: false } })
 vi.mock('quasar', () => ({ useQuasar: () => ({ screen }) }))
 
 import { useIsMobile } from '../composables/use-is-mobile'
@@ -26,5 +26,27 @@ describe('useIsMobile', () => {
     expect(isMobile.value).toBe(false)
     screen.lt.sm = true
     expect(isMobile.value).toBe(true)
+  })
+})
+
+describe('useIsMobile - isDrawerCollapsed', () => {
+  it('is false when screen.lt.md is false', () => {
+    screen.lt.md = false
+    const { isDrawerCollapsed } = useIsMobile()
+    expect(isDrawerCollapsed.value).toBe(false)
+  })
+
+  it('is true when screen.lt.md is true', () => {
+    screen.lt.md = true
+    const { isDrawerCollapsed } = useIsMobile()
+    expect(isDrawerCollapsed.value).toBe(true)
+  })
+
+  it('tracks screen.lt.md reactively', () => {
+    screen.lt.md = false
+    const { isDrawerCollapsed } = useIsMobile()
+    expect(isDrawerCollapsed.value).toBe(false)
+    screen.lt.md = true
+    expect(isDrawerCollapsed.value).toBe(true)
   })
 })

--- a/src/client/src/__tests__/use-is-mobile.test.ts
+++ b/src/client/src/__tests__/use-is-mobile.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it, vi } from 'vitest'
+import { reactive } from 'vue'
+
+// Mutable reactive stand-in for $q.screen; each test controls lt.sm.
+const screen = reactive({ lt: { sm: false } })
+vi.mock('quasar', () => ({ useQuasar: () => ({ screen }) }))
+
+import { useIsMobile } from '../composables/use-is-mobile'
+
+describe('useIsMobile', () => {
+  it('is false when screen.lt.sm is false', () => {
+    screen.lt.sm = false
+    const { isMobile } = useIsMobile()
+    expect(isMobile.value).toBe(false)
+  })
+
+  it('is true when screen.lt.sm is true', () => {
+    screen.lt.sm = true
+    const { isMobile } = useIsMobile()
+    expect(isMobile.value).toBe(true)
+  })
+
+  it('tracks screen.lt.sm reactively', () => {
+    screen.lt.sm = false
+    const { isMobile } = useIsMobile()
+    expect(isMobile.value).toBe(false)
+    screen.lt.sm = true
+    expect(isMobile.value).toBe(true)
+  })
+})

--- a/src/client/src/components/ChatInput.vue
+++ b/src/client/src/components/ChatInput.vue
@@ -210,8 +210,8 @@
     </div>
     <div class="chat-hint row items-center no-wrap text-caption text-grey-8">
       <div class="chat-hint__shortcuts row items-center no-wrap">
-        <span class="chat-hint__primary"><kbd>Enter</kbd> {{ $t('common.send') }} <span class="q-mx-xs">&middot;</span> <kbd>Shift+Enter</kbd> {{ $t('common.newLine') }}</span>
-        <q-btn flat dense round size="xs" icon="keyboard" class="q-ml-xs">
+        <span class="chat-hint__primary"><kbd>Enter</kbd> {{ $t('common.send') }}<template v-if="!isMobile"> <span class="q-mx-xs">&middot;</span> <kbd>Shift+Enter</kbd> {{ $t('common.newLine') }}</template></span>
+        <q-btn v-if="!isMobile" flat dense round size="xs" icon="keyboard" class="q-ml-xs">
           <q-tooltip>{{ $t('chatInput.shortcuts') }}</q-tooltip>
           <q-menu anchor="top left" self="bottom left">
             <q-list dense class="chat-shortcuts-menu">
@@ -259,6 +259,7 @@ import { useQuasar } from 'quasar'
 import QuotaFooter from 'src/components/QuotaFooter.vue'
 import SlashSuggestionsPopup from 'src/components/SlashSuggestionsPopup.vue'
 import { useFileMention } from 'src/composables/use-file-mention'
+import { useIsMobile } from 'src/composables/use-is-mobile'
 import { type SlashDropdownItem, useSlashAutocomplete } from 'src/composables/use-slash-autocomplete'
 import { supportsLiveSteering, supportsQuotaStatus } from 'src/constants/engineFeatures'
 import { useSettingsStore } from 'src/stores/settings'
@@ -277,6 +278,7 @@ const props = defineProps<{
 
 const { t } = useI18n()
 const $q = useQuasar()
+const { isMobile } = useIsMobile()
 const store = useWorkspaceStore()
 const settingsStore = useSettingsStore()
 const wsStore = useWebSocketStore()
@@ -620,10 +622,15 @@ watch(message, async () => {
   }
 })
 
-window.addEventListener('keydown', onWindowKeyDown)
-window.addEventListener('keyup', onWindowKeyUp)
-window.addEventListener('blur', onWindowBlur)
-document.addEventListener('visibilitychange', onVisibilityChange)
+// Keyboard push-to-talk has no tactile effect on phones (no physical
+// keyboard) — skip registration on mobile. The touch mic button
+// (@touchstart/@touchend) keeps working via startVoiceCapture/stopVoiceCapture.
+if (!isMobile.value) {
+  window.addEventListener('keydown', onWindowKeyDown)
+  window.addEventListener('keyup', onWindowKeyUp)
+  window.addEventListener('blur', onWindowBlur)
+  document.addEventListener('visibilitychange', onVisibilityChange)
+}
 onUnmounted(() => {
   window.removeEventListener('keydown', onWindowKeyDown)
   window.removeEventListener('keyup', onWindowKeyUp)

--- a/src/client/src/components/DrawerToggleButton.vue
+++ b/src/client/src/components/DrawerToggleButton.vue
@@ -1,0 +1,34 @@
+<template>
+  <q-btn
+    v-if="shouldShow"
+    flat
+    dense
+    round
+    size="sm"
+    :icon="layout.leftDrawerOpen ? 'menu_open' : 'menu'"
+    @click="layout.toggleLeft()"
+  >
+    <q-tooltip>{{ $t('layout.toggleWorkspaces') }}</q-tooltip>
+  </q-btn>
+</template>
+
+<script setup lang="ts">
+import { useIsMobile } from 'src/composables/use-is-mobile'
+import { useLayoutStore } from 'src/stores/layout'
+import { computed } from 'vue'
+
+/**
+ * Re-opens the global left drawer when it's collapsed to an overlay
+ * (< 1024px). Shared by SearchPage, CreatePage, HealthPage, ChangelogPage
+ * (plain `isDrawerCollapsed` gate) and SettingsPage (`excludeMobile`, to
+ * avoid double hamburgers with its own < 600px mobile nav drawer toggle).
+ */
+const props = defineProps<{ excludeMobile?: boolean }>()
+
+const layout = useLayoutStore()
+const { isMobile, isDrawerCollapsed } = useIsMobile()
+
+const shouldShow = computed(() =>
+  props.excludeMobile ? isDrawerCollapsed.value && !isMobile.value : isDrawerCollapsed.value,
+)
+</script>

--- a/src/client/src/components/SettingsNavList.vue
+++ b/src/client/src/components/SettingsNavList.vue
@@ -1,0 +1,83 @@
+<template>
+  <q-list dense class="settings-nav__list">
+    <q-item
+      v-for="item in navItems"
+      :key="item.value"
+      clickable
+      v-ripple="false"
+      :data-tour="`settings-nav-${item.value}`"
+      :class="['settings-nav__item', { 'settings-nav__item--active': activeTab === item.value }]"
+      @click="emit('select', item.value)"
+    >
+      <q-item-section avatar class="settings-nav__icon">
+        <q-icon :name="item.icon" size="16px" />
+      </q-item-section>
+      <q-item-section class="settings-nav__label">{{ item.label }}</q-item-section>
+    </q-item>
+  </q-list>
+</template>
+
+<script setup lang="ts">
+interface NavItem {
+  value: string
+  icon: string
+  label: string
+}
+
+defineProps<{
+  navItems: NavItem[]
+  activeTab: string
+}>()
+
+const emit = defineEmits<{
+  select: [value: string]
+}>()
+</script>
+
+<style lang="scss" scoped>
+.settings-nav__list {
+  padding: 0;
+}
+
+.settings-nav__item {
+  border-radius: var(--kobo-radius-sm);
+  padding: 6px 12px;
+  color: var(--kobo-text-2);
+  font-size: 13px;
+  font-weight: 500;
+  min-height: 30px;
+  transition: background-color var(--kobo-duration-micro) var(--kobo-ease-out),
+              color var(--kobo-duration-micro) var(--kobo-ease-out);
+
+  &:hover {
+    background-color: var(--kobo-hover);
+    color: var(--kobo-text);
+  }
+}
+
+.settings-nav__item--active {
+  background-color: var(--kobo-hover);
+  color: var(--kobo-text);
+  position: relative;
+
+  &::before {
+    content: '';
+    position: absolute;
+    left: -8px;
+    top: 6px;
+    bottom: 6px;
+    width: 2px;
+    background-color: var(--kobo-accent);
+    border-radius: 1px;
+  }
+}
+
+.settings-nav__icon {
+  min-width: 24px;
+  color: inherit;
+}
+
+.settings-nav__label {
+  padding-left: 4px;
+}
+</style>

--- a/src/client/src/components/WorkspaceToolbarSelectors.vue
+++ b/src/client/src/components/WorkspaceToolbarSelectors.vue
@@ -1,0 +1,352 @@
+<template>
+  <!-- Desktop: selectors laid out inline in the header row. -->
+  <template v-if="layout === 'inline'">
+    <AutoLoopChip />
+    <q-select
+      v-if="sessions.length > 0"
+      v-model="selectedSessionId"
+      :options="sessionOptions"
+      emit-value
+      map-options
+      dense
+      dark
+      borderless
+      options-dense
+      :loading="creatingSession"
+      :disable="creatingSession"
+      class="q-ml-sm"
+      style="min-width: 160px; max-width: 220px; font-size: 11px;"
+    >
+      <template #option="scope">
+        <q-separator v-if="!scope.opt.isSession" spaced />
+        <q-item v-bind="scope.itemProps" clickable dense class="row items-center no-wrap">
+          <q-item-section>
+            <q-item-label :class="!scope.opt.isSession ? 'text-grey-5' : ''">
+              {{ scope.opt.label }}
+            </q-item-label>
+            <q-item-label v-if="scope.opt.caption" caption>{{ scope.opt.caption }}</q-item-label>
+          </q-item-section>
+          <q-item-section v-if="scope.opt.isSession" side>
+            <q-btn
+              icon="more_vert"
+              flat
+              dense
+              round
+              size="xs"
+              color="grey-6"
+              @click.stop
+            >
+              <q-menu auto-close>
+                <q-list dense>
+                  <q-item clickable @click="emit('rename', scope.opt.value, scope.opt.label)">
+                    <q-item-section avatar><q-icon name="edit" size="16px" /></q-item-section>
+                    <q-item-section>{{ $t('workspacePage.renameSession') }}</q-item-section>
+                  </q-item>
+                  <q-item clickable @click="emit('copySessionId', scope.opt.value)">
+                    <q-item-section avatar><q-icon name="content_copy" size="16px" /></q-item-section>
+                    <q-item-section>{{ $t('workspacePage.copySessionId') }}</q-item-section>
+                  </q-item>
+                  <q-item
+                    v-if="canDeleteSession(scope.opt.value)"
+                    clickable
+                    class="text-negative"
+                    @click="emit('deleteSession', scope.opt.value)"
+                  >
+                    <q-item-section avatar><q-icon name="delete_outline" size="16px" /></q-item-section>
+                    <q-item-section>{{ $t('workspacePage.deleteSession') }}</q-item-section>
+                  </q-item>
+                </q-list>
+              </q-menu>
+            </q-btn>
+          </q-item-section>
+        </q-item>
+      </template>
+    </q-select>
+    <q-badge
+      v-if="activeSessionModelLabel !== null"
+      color="indigo-8"
+      text-color="indigo-1"
+      class="q-ml-sm"
+      style="font-size: 10px;"
+    >
+      <q-icon name="auto_awesome" size="11px" class="q-mr-xs" />
+      {{ $t('workspacePage.activeSessionModel', { model: activeSessionModelLabel }) }}
+      <q-tooltip>{{ $t('workspacePage.activeSessionModelTooltip') }}</q-tooltip>
+    </q-badge>
+    <q-space />
+    <q-select
+      v-model="permissionMode"
+      :options="permissionModeOptions"
+      emit-value
+      map-options
+      dense
+      dark
+      borderless
+      options-dense
+      class="q-mr-xs"
+      style="min-width: 80px; max-width: 140px; font-size: 11px;"
+    >
+      <template #selected>
+        <span class="row items-center no-wrap text-caption text-grey-5">
+          <q-icon :name="permissionModeIcon" size="12px" color="amber-6" class="q-mr-xs" />
+          {{ permissionModeLabel }}
+          <q-icon v-if="pendingSpawnChanges.has('agentPermissionMode')" name="schedule" size="11px" color="orange-6" class="q-ml-xs">
+            <q-tooltip>{{ $t('workspacePage.pendingNextRun') }}</q-tooltip>
+          </q-icon>
+        </span>
+      </template>
+    </q-select>
+    <q-select
+      v-model="model"
+      :options="modelOptions"
+      emit-value
+      map-options
+      dense
+      dark
+      borderless
+      options-dense
+      class="q-mr-sm model-select"
+      style="min-width: 100px; max-width: 160px; font-size: 11px;"
+    >
+      <template #selected>
+        <span class="row items-center no-wrap text-caption text-grey-5">
+          <q-icon name="auto_awesome" size="12px" color="indigo-4" class="q-mr-xs" />
+          {{ modelLabel }}
+          <q-icon v-if="pendingSpawnChanges.has('model')" name="schedule" size="11px" color="orange-6" class="q-ml-xs">
+            <q-tooltip>{{ $t('workspacePage.pendingNextRun') }}</q-tooltip>
+          </q-icon>
+        </span>
+      </template>
+    </q-select>
+    <q-select
+      v-model="reasoningEffort"
+      :options="reasoningOptions"
+      emit-value
+      map-options
+      dense
+      dark
+      borderless
+      options-dense
+      class="q-mr-sm"
+      style="min-width: 90px; max-width: 140px; font-size: 11px;"
+    >
+      <template #selected>
+        <span class="row items-center no-wrap text-caption text-grey-5">
+          <q-icon name="psychology" size="12px" color="amber-6" class="q-mr-xs" />
+          {{ reasoningLabel }}
+          <q-icon v-if="pendingSpawnChanges.has('reasoningEffort')" name="schedule" size="11px" color="orange-6" class="q-ml-xs">
+            <q-tooltip>{{ $t('workspacePage.pendingNextRun') }}</q-tooltip>
+          </q-icon>
+        </span>
+      </template>
+    </q-select>
+  </template>
+
+  <!-- Mobile: same selectors, stacked as items inside the overflow q-menu. -->
+  <template v-else>
+    <q-item>
+      <q-item-section @click.stop>
+        <AutoLoopChip />
+      </q-item-section>
+    </q-item>
+    <q-item v-if="sessions.length > 0">
+      <q-item-section @click.stop>
+        <q-select
+          v-model="selectedSessionId"
+          :options="sessionOptions"
+          emit-value
+          map-options
+          dense
+          dark
+          borderless
+          options-dense
+          :loading="creatingSession"
+          :disable="creatingSession"
+          style="min-width: 160px; font-size: 11px;"
+        >
+          <template #option="scope">
+            <q-separator v-if="!scope.opt.isSession" spaced />
+            <q-item v-bind="scope.itemProps" clickable dense class="row items-center no-wrap">
+              <q-item-section>
+                <q-item-label :class="!scope.opt.isSession ? 'text-grey-5' : ''">
+                  {{ scope.opt.label }}
+                </q-item-label>
+                <q-item-label v-if="scope.opt.caption" caption>{{ scope.opt.caption }}</q-item-label>
+              </q-item-section>
+              <q-item-section v-if="scope.opt.isSession" side>
+                <q-btn
+                  icon="more_vert"
+                  flat
+                  dense
+                  round
+                  size="xs"
+                  color="grey-6"
+                  @click.stop
+                >
+                  <q-menu auto-close>
+                    <q-list dense>
+                      <q-item clickable @click="emit('rename', scope.opt.value, scope.opt.label)">
+                        <q-item-section avatar><q-icon name="edit" size="16px" /></q-item-section>
+                        <q-item-section>{{ $t('workspacePage.renameSession') }}</q-item-section>
+                      </q-item>
+                      <q-item clickable @click="emit('copySessionId', scope.opt.value)">
+                        <q-item-section avatar><q-icon name="content_copy" size="16px" /></q-item-section>
+                        <q-item-section>{{ $t('workspacePage.copySessionId') }}</q-item-section>
+                      </q-item>
+                      <q-item
+                        v-if="canDeleteSession(scope.opt.value)"
+                        clickable
+                        class="text-negative"
+                        @click="emit('deleteSession', scope.opt.value)"
+                      >
+                        <q-item-section avatar><q-icon name="delete_outline" size="16px" /></q-item-section>
+                        <q-item-section>{{ $t('workspacePage.deleteSession') }}</q-item-section>
+                      </q-item>
+                    </q-list>
+                  </q-menu>
+                </q-btn>
+              </q-item-section>
+            </q-item>
+          </template>
+        </q-select>
+      </q-item-section>
+    </q-item>
+    <q-item>
+      <q-item-section @click.stop>
+        <q-select
+          v-model="permissionMode"
+          :options="permissionModeOptions"
+          emit-value
+          map-options
+          dense
+          dark
+          borderless
+          options-dense
+          style="min-width: 160px; font-size: 11px;"
+        >
+          <template #selected>
+            <span class="row items-center no-wrap text-caption text-grey-5">
+              <q-icon :name="permissionModeIcon" size="12px" color="amber-6" class="q-mr-xs" />
+              {{ permissionModeLabel }}
+              <q-icon v-if="pendingSpawnChanges.has('agentPermissionMode')" name="schedule" size="11px" color="orange-6" class="q-ml-xs">
+                <q-tooltip>{{ $t('workspacePage.pendingNextRun') }}</q-tooltip>
+              </q-icon>
+            </span>
+          </template>
+        </q-select>
+      </q-item-section>
+    </q-item>
+    <q-item>
+      <q-item-section @click.stop>
+        <q-select
+          v-model="model"
+          :options="modelOptions"
+          emit-value
+          map-options
+          dense
+          dark
+          borderless
+          options-dense
+          class="model-select"
+          style="min-width: 160px; font-size: 11px;"
+        >
+          <template #selected>
+            <span class="row items-center no-wrap text-caption text-grey-5">
+              <q-icon name="auto_awesome" size="12px" color="indigo-4" class="q-mr-xs" />
+              {{ modelLabel }}
+              <q-icon v-if="pendingSpawnChanges.has('model')" name="schedule" size="11px" color="orange-6" class="q-ml-xs">
+                <q-tooltip>{{ $t('workspacePage.pendingNextRun') }}</q-tooltip>
+              </q-icon>
+            </span>
+          </template>
+        </q-select>
+      </q-item-section>
+    </q-item>
+    <q-item>
+      <q-item-section @click.stop>
+        <q-select
+          v-model="reasoningEffort"
+          :options="reasoningOptions"
+          emit-value
+          map-options
+          dense
+          dark
+          borderless
+          options-dense
+          style="min-width: 160px; font-size: 11px;"
+        >
+          <template #selected>
+            <span class="row items-center no-wrap text-caption text-grey-5">
+              <q-icon name="psychology" size="12px" color="amber-6" class="q-mr-xs" />
+              {{ reasoningLabel }}
+              <q-icon v-if="pendingSpawnChanges.has('reasoningEffort')" name="schedule" size="11px" color="orange-6" class="q-ml-xs">
+                <q-tooltip>{{ $t('workspacePage.pendingNextRun') }}</q-tooltip>
+              </q-icon>
+            </span>
+          </template>
+        </q-select>
+      </q-item-section>
+    </q-item>
+  </template>
+</template>
+
+<script setup lang="ts">
+import AutoLoopChip from 'src/components/AutoLoopChip.vue'
+import type { AgentSession } from 'src/stores/workspace'
+import { computed } from 'vue'
+
+type AgentPermissionModeValue = 'plan' | 'bypass' | 'strict' | 'interactive'
+type SpawnField = 'model' | 'reasoningEffort' | 'agentPermissionMode'
+
+interface SelectOption {
+  label: string
+  value: string
+  disable?: boolean
+}
+
+interface SessionOption {
+  label: string
+  value: string
+  caption: string
+  isSession: boolean
+}
+
+const props = defineProps<{
+  layout: 'inline' | 'menu'
+  sessions: AgentSession[]
+  sessionOptions: SessionOption[]
+  permissionModeOptions: SelectOption[]
+  modelOptions: SelectOption[]
+  reasoningOptions: SelectOption[]
+  pendingSpawnChanges: Set<SpawnField>
+  creatingSession: boolean
+  canDeleteSession: (sessionId: string) => boolean
+  activeSessionModelLabel: string | null
+}>()
+
+const emit = defineEmits<{
+  rename: [sessionId: string, label: string]
+  copySessionId: [sessionId: string]
+  deleteSession: [sessionId: string]
+}>()
+
+const selectedSessionId = defineModel<string | null>('selectedSessionId')
+const permissionMode = defineModel<AgentPermissionModeValue>('permissionMode', { required: true })
+const model = defineModel<string>('model', { required: true })
+const reasoningEffort = defineModel<string>('reasoningEffort', { required: true })
+
+const permissionModeIcon = computed(() => {
+  const val = permissionMode.value
+  return val === 'plan' ? 'visibility' : val === 'strict' ? 'lock' : val === 'interactive' ? 'security' : 'flash_on'
+})
+
+const permissionModeLabel = computed(
+  () => props.permissionModeOptions.find((m) => m.value === permissionMode.value)?.label ?? permissionMode.value,
+)
+
+const modelLabel = computed(() => props.modelOptions.find((m) => m.value === model.value)?.label ?? model.value)
+
+const reasoningLabel = computed(
+  () => props.reasoningOptions.find((r) => r.value === reasoningEffort.value)?.label ?? reasoningEffort.value,
+)
+</script>

--- a/src/client/src/composables/use-is-mobile.ts
+++ b/src/client/src/composables/use-is-mobile.ts
@@ -1,0 +1,12 @@
+import { useQuasar } from 'quasar'
+import { computed } from 'vue'
+
+/**
+ * Single source of truth for "phone portrait" (< 600px, Quasar `lt.sm`).
+ * Reused by SettingsPage, WorkspacePage and ChatInput to branch layout.
+ */
+export function useIsMobile() {
+  const $q = useQuasar()
+  const isMobile = computed(() => $q.screen.lt.sm)
+  return { isMobile }
+}

--- a/src/client/src/composables/use-is-mobile.ts
+++ b/src/client/src/composables/use-is-mobile.ts
@@ -2,11 +2,14 @@ import { useQuasar } from 'quasar'
 import { computed } from 'vue'
 
 /**
- * Single source of truth for "phone portrait" (< 600px, Quasar `lt.sm`).
- * Reused by SettingsPage, WorkspacePage and ChatInput to branch layout.
+ * Responsive breakpoints for the client.
+ * - isMobile: phone portrait (< 600px, Quasar `lt.sm`) — layout compactness.
+ * - isDrawerCollapsed: the global left drawer is an overlay (< 1024px, `lt.md`),
+ *   matching MainLayout's DRAWER_BREAKPOINT. Use for "re-open the drawer" affordances.
  */
 export function useIsMobile() {
   const $q = useQuasar()
   const isMobile = computed(() => $q.screen.lt.sm)
-  return { isMobile }
+  const isDrawerCollapsed = computed(() => $q.screen.lt.md)
+  return { isMobile, isDrawerCollapsed }
 }

--- a/src/client/src/i18n/de.ts
+++ b/src/client/src/i18n/de.ts
@@ -772,6 +772,7 @@ export default {
   'settings.nav.notifications': 'Benachrichtigungen',
   'settings.nav.worktrees': 'Worktrees',
   'settings.nav.export': 'Export',
+  'settings.openNav': 'Navigation öffnen',
   'settings.saveError': 'Fehler beim Speichern der Einstellungen.',
   'settings.projectSaved': 'Projekt gespeichert.',
   'settings.projectSaveError': 'Fehler beim Speichern des Projekts.',

--- a/src/client/src/i18n/de.ts
+++ b/src/client/src/i18n/de.ts
@@ -176,6 +176,7 @@ export default {
   'workspacePage.activeSessionModelTooltip': 'Modell, das von der ausgewählten Sitzung tatsächlich verwendet wird',
   'workspacePage.switchEngine': 'Engine wechseln',
   'workspacePage.switchEngineHint': 'Diesen Workspace mit einer anderen Agent-Engine fortsetzen',
+  'workspacePage.moreActions': 'Weitere Aktionen',
   'workspacePage.switchEngineTitle': 'Agent-Engine wechseln',
   'workspacePage.switchEngineWarning':
     'Der aktuelle Agent wird gestoppt und eine neue Sitzung startet im selben Worktree.',

--- a/src/client/src/i18n/en.ts
+++ b/src/client/src/i18n/en.ts
@@ -763,6 +763,7 @@ export default {
   'settings.nav.notifications': 'Notifications',
   'settings.nav.worktrees': 'Worktrees',
   'settings.nav.export': 'Export',
+  'settings.openNav': 'Open navigation',
   'settings.saveError': 'Error saving settings.',
   'settings.projectSaved': 'Project saved.',
   'settings.projectSaveError': 'Error saving project.',

--- a/src/client/src/i18n/en.ts
+++ b/src/client/src/i18n/en.ts
@@ -174,6 +174,7 @@ export default {
   'workspacePage.activeSessionModelTooltip': 'Model currently used by the selected session',
   'workspacePage.switchEngine': 'Switch engine',
   'workspacePage.switchEngineHint': 'Continue this workspace with another agent engine',
+  'workspacePage.moreActions': 'More actions',
   'workspacePage.switchEngineTitle': 'Switch agent engine',
   'workspacePage.switchEngineWarning':
     'The current agent will be stopped and a fresh session will start in the same worktree.',

--- a/src/client/src/i18n/es.ts
+++ b/src/client/src/i18n/es.ts
@@ -177,6 +177,7 @@ export default {
   'workspacePage.activeSessionModelTooltip': 'Modelo utilizado actualmente por la sesión seleccionada',
   'workspacePage.switchEngine': 'Cambiar motor',
   'workspacePage.switchEngineHint': 'Continuar este workspace con otro motor de agente',
+  'workspacePage.moreActions': 'Más acciones',
   'workspacePage.switchEngineTitle': 'Cambiar motor de agente',
   'workspacePage.switchEngineWarning':
     'El agente actual se detendrá y se iniciará una sesión nueva en el mismo worktree.',

--- a/src/client/src/i18n/es.ts
+++ b/src/client/src/i18n/es.ts
@@ -772,6 +772,7 @@ export default {
   'settings.nav.notifications': 'Notificaciones',
   'settings.nav.worktrees': 'Worktrees',
   'settings.nav.export': 'Exportar',
+  'settings.openNav': 'Abrir la navegación',
   'settings.saveError': 'Error al guardar los ajustes.',
   'settings.projectSaved': 'Proyecto guardado.',
   'settings.projectSaveError': 'Error al guardar el proyecto.',

--- a/src/client/src/i18n/fr.ts
+++ b/src/client/src/i18n/fr.ts
@@ -179,6 +179,7 @@ export default {
   'workspacePage.activeSessionModelTooltip': 'Modèle effectivement utilisé par la session sélectionnée',
   'workspacePage.switchEngine': 'Changer d’engine',
   'workspacePage.switchEngineHint': 'Continuer ce workspace avec un autre engine agent',
+  'workspacePage.moreActions': "Plus d'actions",
   'workspacePage.switchEngineTitle': 'Changer d’engine agent',
   'workspacePage.switchEngineWarning':
     'L’agent actuel sera arrêté et une nouvelle session démarrera dans le même worktree.',

--- a/src/client/src/i18n/fr.ts
+++ b/src/client/src/i18n/fr.ts
@@ -773,6 +773,7 @@ export default {
   'settings.nav.notifications': 'Notifications',
   'settings.nav.worktrees': 'Worktrees',
   'settings.nav.export': 'Export',
+  'settings.openNav': 'Ouvrir la navigation',
   'settings.saveError': "Erreur lors de l'enregistrement des paramètres.",
   'settings.projectSaved': 'Projet enregistré.',
   'settings.projectSaveError': "Erreur lors de l'enregistrement du projet.",

--- a/src/client/src/i18n/it.ts
+++ b/src/client/src/i18n/it.ts
@@ -179,6 +179,7 @@ export default {
   'workspacePage.activeSessionModelTooltip': 'Modello effettivamente usato dalla sessione selezionata',
   'workspacePage.switchEngine': 'Cambia motore',
   'workspacePage.switchEngineHint': 'Continua questo workspace con un altro motore agente',
+  'workspacePage.moreActions': 'Altre azioni',
   'workspacePage.switchEngineTitle': 'Cambia motore agente',
   'workspacePage.switchEngineWarning':
     "L'agente attuale verrà fermato e una nuova sessione inizierà nello stesso worktree.",

--- a/src/client/src/i18n/it.ts
+++ b/src/client/src/i18n/it.ts
@@ -772,6 +772,7 @@ export default {
   'settings.nav.notifications': 'Notifiche',
   'settings.nav.worktrees': 'Worktrees',
   'settings.nav.export': 'Esporta',
+  'settings.openNav': 'Apri la navigazione',
   'settings.saveError': 'Errore durante il salvataggio delle impostazioni.',
   'settings.projectSaved': 'Progetto salvato.',
   'settings.projectSaveError': 'Errore durante il salvataggio del progetto.',

--- a/src/client/src/pages/ChangelogPage.vue
+++ b/src/client/src/pages/ChangelogPage.vue
@@ -1,6 +1,15 @@
 <template>
   <q-page class="q-pa-md" style="max-width: 900px; margin: 0 auto;">
     <div class="row items-center q-mb-md">
+      <q-btn
+        v-if="isDrawerCollapsed"
+        flat dense round size="sm"
+        class="q-mr-xs"
+        :icon="layout.leftDrawerOpen ? 'menu_open' : 'menu'"
+        @click="layout.toggleLeft()"
+      >
+        <q-tooltip>{{ $t('layout.toggleWorkspaces') }}</q-tooltip>
+      </q-btn>
       <q-btn flat dense round icon="arrow_back" @click="router.back()" />
       <div class="text-h6 q-ml-sm">{{ $t('changelog.title') }}</div>
       <q-space />
@@ -52,6 +61,8 @@
 import { renderChatMarkdown } from 'src/utils/render-chat-markdown'
 import { onMounted, ref } from 'vue'
 import { useRouter } from 'vue-router'
+import { useIsMobile } from 'src/composables/use-is-mobile'
+import { useLayoutStore } from 'src/stores/layout'
 
 interface ChangelogEntry {
   version: string
@@ -59,6 +70,8 @@ interface ChangelogEntry {
 }
 
 const router = useRouter()
+const layout = useLayoutStore()
+const { isDrawerCollapsed } = useIsMobile()
 const versions = ref<ChangelogEntry[]>([])
 const currentVersion = ref<string>('')
 const loading = ref<boolean>(false)

--- a/src/client/src/pages/ChangelogPage.vue
+++ b/src/client/src/pages/ChangelogPage.vue
@@ -1,15 +1,7 @@
 <template>
   <q-page class="q-pa-md" style="max-width: 900px; margin: 0 auto;">
     <div class="row items-center q-mb-md">
-      <q-btn
-        v-if="isDrawerCollapsed"
-        flat dense round size="sm"
-        class="q-mr-xs"
-        :icon="layout.leftDrawerOpen ? 'menu_open' : 'menu'"
-        @click="layout.toggleLeft()"
-      >
-        <q-tooltip>{{ $t('layout.toggleWorkspaces') }}</q-tooltip>
-      </q-btn>
+      <DrawerToggleButton class="q-mr-xs" />
       <q-btn flat dense round icon="arrow_back" @click="router.back()" />
       <div class="text-h6 q-ml-sm">{{ $t('changelog.title') }}</div>
       <q-space />
@@ -58,8 +50,7 @@
 </template>
 
 <script setup lang="ts">
-import { useIsMobile } from 'src/composables/use-is-mobile'
-import { useLayoutStore } from 'src/stores/layout'
+import DrawerToggleButton from 'src/components/DrawerToggleButton.vue'
 import { renderChatMarkdown } from 'src/utils/render-chat-markdown'
 import { onMounted, ref } from 'vue'
 import { useRouter } from 'vue-router'
@@ -70,8 +61,6 @@ interface ChangelogEntry {
 }
 
 const router = useRouter()
-const layout = useLayoutStore()
-const { isDrawerCollapsed } = useIsMobile()
 const versions = ref<ChangelogEntry[]>([])
 const currentVersion = ref<string>('')
 const loading = ref<boolean>(false)

--- a/src/client/src/pages/ChangelogPage.vue
+++ b/src/client/src/pages/ChangelogPage.vue
@@ -58,11 +58,11 @@
 </template>
 
 <script setup lang="ts">
+import { useIsMobile } from 'src/composables/use-is-mobile'
+import { useLayoutStore } from 'src/stores/layout'
 import { renderChatMarkdown } from 'src/utils/render-chat-markdown'
 import { onMounted, ref } from 'vue'
 import { useRouter } from 'vue-router'
-import { useIsMobile } from 'src/composables/use-is-mobile'
-import { useLayoutStore } from 'src/stores/layout'
 
 interface ChangelogEntry {
   version: string

--- a/src/client/src/pages/CreatePage.vue
+++ b/src/client/src/pages/CreatePage.vue
@@ -1,17 +1,6 @@
 <template>
   <q-page class="create-page">
-    <q-btn
-      v-if="isDrawerCollapsed"
-      flat
-      dense
-      round
-      size="sm"
-      class="create-page__drawer-toggle"
-      :icon="layout.leftDrawerOpen ? 'menu_open' : 'menu'"
-      @click="layout.toggleLeft()"
-    >
-      <q-tooltip>{{ $t('layout.toggleWorkspaces') }}</q-tooltip>
-    </q-btn>
+    <DrawerToggleButton class="create-page__drawer-toggle" />
     <div class="create-inner q-mx-auto">
       <header class="q-mb-lg">
         <div class="create-title text-weight-bold text-grey-2">{{ $t('createPage.title') }}</div>
@@ -716,13 +705,12 @@
 <script setup lang="ts">
 import type { QInput } from 'quasar'
 import { useQuasar } from 'quasar'
+import DrawerToggleButton from 'src/components/DrawerToggleButton.vue'
 import SlashSuggestionsPopup from 'src/components/SlashSuggestionsPopup.vue'
-import { useIsMobile } from 'src/composables/use-is-mobile'
 import { type SlashDropdownItem, useSlashAutocomplete } from 'src/composables/use-slash-autocomplete'
 import { EFFORT_OPTION_DEFS_BY_ENGINE } from 'src/constants/efforts'
 import { MODEL_OPTION_DEFS, MODEL_OPTION_DEFS_BY_ENGINE } from 'src/constants/models'
 import { PERMISSION_MODES_BY_ENGINE } from 'src/constants/permissionModes'
-import { useLayoutStore } from 'src/stores/layout'
 import { useSettingsStore } from 'src/stores/settings'
 import { useTemplatesStore } from 'src/stores/templates'
 import { useWebSocketStore } from 'src/stores/websocket'
@@ -762,8 +750,6 @@ const router = useRouter()
 const $q = useQuasar()
 const store = useWorkspaceStore()
 const settingsStore = useSettingsStore()
-const layout = useLayoutStore()
-const { isDrawerCollapsed } = useIsMobile()
 const { t } = useI18n()
 
 const pathFilterOptions = ref<string[]>([])

--- a/src/client/src/pages/CreatePage.vue
+++ b/src/client/src/pages/CreatePage.vue
@@ -1,5 +1,17 @@
 <template>
   <q-page class="create-page">
+    <q-btn
+      v-if="isDrawerCollapsed"
+      flat
+      dense
+      round
+      size="sm"
+      class="create-page__drawer-toggle"
+      :icon="layout.leftDrawerOpen ? 'menu_open' : 'menu'"
+      @click="layout.toggleLeft()"
+    >
+      <q-tooltip>{{ $t('layout.toggleWorkspaces') }}</q-tooltip>
+    </q-btn>
     <div class="create-inner q-mx-auto">
       <header class="q-mb-lg">
         <div class="create-title text-weight-bold text-grey-2">{{ $t('createPage.title') }}</div>
@@ -705,10 +717,12 @@
 import type { QInput } from 'quasar'
 import { useQuasar } from 'quasar'
 import SlashSuggestionsPopup from 'src/components/SlashSuggestionsPopup.vue'
+import { useIsMobile } from 'src/composables/use-is-mobile'
 import { type SlashDropdownItem, useSlashAutocomplete } from 'src/composables/use-slash-autocomplete'
 import { EFFORT_OPTION_DEFS_BY_ENGINE } from 'src/constants/efforts'
 import { MODEL_OPTION_DEFS, MODEL_OPTION_DEFS_BY_ENGINE } from 'src/constants/models'
 import { PERMISSION_MODES_BY_ENGINE } from 'src/constants/permissionModes'
+import { useLayoutStore } from 'src/stores/layout'
 import { useSettingsStore } from 'src/stores/settings'
 import { useTemplatesStore } from 'src/stores/templates'
 import { useWebSocketStore } from 'src/stores/websocket'
@@ -748,6 +762,8 @@ const router = useRouter()
 const $q = useQuasar()
 const store = useWorkspaceStore()
 const settingsStore = useSettingsStore()
+const layout = useLayoutStore()
+const { isDrawerCollapsed } = useIsMobile()
 const { t } = useI18n()
 
 const pathFilterOptions = ref<string[]>([])
@@ -1668,9 +1684,17 @@ async function handleCreate() {
 
 <style lang="scss" scoped>
 .create-page {
+  position: relative;
   min-height: 100%;
   padding: 48px 24px 80px;
   background: #1a1a2e;
+}
+
+.create-page__drawer-toggle {
+  position: absolute;
+  top: var(--kobo-space-md);
+  left: var(--kobo-space-md);
+  z-index: 1;
 }
 
 .create-inner {

--- a/src/client/src/pages/HealthPage.vue
+++ b/src/client/src/pages/HealthPage.vue
@@ -337,10 +337,10 @@
 
 <script setup lang="ts">
 import { useQuasar } from 'quasar'
-import { computed, onMounted, ref } from 'vue'
-import { useRouter } from 'vue-router'
 import { useIsMobile } from 'src/composables/use-is-mobile'
 import { useLayoutStore } from 'src/stores/layout'
+import { computed, onMounted, ref } from 'vue'
+import { useRouter } from 'vue-router'
 
 const $q = useQuasar()
 const router = useRouter()

--- a/src/client/src/pages/HealthPage.vue
+++ b/src/client/src/pages/HealthPage.vue
@@ -1,6 +1,15 @@
 <template>
   <q-page class="q-pa-md" style="max-width: 900px; margin: 0 auto;">
     <div class="row items-center q-mb-md">
+      <q-btn
+        v-if="isDrawerCollapsed"
+        flat dense round size="sm"
+        class="q-mr-xs"
+        :icon="layout.leftDrawerOpen ? 'menu_open' : 'menu'"
+        @click="layout.toggleLeft()"
+      >
+        <q-tooltip>{{ $t('layout.toggleWorkspaces') }}</q-tooltip>
+      </q-btn>
       <q-btn flat dense round icon="arrow_back" @click="router.back()" />
       <div class="text-h6 q-ml-sm">{{ $t('health.title') }}</div>
       <q-space />
@@ -15,21 +24,21 @@
         <q-card-section>
           <div class="text-subtitle2 q-mb-sm">{{ $t('health.envTitle') }}</div>
           <div class="row q-col-gutter-md">
-            <div class="col-auto">
+            <div class="col-12 col-sm-auto">
               <div class="text-caption text-grey-6">{{ $t('health.version') }}</div>
               <div class="text-body2" style="font-family: var(--kobo-font-mono, monospace);">
                 {{ report.version }}
               </div>
             </div>
-            <div class="col-auto">
+            <div class="col-12 col-sm-auto">
               <div class="text-caption text-grey-6">{{ $t('health.settingsSchemaVersion') }}</div>
               <div class="text-body2" style="font-family: var(--kobo-font-mono, monospace);">
                 {{ report.settings.schemaVersion }}
               </div>
             </div>
-            <div class="col">
+            <div class="col-12 col-sm">
               <div class="text-caption text-grey-6">{{ $t('health.koboHome') }}</div>
-              <div class="text-body2">{{ report.koboHome }}</div>
+              <div class="text-body2 health-path">{{ report.koboHome }}</div>
             </div>
           </div>
         </q-card-section>
@@ -44,15 +53,15 @@
             <q-icon :name="statusIcon(dbSchemaOk)" :color="statusColor(dbSchemaOk)" />
           </div>
           <div class="row q-col-gutter-md q-mt-xs">
-            <div class="col">
+            <div class="col-12 col-sm">
               <div class="text-caption text-grey-6">{{ $t('health.dbPath') }}</div>
-              <div class="text-body2">{{ report.db.path }}</div>
+              <div class="text-body2 health-path">{{ report.db.path }}</div>
             </div>
-            <div class="col-auto">
+            <div class="col-12 col-sm-auto">
               <div class="text-caption text-grey-6">{{ $t('health.dbSize') }}</div>
               <div class="text-body2">{{ dbSizeHuman }}</div>
             </div>
-            <div class="col-auto">
+            <div class="col-12 col-sm-auto">
               <div class="text-caption text-grey-6">{{ $t('health.schemaVersion') }}</div>
               <div class="text-body2">{{ report.db.schemaVersion }} / {{ report.db.currentSchemaVersion }}</div>
             </div>
@@ -121,7 +130,7 @@
               <q-item v-for="w in report.workspaces.worktreesMissing" :key="w.workspaceId">
                 <q-item-section>
                   <div class="text-body2">{{ w.name }}</div>
-                  <div class="text-caption text-grey-6">{{ w.path }}</div>
+                  <div class="text-caption text-grey-6 health-path">{{ w.path }}</div>
                 </q-item-section>
               </q-item>
             </q-list>
@@ -330,9 +339,13 @@
 import { useQuasar } from 'quasar'
 import { computed, onMounted, ref } from 'vue'
 import { useRouter } from 'vue-router'
+import { useIsMobile } from 'src/composables/use-is-mobile'
+import { useLayoutStore } from 'src/stores/layout'
 
 const $q = useQuasar()
 const router = useRouter()
+const layout = useLayoutStore()
+const { isDrawerCollapsed } = useIsMobile()
 
 interface WorktreeCheck {
   workspaceId: string
@@ -458,3 +471,9 @@ function goToWorkspace(id: string): void {
   router.push({ name: 'workspace', params: { id } }).catch(() => {})
 }
 </script>
+
+<style scoped>
+.health-path {
+  word-break: break-all;
+}
+</style>

--- a/src/client/src/pages/HealthPage.vue
+++ b/src/client/src/pages/HealthPage.vue
@@ -1,15 +1,7 @@
 <template>
   <q-page class="q-pa-md" style="max-width: 900px; margin: 0 auto;">
     <div class="row items-center q-mb-md">
-      <q-btn
-        v-if="isDrawerCollapsed"
-        flat dense round size="sm"
-        class="q-mr-xs"
-        :icon="layout.leftDrawerOpen ? 'menu_open' : 'menu'"
-        @click="layout.toggleLeft()"
-      >
-        <q-tooltip>{{ $t('layout.toggleWorkspaces') }}</q-tooltip>
-      </q-btn>
+      <DrawerToggleButton class="q-mr-xs" />
       <q-btn flat dense round icon="arrow_back" @click="router.back()" />
       <div class="text-h6 q-ml-sm">{{ $t('health.title') }}</div>
       <q-space />
@@ -337,15 +329,12 @@
 
 <script setup lang="ts">
 import { useQuasar } from 'quasar'
-import { useIsMobile } from 'src/composables/use-is-mobile'
-import { useLayoutStore } from 'src/stores/layout'
+import DrawerToggleButton from 'src/components/DrawerToggleButton.vue'
 import { computed, onMounted, ref } from 'vue'
 import { useRouter } from 'vue-router'
 
 const $q = useQuasar()
 const router = useRouter()
-const layout = useLayoutStore()
-const { isDrawerCollapsed } = useIsMobile()
 
 interface WorktreeCheck {
   workspaceId: string

--- a/src/client/src/pages/SearchPage.vue
+++ b/src/client/src/pages/SearchPage.vue
@@ -2,18 +2,7 @@
   <q-page class="q-pa-md search-page">
     <div class="search-header">
       <div class="row items-center">
-        <q-btn
-          v-if="isDrawerCollapsed"
-          flat
-          dense
-          round
-          size="sm"
-          class="q-mr-sm"
-          :icon="layout.leftDrawerOpen ? 'menu_open' : 'menu'"
-          @click="layout.toggleLeft()"
-        >
-          <q-tooltip>{{ $t('layout.toggleWorkspaces') }}</q-tooltip>
-        </q-btn>
+        <DrawerToggleButton class="q-mr-sm" />
         <h2 class="text-h5 q-mb-md">{{ $t('search.title') }}</h2>
       </div>
 
@@ -90,8 +79,7 @@
 </template>
 
 <script setup lang="ts">
-import { useIsMobile } from 'src/composables/use-is-mobile'
-import { useLayoutStore } from 'src/stores/layout'
+import DrawerToggleButton from 'src/components/DrawerToggleButton.vue'
 import { type SearchResult, useSearchStore } from 'src/stores/search'
 import { useTimeAgo } from 'src/utils/formatters'
 import { ref, watch } from 'vue'
@@ -102,8 +90,6 @@ const store = useSearchStore()
 const router = useRouter()
 const { t } = useI18n()
 const { timeAgo } = useTimeAgo()
-const layout = useLayoutStore()
-const { isDrawerCollapsed } = useIsMobile()
 
 const inputEl = ref<HTMLInputElement | null>(null)
 let debounceTimer: ReturnType<typeof setTimeout> | null = null

--- a/src/client/src/pages/SearchPage.vue
+++ b/src/client/src/pages/SearchPage.vue
@@ -1,7 +1,21 @@
 <template>
   <q-page class="q-pa-md search-page">
     <div class="search-header">
-      <h2 class="text-h5 q-mb-md">{{ $t('search.title') }}</h2>
+      <div class="row items-center">
+        <q-btn
+          v-if="isDrawerCollapsed"
+          flat
+          dense
+          round
+          size="sm"
+          class="q-mr-sm"
+          :icon="layout.leftDrawerOpen ? 'menu_open' : 'menu'"
+          @click="layout.toggleLeft()"
+        >
+          <q-tooltip>{{ $t('layout.toggleWorkspaces') }}</q-tooltip>
+        </q-btn>
+        <h2 class="text-h5 q-mb-md">{{ $t('search.title') }}</h2>
+      </div>
 
       <q-input
         ref="inputEl"
@@ -76,6 +90,8 @@
 </template>
 
 <script setup lang="ts">
+import { useIsMobile } from 'src/composables/use-is-mobile'
+import { useLayoutStore } from 'src/stores/layout'
 import { type SearchResult, useSearchStore } from 'src/stores/search'
 import { useTimeAgo } from 'src/utils/formatters'
 import { ref, watch } from 'vue'
@@ -86,6 +102,8 @@ const store = useSearchStore()
 const router = useRouter()
 const { t } = useI18n()
 const { timeAgo } = useTimeAgo()
+const layout = useLayoutStore()
+const { isDrawerCollapsed } = useIsMobile()
 
 const inputEl = ref<HTMLInputElement | null>(null)
 let debounceTimer: ReturnType<typeof setTimeout> | null = null

--- a/src/client/src/pages/SettingsPage.vue
+++ b/src/client/src/pages/SettingsPage.vue
@@ -16,6 +16,15 @@
         behavior="mobile"
         :width="240"
       >
+        <q-list>
+          <q-item clickable @click="openWorkspacesDrawer">
+            <q-item-section avatar>
+              <q-icon name="arrow_back" />
+            </q-item-section>
+            <q-item-section>{{ $t('workspaceList.title') }}</q-item-section>
+          </q-item>
+          <q-separator />
+        </q-list>
         <div class="settings-nav">
           <div class="settings-nav__title">{{ $t('settings.title') }}</div>
           <SettingsNavList :nav-items="navItems" :active-tab="activeTab" @select="selectTab" />
@@ -2483,6 +2492,7 @@ import { useIsMobile } from 'src/composables/use-is-mobile'
 import { useOnboarding } from 'src/composables/use-onboarding'
 import { CODEX_MODEL_OPTION_DEFS, MODEL_OPTION_DEFS } from 'src/constants/models'
 import { type AgentPermissionMode, PERMISSION_MODES_BY_ENGINE } from 'src/constants/permissionModes'
+import { useLayoutStore } from 'src/stores/layout'
 import type { ProjectSettings } from 'src/stores/settings'
 import { useSettingsStore } from 'src/stores/settings'
 import { type Template, useTemplatesStore } from 'src/stores/templates'
@@ -2519,6 +2529,7 @@ const templatesStore = useTemplatesStore()
 const { t, locale } = useI18n()
 const { startTour } = useOnboarding()
 const { isMobile } = useIsMobile()
+const layout = useLayoutStore()
 
 // Tab state
 const activeTab = ref('general')
@@ -2527,6 +2538,11 @@ const navDrawerOpen = ref(false)
 function selectTab(tab: string) {
   activeTab.value = tab
   if (isMobile.value) navDrawerOpen.value = false
+}
+
+function openWorkspacesDrawer() {
+  navDrawerOpen.value = false
+  layout.toggleLeft()
 }
 
 const navItems = computed(() => [

--- a/src/client/src/pages/SettingsPage.vue
+++ b/src/client/src/pages/SettingsPage.vue
@@ -34,6 +34,7 @@
       <!-- Content panel -->
       <main class="settings-content">
         <header class="settings-content__header">
+          <DrawerToggleButton exclude-mobile class="q-mr-sm" />
           <q-btn
             v-if="isMobile"
             flat
@@ -2484,6 +2485,7 @@ where ffmpeg</pre>
 <script setup lang="ts">
 import QRCode from 'qrcode'
 import { type QInput, useQuasar } from 'quasar'
+import DrawerToggleButton from 'src/components/DrawerToggleButton.vue'
 import FolderPickerDialog from 'src/components/FolderPickerDialog.vue'
 import PrNotificationSoundSettings from 'src/components/PrNotificationSoundSettings.vue'
 import SettingsNavList from 'src/components/SettingsNavList.vue'

--- a/src/client/src/pages/SettingsPage.vue
+++ b/src/client/src/pages/SettingsPage.vue
@@ -1,30 +1,42 @@
 <template>
   <q-page class="settings-page">
     <div class="settings-layout">
-      <!-- Sidebar nav -->
-      <aside class="settings-nav">
+      <!-- Sidebar nav (desktop: fixed aside) -->
+      <aside v-if="!isMobile" class="settings-nav">
         <div class="settings-nav__title">{{ $t('settings.title') }}</div>
-        <q-list dense class="settings-nav__list">
-          <q-item
-            v-for="item in navItems"
-            :key="item.value"
-            clickable
-            v-ripple="false"
-            :data-tour="`settings-nav-${item.value}`"
-            :class="['settings-nav__item', { 'settings-nav__item--active': activeTab === item.value }]"
-            @click="activeTab = item.value"
-          >
-            <q-item-section avatar class="settings-nav__icon">
-              <q-icon :name="item.icon" size="16px" />
-            </q-item-section>
-            <q-item-section class="settings-nav__label">{{ item.label }}</q-item-section>
-          </q-item>
-        </q-list>
+        <SettingsNavList :nav-items="navItems" :active-tab="activeTab" @select="selectTab" />
       </aside>
+
+      <!-- Sidebar nav (mobile: overlay drawer) -->
+      <q-drawer
+        v-else
+        v-model="navDrawerOpen"
+        side="left"
+        overlay
+        behavior="mobile"
+        :width="240"
+      >
+        <div class="settings-nav">
+          <div class="settings-nav__title">{{ $t('settings.title') }}</div>
+          <SettingsNavList :nav-items="navItems" :active-tab="activeTab" @select="selectTab" />
+        </div>
+      </q-drawer>
 
       <!-- Content panel -->
       <main class="settings-content">
         <header class="settings-content__header">
+          <q-btn
+            v-if="isMobile"
+            flat
+            dense
+            round
+            icon="menu"
+            :aria-label="$t('settings.openNav')"
+            class="settings-content__nav-toggle"
+            @click="navDrawerOpen = true"
+          >
+            <q-tooltip>{{ $t('settings.openNav') }}</q-tooltip>
+          </q-btn>
           <h2 class="settings-content__title">{{ activeNavLabel }}</h2>
         </header>
 
@@ -2465,7 +2477,9 @@ import QRCode from 'qrcode'
 import { type QInput, useQuasar } from 'quasar'
 import FolderPickerDialog from 'src/components/FolderPickerDialog.vue'
 import PrNotificationSoundSettings from 'src/components/PrNotificationSoundSettings.vue'
+import SettingsNavList from 'src/components/SettingsNavList.vue'
 import WhipShortcutRecorder from 'src/components/WhipShortcutRecorder.vue'
+import { useIsMobile } from 'src/composables/use-is-mobile'
 import { useOnboarding } from 'src/composables/use-onboarding'
 import { CODEX_MODEL_OPTION_DEFS, MODEL_OPTION_DEFS } from 'src/constants/models'
 import { type AgentPermissionMode, PERMISSION_MODES_BY_ENGINE } from 'src/constants/permissionModes'
@@ -2504,9 +2518,16 @@ const store = useSettingsStore()
 const templatesStore = useTemplatesStore()
 const { t, locale } = useI18n()
 const { startTour } = useOnboarding()
+const { isMobile } = useIsMobile()
 
 // Tab state
 const activeTab = ref('general')
+const navDrawerOpen = ref(false)
+
+function selectTab(tab: string) {
+  activeTab.value = tab
+  if (isMobile.value) navDrawerOpen.value = false
+}
 
 const navItems = computed(() => [
   { value: 'general', icon: 'tune', label: t('settings.nav.general') },
@@ -4194,52 +4215,6 @@ onUnmounted(() => {
   margin-bottom: 16px;
 }
 
-.settings-nav__list {
-  padding: 0;
-}
-
-.settings-nav__item {
-  border-radius: var(--kobo-radius-sm);
-  padding: 6px 12px;
-  color: var(--kobo-text-2);
-  font-size: 13px;
-  font-weight: 500;
-  min-height: 30px;
-  transition: background-color var(--kobo-duration-micro) var(--kobo-ease-out),
-              color var(--kobo-duration-micro) var(--kobo-ease-out);
-
-  &:hover {
-    background-color: var(--kobo-hover);
-    color: var(--kobo-text);
-  }
-}
-
-.settings-nav__item--active {
-  background-color: var(--kobo-hover);
-  color: var(--kobo-text);
-  position: relative;
-
-  &::before {
-    content: '';
-    position: absolute;
-    left: -8px;
-    top: 6px;
-    bottom: 6px;
-    width: 2px;
-    background-color: var(--kobo-accent);
-    border-radius: 1px;
-  }
-}
-
-.settings-nav__icon {
-  min-width: 24px;
-  color: inherit;
-}
-
-.settings-nav__label {
-  padding-left: 4px;
-}
-
 .settings-content {
   flex: 1;
   min-width: 0;
@@ -4257,6 +4232,13 @@ onUnmounted(() => {
   margin-top: -24px;
   padding-top: 24px;
   z-index: 2;
+  display: flex;
+  align-items: center;
+  gap: var(--kobo-space-sm);
+}
+
+.settings-content__nav-toggle {
+  color: var(--kobo-text-2);
 }
 
 .settings-content__title {

--- a/src/client/src/pages/WorkspacePage.vue
+++ b/src/client/src/pages/WorkspacePage.vue
@@ -29,140 +29,143 @@
           class="q-ml-sm"
           style="font-size: 10px;"
         />
-        <AutoLoopChip />
-        <q-select
-          v-if="sessions.length > 0"
-          v-model="selectedSessionId"
-          :options="sessionOptions"
-          emit-value
-          map-options
-          dense
-          dark
-          borderless
-          options-dense
-          :loading="creatingSession"
-          :disable="creatingSession"
-          class="q-ml-sm"
-          style="min-width: 160px; max-width: 220px; font-size: 11px;"
-        >
-          <template #option="scope">
-            <q-separator v-if="!scope.opt.isSession" spaced />
-            <q-item v-bind="scope.itemProps" clickable dense class="row items-center no-wrap">
-              <q-item-section>
-                <q-item-label :class="!scope.opt.isSession ? 'text-grey-5' : ''">
-                  {{ scope.opt.label }}
-                </q-item-label>
-                <q-item-label v-if="scope.opt.caption" caption>{{ scope.opt.caption }}</q-item-label>
-              </q-item-section>
-              <q-item-section v-if="scope.opt.isSession" side>
-                <q-btn
-                  icon="more_vert"
-                  flat
-                  dense
-                  round
-                  size="xs"
-                  color="grey-6"
-                  @click.stop
-                >
-                  <q-menu auto-close>
-                    <q-list dense>
-                      <q-item clickable @click="openRenameDialog(scope.opt.value, scope.opt.label)">
-                        <q-item-section avatar><q-icon name="edit" size="16px" /></q-item-section>
-                        <q-item-section>{{ $t('workspacePage.renameSession') }}</q-item-section>
-                      </q-item>
-                      <q-item clickable @click="copyEngineSessionId(scope.opt.value)">
-                        <q-item-section avatar><q-icon name="content_copy" size="16px" /></q-item-section>
-                        <q-item-section>{{ $t('workspacePage.copySessionId') }}</q-item-section>
-                      </q-item>
-                      <q-item v-if="sessionCanBeDeleted(scope.opt.value)" clickable class="text-negative" @click="confirmDeleteSession(scope.opt.value)">
-                        <q-item-section avatar><q-icon name="delete_outline" size="16px" /></q-item-section>
-                        <q-item-section>{{ $t('workspacePage.deleteSession') }}</q-item-section>
-                      </q-item>
-                    </q-list>
-                  </q-menu>
-                </q-btn>
-              </q-item-section>
-            </q-item>
-          </template>
-        </q-select>
-        <q-badge
-          v-if="selectedSessionModel !== null && selectedSessionModel !== selectedWs.model"
-          color="indigo-8"
-          text-color="indigo-1"
-          class="q-ml-sm"
-          style="font-size: 10px;"
-        >
-          <q-icon name="auto_awesome" size="11px" class="q-mr-xs" />
-          {{ $t('workspacePage.activeSessionModel', { model: activeSessionModelLabel }) }}
-          <q-tooltip>{{ $t('workspacePage.activeSessionModelTooltip') }}</q-tooltip>
-        </q-badge>
-        <q-space />
-        <q-select
-          v-model="currentPermissionMode"
-          :options="permissionModeOptions"
-          emit-value
-          map-options
-          dense
-          dark
-          borderless
-          options-dense
-          class="q-mr-xs"
-          style="min-width: 80px; max-width: 140px; font-size: 11px;"
-        >
-          <template #selected>
-            <span class="row items-center no-wrap text-caption text-grey-5">
-              <q-icon :name="currentPermissionMode === 'plan' ? 'visibility' : currentPermissionMode === 'strict' ? 'lock' : currentPermissionMode === 'interactive' ? 'security' : 'flash_on'" size="12px" color="amber-6" class="q-mr-xs" />
-              {{ permissionModeOptions.find(m => m.value === currentPermissionMode)?.label ?? currentPermissionMode }}
-              <q-icon v-if="pendingSpawnChanges.has('agentPermissionMode')" name="schedule" size="11px" color="orange-6" class="q-ml-xs">
-                <q-tooltip>{{ $t('workspacePage.pendingNextRun') }}</q-tooltip>
-              </q-icon>
-            </span>
-          </template>
-        </q-select>
-        <q-select
-          v-model="currentModel"
-          :options="modelOptions"
-          emit-value
-          map-options
-          dense
-          dark
-          borderless
-          options-dense
-          class="q-mr-sm model-select"
-          style="min-width: 100px; max-width: 160px; font-size: 11px;"
-        >
-          <template #selected>
-            <span class="row items-center no-wrap text-caption text-grey-5">
-              <q-icon name="auto_awesome" size="12px" color="indigo-4" class="q-mr-xs" />
-              {{ modelOptions.find(m => m.value === currentModel)?.label ?? currentModel }}
-              <q-icon v-if="pendingSpawnChanges.has('model')" name="schedule" size="11px" color="orange-6" class="q-ml-xs">
-                <q-tooltip>{{ $t('workspacePage.pendingNextRun') }}</q-tooltip>
-              </q-icon>
-            </span>
-          </template>
-        </q-select>
-        <q-select
-          v-model="currentReasoningEffort"
-          :options="reasoningOptions"
-          emit-value
-          map-options
-          dense
-          dark
-          borderless
-          options-dense
-          class="q-mr-sm"
-          style="min-width: 90px; max-width: 140px; font-size: 11px;"
-        >
-          <template #selected>
-            <span class="row items-center no-wrap text-caption text-grey-5">
-              <q-icon name="psychology" size="12px" color="amber-6" class="q-mr-xs" />
-              {{ formatReasoningSelectedLabel(currentReasoningEffort) }}
-              <q-icon v-if="pendingSpawnChanges.has('reasoningEffort')" name="schedule" size="11px" color="orange-6" class="q-ml-xs">
-                <q-tooltip>{{ $t('workspacePage.pendingNextRun') }}</q-tooltip>
-              </q-icon>
-            </span>
-          </template>
-        </q-select>
+        <template v-if="!isMobile">
+          <AutoLoopChip />
+          <q-select
+            v-if="sessions.length > 0"
+            v-model="selectedSessionId"
+            :options="sessionOptions"
+            emit-value
+            map-options
+            dense
+            dark
+            borderless
+            options-dense
+            :loading="creatingSession"
+            :disable="creatingSession"
+            class="q-ml-sm"
+            style="min-width: 160px; max-width: 220px; font-size: 11px;"
+          >
+            <template #option="scope">
+              <q-separator v-if="!scope.opt.isSession" spaced />
+              <q-item v-bind="scope.itemProps" clickable dense class="row items-center no-wrap">
+                <q-item-section>
+                  <q-item-label :class="!scope.opt.isSession ? 'text-grey-5' : ''">
+                    {{ scope.opt.label }}
+                  </q-item-label>
+                  <q-item-label v-if="scope.opt.caption" caption>{{ scope.opt.caption }}</q-item-label>
+                </q-item-section>
+                <q-item-section v-if="scope.opt.isSession" side>
+                  <q-btn
+                    icon="more_vert"
+                    flat
+                    dense
+                    round
+                    size="xs"
+                    color="grey-6"
+                    @click.stop
+                  >
+                    <q-menu auto-close>
+                      <q-list dense>
+                        <q-item clickable @click="openRenameDialog(scope.opt.value, scope.opt.label)">
+                          <q-item-section avatar><q-icon name="edit" size="16px" /></q-item-section>
+                          <q-item-section>{{ $t('workspacePage.renameSession') }}</q-item-section>
+                        </q-item>
+                        <q-item clickable @click="copyEngineSessionId(scope.opt.value)">
+                          <q-item-section avatar><q-icon name="content_copy" size="16px" /></q-item-section>
+                          <q-item-section>{{ $t('workspacePage.copySessionId') }}</q-item-section>
+                        </q-item>
+                        <q-item v-if="sessionCanBeDeleted(scope.opt.value)" clickable class="text-negative" @click="confirmDeleteSession(scope.opt.value)">
+                          <q-item-section avatar><q-icon name="delete_outline" size="16px" /></q-item-section>
+                          <q-item-section>{{ $t('workspacePage.deleteSession') }}</q-item-section>
+                        </q-item>
+                      </q-list>
+                    </q-menu>
+                  </q-btn>
+                </q-item-section>
+              </q-item>
+            </template>
+          </q-select>
+          <q-badge
+            v-if="selectedSessionModel !== null && selectedSessionModel !== selectedWs.model"
+            color="indigo-8"
+            text-color="indigo-1"
+            class="q-ml-sm"
+            style="font-size: 10px;"
+          >
+            <q-icon name="auto_awesome" size="11px" class="q-mr-xs" />
+            {{ $t('workspacePage.activeSessionModel', { model: activeSessionModelLabel }) }}
+            <q-tooltip>{{ $t('workspacePage.activeSessionModelTooltip') }}</q-tooltip>
+          </q-badge>
+          <q-space />
+          <q-select
+            v-model="currentPermissionMode"
+            :options="permissionModeOptions"
+            emit-value
+            map-options
+            dense
+            dark
+            borderless
+            options-dense
+            class="q-mr-xs"
+            style="min-width: 80px; max-width: 140px; font-size: 11px;"
+          >
+            <template #selected>
+              <span class="row items-center no-wrap text-caption text-grey-5">
+                <q-icon :name="currentPermissionMode === 'plan' ? 'visibility' : currentPermissionMode === 'strict' ? 'lock' : currentPermissionMode === 'interactive' ? 'security' : 'flash_on'" size="12px" color="amber-6" class="q-mr-xs" />
+                {{ permissionModeOptions.find(m => m.value === currentPermissionMode)?.label ?? currentPermissionMode }}
+                <q-icon v-if="pendingSpawnChanges.has('agentPermissionMode')" name="schedule" size="11px" color="orange-6" class="q-ml-xs">
+                  <q-tooltip>{{ $t('workspacePage.pendingNextRun') }}</q-tooltip>
+                </q-icon>
+              </span>
+            </template>
+          </q-select>
+          <q-select
+            v-model="currentModel"
+            :options="modelOptions"
+            emit-value
+            map-options
+            dense
+            dark
+            borderless
+            options-dense
+            class="q-mr-sm model-select"
+            style="min-width: 100px; max-width: 160px; font-size: 11px;"
+          >
+            <template #selected>
+              <span class="row items-center no-wrap text-caption text-grey-5">
+                <q-icon name="auto_awesome" size="12px" color="indigo-4" class="q-mr-xs" />
+                {{ modelOptions.find(m => m.value === currentModel)?.label ?? currentModel }}
+                <q-icon v-if="pendingSpawnChanges.has('model')" name="schedule" size="11px" color="orange-6" class="q-ml-xs">
+                  <q-tooltip>{{ $t('workspacePage.pendingNextRun') }}</q-tooltip>
+                </q-icon>
+              </span>
+            </template>
+          </q-select>
+          <q-select
+            v-model="currentReasoningEffort"
+            :options="reasoningOptions"
+            emit-value
+            map-options
+            dense
+            dark
+            borderless
+            options-dense
+            class="q-mr-sm"
+            style="min-width: 90px; max-width: 140px; font-size: 11px;"
+          >
+            <template #selected>
+              <span class="row items-center no-wrap text-caption text-grey-5">
+                <q-icon name="psychology" size="12px" color="amber-6" class="q-mr-xs" />
+                {{ formatReasoningSelectedLabel(currentReasoningEffort) }}
+                <q-icon v-if="pendingSpawnChanges.has('reasoningEffort')" name="schedule" size="11px" color="orange-6" class="q-ml-xs">
+                  <q-tooltip>{{ $t('workspacePage.pendingNextRun') }}</q-tooltip>
+                </q-icon>
+              </span>
+            </template>
+          </q-select>
+        </template>
+        <q-space v-else />
         <WorkspaceWhipControl
           v-if="selectedWs && !selectedWs.archivedAt"
           :workspace-id="selectedWs.id"
@@ -184,12 +187,160 @@
           size="sm"
           color="negative"
           icon="stop"
-          :label="$t('common.stop')"
+          :label="isMobile ? undefined : $t('common.stop')"
           class="q-mr-xs"
           :loading="stopping"
           :disable="stopping"
           @click="handleStop"
         />
+        <q-btn
+          v-if="isMobile"
+          flat
+          dense
+          round
+          icon="more_vert"
+          :aria-label="$t('workspacePage.moreActions')"
+        >
+          <q-tooltip>{{ $t('workspacePage.moreActions') }}</q-tooltip>
+          <q-menu>
+            <q-list style="min-width: 240px">
+              <q-item>
+                <q-item-section @click.stop>
+                  <AutoLoopChip />
+                </q-item-section>
+              </q-item>
+              <q-item v-if="sessions.length > 0">
+                <q-item-section @click.stop>
+                  <q-select
+                    v-model="selectedSessionId"
+                    :options="sessionOptions"
+                    emit-value
+                    map-options
+                    dense
+                    dark
+                    borderless
+                    options-dense
+                    :loading="creatingSession"
+                    :disable="creatingSession"
+                    style="min-width: 160px; font-size: 11px;"
+                  >
+                    <template #option="scope">
+                      <q-separator v-if="!scope.opt.isSession" spaced />
+                      <q-item v-bind="scope.itemProps" clickable dense class="row items-center no-wrap">
+                        <q-item-section>
+                          <q-item-label :class="!scope.opt.isSession ? 'text-grey-5' : ''">
+                            {{ scope.opt.label }}
+                          </q-item-label>
+                          <q-item-label v-if="scope.opt.caption" caption>{{ scope.opt.caption }}</q-item-label>
+                        </q-item-section>
+                        <q-item-section v-if="scope.opt.isSession" side>
+                          <q-btn
+                            icon="more_vert"
+                            flat
+                            dense
+                            round
+                            size="xs"
+                            color="grey-6"
+                            @click.stop
+                          >
+                            <q-menu auto-close>
+                              <q-list dense>
+                                <q-item clickable @click="openRenameDialog(scope.opt.value, scope.opt.label)">
+                                  <q-item-section avatar><q-icon name="edit" size="16px" /></q-item-section>
+                                  <q-item-section>{{ $t('workspacePage.renameSession') }}</q-item-section>
+                                </q-item>
+                                <q-item clickable @click="copyEngineSessionId(scope.opt.value)">
+                                  <q-item-section avatar><q-icon name="content_copy" size="16px" /></q-item-section>
+                                  <q-item-section>{{ $t('workspacePage.copySessionId') }}</q-item-section>
+                                </q-item>
+                              </q-list>
+                            </q-menu>
+                          </q-btn>
+                        </q-item-section>
+                      </q-item>
+                    </template>
+                  </q-select>
+                </q-item-section>
+              </q-item>
+              <q-item>
+                <q-item-section @click.stop>
+                  <q-select
+                    v-model="currentPermissionMode"
+                    :options="permissionModeOptions"
+                    emit-value
+                    map-options
+                    dense
+                    dark
+                    borderless
+                    options-dense
+                    style="min-width: 160px; font-size: 11px;"
+                  >
+                    <template #selected>
+                      <span class="row items-center no-wrap text-caption text-grey-5">
+                        <q-icon :name="currentPermissionMode === 'plan' ? 'visibility' : currentPermissionMode === 'strict' ? 'lock' : currentPermissionMode === 'interactive' ? 'security' : 'flash_on'" size="12px" color="amber-6" class="q-mr-xs" />
+                        {{ permissionModeOptions.find(m => m.value === currentPermissionMode)?.label ?? currentPermissionMode }}
+                        <q-icon v-if="pendingSpawnChanges.has('agentPermissionMode')" name="schedule" size="11px" color="orange-6" class="q-ml-xs">
+                          <q-tooltip>{{ $t('workspacePage.pendingNextRun') }}</q-tooltip>
+                        </q-icon>
+                      </span>
+                    </template>
+                  </q-select>
+                </q-item-section>
+              </q-item>
+              <q-item>
+                <q-item-section @click.stop>
+                  <q-select
+                    v-model="currentModel"
+                    :options="modelOptions"
+                    emit-value
+                    map-options
+                    dense
+                    dark
+                    borderless
+                    options-dense
+                    class="model-select"
+                    style="min-width: 160px; font-size: 11px;"
+                  >
+                    <template #selected>
+                      <span class="row items-center no-wrap text-caption text-grey-5">
+                        <q-icon name="auto_awesome" size="12px" color="indigo-4" class="q-mr-xs" />
+                        {{ modelOptions.find(m => m.value === currentModel)?.label ?? currentModel }}
+                        <q-icon v-if="pendingSpawnChanges.has('model')" name="schedule" size="11px" color="orange-6" class="q-ml-xs">
+                          <q-tooltip>{{ $t('workspacePage.pendingNextRun') }}</q-tooltip>
+                        </q-icon>
+                      </span>
+                    </template>
+                  </q-select>
+                </q-item-section>
+              </q-item>
+              <q-item>
+                <q-item-section @click.stop>
+                  <q-select
+                    v-model="currentReasoningEffort"
+                    :options="reasoningOptions"
+                    emit-value
+                    map-options
+                    dense
+                    dark
+                    borderless
+                    options-dense
+                    style="min-width: 160px; font-size: 11px;"
+                  >
+                    <template #selected>
+                      <span class="row items-center no-wrap text-caption text-grey-5">
+                        <q-icon name="psychology" size="12px" color="amber-6" class="q-mr-xs" />
+                        {{ formatReasoningSelectedLabel(currentReasoningEffort) }}
+                        <q-icon v-if="pendingSpawnChanges.has('reasoningEffort')" name="schedule" size="11px" color="orange-6" class="q-ml-xs">
+                          <q-tooltip>{{ $t('workspacePage.pendingNextRun') }}</q-tooltip>
+                        </q-icon>
+                      </span>
+                    </template>
+                  </q-select>
+                </q-item-section>
+              </q-item>
+            </q-list>
+          </q-menu>
+        </q-btn>
       </template>
       <template v-else>
         <span class="text-body2 text-grey-8">
@@ -446,6 +597,7 @@
 
 <script setup lang="ts">
 import { useQuasar } from 'quasar'
+import { useIsMobile } from 'src/composables/use-is-mobile'
 import { EFFORT_OPTION_DEFS_BY_ENGINE } from 'src/constants/efforts'
 import { MODEL_OPTION_DEFS, MODEL_OPTION_DEFS_BY_ENGINE } from 'src/constants/models'
 import { PERMISSION_MODES_BY_ENGINE } from 'src/constants/permissionModes'
@@ -481,6 +633,7 @@ import WorkspaceHistorySearch from 'src/components/WorkspaceHistorySearch.vue'
 import WorkspaceWhipControl from 'src/components/WorkspaceWhipControl.vue'
 
 const $q = useQuasar()
+const { isMobile } = useIsMobile()
 const store = useWorkspaceStore()
 const layout = useLayoutStore()
 const { t } = useI18n()

--- a/src/client/src/pages/WorkspacePage.vue
+++ b/src/client/src/pages/WorkspacePage.vue
@@ -30,140 +30,25 @@
           style="font-size: 10px;"
         />
         <template v-if="!isMobile">
-          <AutoLoopChip />
-          <q-select
-            v-if="sessions.length > 0"
-            v-model="selectedSessionId"
-            :options="sessionOptions"
-            emit-value
-            map-options
-            dense
-            dark
-            borderless
-            options-dense
-            :loading="creatingSession"
-            :disable="creatingSession"
-            class="q-ml-sm"
-            style="min-width: 160px; max-width: 220px; font-size: 11px;"
-          >
-            <template #option="scope">
-              <q-separator v-if="!scope.opt.isSession" spaced />
-              <q-item v-bind="scope.itemProps" clickable dense class="row items-center no-wrap">
-                <q-item-section>
-                  <q-item-label :class="!scope.opt.isSession ? 'text-grey-5' : ''">
-                    {{ scope.opt.label }}
-                  </q-item-label>
-                  <q-item-label v-if="scope.opt.caption" caption>{{ scope.opt.caption }}</q-item-label>
-                </q-item-section>
-                <q-item-section v-if="scope.opt.isSession" side>
-                  <q-btn
-                    icon="more_vert"
-                    flat
-                    dense
-                    round
-                    size="xs"
-                    color="grey-6"
-                    @click.stop
-                  >
-                    <q-menu auto-close>
-                      <q-list dense>
-                        <q-item clickable @click="openRenameDialog(scope.opt.value, scope.opt.label)">
-                          <q-item-section avatar><q-icon name="edit" size="16px" /></q-item-section>
-                          <q-item-section>{{ $t('workspacePage.renameSession') }}</q-item-section>
-                        </q-item>
-                        <q-item clickable @click="copyEngineSessionId(scope.opt.value)">
-                          <q-item-section avatar><q-icon name="content_copy" size="16px" /></q-item-section>
-                          <q-item-section>{{ $t('workspacePage.copySessionId') }}</q-item-section>
-                        </q-item>
-                        <q-item v-if="sessionCanBeDeleted(scope.opt.value)" clickable class="text-negative" @click="confirmDeleteSession(scope.opt.value)">
-                          <q-item-section avatar><q-icon name="delete_outline" size="16px" /></q-item-section>
-                          <q-item-section>{{ $t('workspacePage.deleteSession') }}</q-item-section>
-                        </q-item>
-                      </q-list>
-                    </q-menu>
-                  </q-btn>
-                </q-item-section>
-              </q-item>
-            </template>
-          </q-select>
-          <q-badge
-            v-if="selectedSessionModel !== null && selectedSessionModel !== selectedWs.model"
-            color="indigo-8"
-            text-color="indigo-1"
-            class="q-ml-sm"
-            style="font-size: 10px;"
-          >
-            <q-icon name="auto_awesome" size="11px" class="q-mr-xs" />
-            {{ $t('workspacePage.activeSessionModel', { model: activeSessionModelLabel }) }}
-            <q-tooltip>{{ $t('workspacePage.activeSessionModelTooltip') }}</q-tooltip>
-          </q-badge>
-          <q-space />
-          <q-select
-            v-model="currentPermissionMode"
-            :options="permissionModeOptions"
-            emit-value
-            map-options
-            dense
-            dark
-            borderless
-            options-dense
-            class="q-mr-xs"
-            style="min-width: 80px; max-width: 140px; font-size: 11px;"
-          >
-            <template #selected>
-              <span class="row items-center no-wrap text-caption text-grey-5">
-                <q-icon :name="currentPermissionMode === 'plan' ? 'visibility' : currentPermissionMode === 'strict' ? 'lock' : currentPermissionMode === 'interactive' ? 'security' : 'flash_on'" size="12px" color="amber-6" class="q-mr-xs" />
-                {{ permissionModeOptions.find(m => m.value === currentPermissionMode)?.label ?? currentPermissionMode }}
-                <q-icon v-if="pendingSpawnChanges.has('agentPermissionMode')" name="schedule" size="11px" color="orange-6" class="q-ml-xs">
-                  <q-tooltip>{{ $t('workspacePage.pendingNextRun') }}</q-tooltip>
-                </q-icon>
-              </span>
-            </template>
-          </q-select>
-          <q-select
-            v-model="currentModel"
-            :options="modelOptions"
-            emit-value
-            map-options
-            dense
-            dark
-            borderless
-            options-dense
-            class="q-mr-sm model-select"
-            style="min-width: 100px; max-width: 160px; font-size: 11px;"
-          >
-            <template #selected>
-              <span class="row items-center no-wrap text-caption text-grey-5">
-                <q-icon name="auto_awesome" size="12px" color="indigo-4" class="q-mr-xs" />
-                {{ modelOptions.find(m => m.value === currentModel)?.label ?? currentModel }}
-                <q-icon v-if="pendingSpawnChanges.has('model')" name="schedule" size="11px" color="orange-6" class="q-ml-xs">
-                  <q-tooltip>{{ $t('workspacePage.pendingNextRun') }}</q-tooltip>
-                </q-icon>
-              </span>
-            </template>
-          </q-select>
-          <q-select
-            v-model="currentReasoningEffort"
-            :options="reasoningOptions"
-            emit-value
-            map-options
-            dense
-            dark
-            borderless
-            options-dense
-            class="q-mr-sm"
-            style="min-width: 90px; max-width: 140px; font-size: 11px;"
-          >
-            <template #selected>
-              <span class="row items-center no-wrap text-caption text-grey-5">
-                <q-icon name="psychology" size="12px" color="amber-6" class="q-mr-xs" />
-                {{ formatReasoningSelectedLabel(currentReasoningEffort) }}
-                <q-icon v-if="pendingSpawnChanges.has('reasoningEffort')" name="schedule" size="11px" color="orange-6" class="q-ml-xs">
-                  <q-tooltip>{{ $t('workspacePage.pendingNextRun') }}</q-tooltip>
-                </q-icon>
-              </span>
-            </template>
-          </q-select>
+          <WorkspaceToolbarSelectors
+            layout="inline"
+            :sessions="sessions"
+            :session-options="sessionOptions"
+            :permission-mode-options="permissionModeOptions"
+            :model-options="modelOptions"
+            :reasoning-options="reasoningOptions"
+            :pending-spawn-changes="pendingSpawnChanges"
+            :creating-session="creatingSession"
+            :can-delete-session="sessionCanBeDeleted"
+            :active-session-model-label="toolbarActiveSessionModelLabel"
+            v-model:selected-session-id="selectedSessionId"
+            v-model:permission-mode="currentPermissionMode"
+            v-model:model="currentModel"
+            v-model:reasoning-effort="currentReasoningEffort"
+            @rename="openRenameDialog"
+            @copy-session-id="copyEngineSessionId"
+            @delete-session="confirmDeleteSession"
+          />
         </template>
         <q-space v-else />
         <WorkspaceWhipControl
@@ -204,140 +89,25 @@
           <q-tooltip>{{ $t('workspacePage.moreActions') }}</q-tooltip>
           <q-menu>
             <q-list style="min-width: 240px">
-              <q-item>
-                <q-item-section @click.stop>
-                  <AutoLoopChip />
-                </q-item-section>
-              </q-item>
-              <q-item v-if="sessions.length > 0">
-                <q-item-section @click.stop>
-                  <q-select
-                    v-model="selectedSessionId"
-                    :options="sessionOptions"
-                    emit-value
-                    map-options
-                    dense
-                    dark
-                    borderless
-                    options-dense
-                    :loading="creatingSession"
-                    :disable="creatingSession"
-                    style="min-width: 160px; font-size: 11px;"
-                  >
-                    <template #option="scope">
-                      <q-separator v-if="!scope.opt.isSession" spaced />
-                      <q-item v-bind="scope.itemProps" clickable dense class="row items-center no-wrap">
-                        <q-item-section>
-                          <q-item-label :class="!scope.opt.isSession ? 'text-grey-5' : ''">
-                            {{ scope.opt.label }}
-                          </q-item-label>
-                          <q-item-label v-if="scope.opt.caption" caption>{{ scope.opt.caption }}</q-item-label>
-                        </q-item-section>
-                        <q-item-section v-if="scope.opt.isSession" side>
-                          <q-btn
-                            icon="more_vert"
-                            flat
-                            dense
-                            round
-                            size="xs"
-                            color="grey-6"
-                            @click.stop
-                          >
-                            <q-menu auto-close>
-                              <q-list dense>
-                                <q-item clickable @click="openRenameDialog(scope.opt.value, scope.opt.label)">
-                                  <q-item-section avatar><q-icon name="edit" size="16px" /></q-item-section>
-                                  <q-item-section>{{ $t('workspacePage.renameSession') }}</q-item-section>
-                                </q-item>
-                                <q-item clickable @click="copyEngineSessionId(scope.opt.value)">
-                                  <q-item-section avatar><q-icon name="content_copy" size="16px" /></q-item-section>
-                                  <q-item-section>{{ $t('workspacePage.copySessionId') }}</q-item-section>
-                                </q-item>
-                              </q-list>
-                            </q-menu>
-                          </q-btn>
-                        </q-item-section>
-                      </q-item>
-                    </template>
-                  </q-select>
-                </q-item-section>
-              </q-item>
-              <q-item>
-                <q-item-section @click.stop>
-                  <q-select
-                    v-model="currentPermissionMode"
-                    :options="permissionModeOptions"
-                    emit-value
-                    map-options
-                    dense
-                    dark
-                    borderless
-                    options-dense
-                    style="min-width: 160px; font-size: 11px;"
-                  >
-                    <template #selected>
-                      <span class="row items-center no-wrap text-caption text-grey-5">
-                        <q-icon :name="currentPermissionMode === 'plan' ? 'visibility' : currentPermissionMode === 'strict' ? 'lock' : currentPermissionMode === 'interactive' ? 'security' : 'flash_on'" size="12px" color="amber-6" class="q-mr-xs" />
-                        {{ permissionModeOptions.find(m => m.value === currentPermissionMode)?.label ?? currentPermissionMode }}
-                        <q-icon v-if="pendingSpawnChanges.has('agentPermissionMode')" name="schedule" size="11px" color="orange-6" class="q-ml-xs">
-                          <q-tooltip>{{ $t('workspacePage.pendingNextRun') }}</q-tooltip>
-                        </q-icon>
-                      </span>
-                    </template>
-                  </q-select>
-                </q-item-section>
-              </q-item>
-              <q-item>
-                <q-item-section @click.stop>
-                  <q-select
-                    v-model="currentModel"
-                    :options="modelOptions"
-                    emit-value
-                    map-options
-                    dense
-                    dark
-                    borderless
-                    options-dense
-                    class="model-select"
-                    style="min-width: 160px; font-size: 11px;"
-                  >
-                    <template #selected>
-                      <span class="row items-center no-wrap text-caption text-grey-5">
-                        <q-icon name="auto_awesome" size="12px" color="indigo-4" class="q-mr-xs" />
-                        {{ modelOptions.find(m => m.value === currentModel)?.label ?? currentModel }}
-                        <q-icon v-if="pendingSpawnChanges.has('model')" name="schedule" size="11px" color="orange-6" class="q-ml-xs">
-                          <q-tooltip>{{ $t('workspacePage.pendingNextRun') }}</q-tooltip>
-                        </q-icon>
-                      </span>
-                    </template>
-                  </q-select>
-                </q-item-section>
-              </q-item>
-              <q-item>
-                <q-item-section @click.stop>
-                  <q-select
-                    v-model="currentReasoningEffort"
-                    :options="reasoningOptions"
-                    emit-value
-                    map-options
-                    dense
-                    dark
-                    borderless
-                    options-dense
-                    style="min-width: 160px; font-size: 11px;"
-                  >
-                    <template #selected>
-                      <span class="row items-center no-wrap text-caption text-grey-5">
-                        <q-icon name="psychology" size="12px" color="amber-6" class="q-mr-xs" />
-                        {{ formatReasoningSelectedLabel(currentReasoningEffort) }}
-                        <q-icon v-if="pendingSpawnChanges.has('reasoningEffort')" name="schedule" size="11px" color="orange-6" class="q-ml-xs">
-                          <q-tooltip>{{ $t('workspacePage.pendingNextRun') }}</q-tooltip>
-                        </q-icon>
-                      </span>
-                    </template>
-                  </q-select>
-                </q-item-section>
-              </q-item>
+              <WorkspaceToolbarSelectors
+                layout="menu"
+                :sessions="sessions"
+                :session-options="sessionOptions"
+                :permission-mode-options="permissionModeOptions"
+                :model-options="modelOptions"
+                :reasoning-options="reasoningOptions"
+                :pending-spawn-changes="pendingSpawnChanges"
+                :creating-session="creatingSession"
+                :can-delete-session="sessionCanBeDeleted"
+                :active-session-model-label="toolbarActiveSessionModelLabel"
+                v-model:selected-session-id="selectedSessionId"
+                v-model:permission-mode="currentPermissionMode"
+                v-model:model="currentModel"
+                v-model:reasoning-effort="currentReasoningEffort"
+                @rename="openRenameDialog"
+                @copy-session-id="copyEngineSessionId"
+                @delete-session="confirmDeleteSession"
+              />
             </q-list>
           </q-menu>
         </q-btn>
@@ -622,7 +392,6 @@ const ActivityFeed = defineAsyncComponent(() =>
 import AgentBusyBanner from 'src/components/AgentBusyBanner.vue'
 import AgentErrorBanner from 'src/components/AgentErrorBanner.vue'
 import AskUserQuestionPanel from 'src/components/AskUserQuestionPanel.vue'
-import AutoLoopChip from 'src/components/AutoLoopChip.vue'
 import ChatInput from 'src/components/ChatInput.vue'
 import LatestThinkingPanel from 'src/components/LatestThinkingPanel.vue'
 import PermissionRequestPanel from 'src/components/PermissionRequestPanel.vue'
@@ -630,6 +399,7 @@ import QuotaBackoffBanner from 'src/components/QuotaBackoffBanner.vue'
 import StaleSessionBanner from 'src/components/StaleSessionBanner.vue'
 import WakeupBanner from 'src/components/WakeupBanner.vue'
 import WorkspaceHistorySearch from 'src/components/WorkspaceHistorySearch.vue'
+import WorkspaceToolbarSelectors from 'src/components/WorkspaceToolbarSelectors.vue'
 import WorkspaceWhipControl from 'src/components/WorkspaceWhipControl.vue'
 
 const $q = useQuasar()
@@ -920,10 +690,6 @@ function formatReasoningLabel(label: string): string {
   return label
 }
 
-function formatReasoningSelectedLabel(value: string): string {
-  return reasoningOptions.value.find((r) => r.value === value)?.label ?? value
-}
-
 type AgentPermissionModeValue = 'plan' | 'bypass' | 'strict' | 'interactive'
 
 const currentPermissionMode = computed<AgentPermissionModeValue>({
@@ -954,6 +720,11 @@ const activeSessionModelLabel = computed(
   () =>
     modelOptions.value.find((option) => option.value === selectedSessionModel.value)?.label ??
     selectedSessionModel.value,
+)
+const toolbarActiveSessionModelLabel = computed(() =>
+  selectedSessionModel.value !== null && selectedSessionModel.value !== selectedWs.value?.model
+    ? activeSessionModelLabel.value
+    : null,
 )
 const selectedSessionId = computed({
   get: () => store.selectedSessionId,


### PR DESCRIPTION
## Summary

Makes the Kōbō UI usable on phones and small tablets: the left workspaces drawer and the settings nav become collapsible, the workspace toolbar collapses into an overflow menu, and the chat input drops keyboard-only affordances that don't apply on touch.

## Changes

**Frontend — breakpoints**
- New `useIsMobile` composable (`src/client/src/composables/use-is-mobile.ts`) exposing `isMobile` (phone-portrait, `lt.sm`) and `isDrawerCollapsed` (`lt.md`, tablet-portrait band)

**Frontend — navigation**
- `SettingsPage` nav collapses into a drawer on mobile, extracted into a reusable `SettingsNavList.vue`
- Settings nav gains an entry point back to the workspaces drawer on mobile
- New `DrawerToggleButton.vue`, wired into `SearchPage`, `CreatePage`, `HealthPage` and `ChangelogPage` so the workspaces drawer is reachable from every route

**Frontend — workspace view**
- Workspace toolbar selectors (engine / model / permission mode / …) collapse into an overflow menu on mobile, extracted into `WorkspaceToolbarSelectors.vue` (`WorkspacePage.vue` shrinks by ~180 lines)
- `HealthPage` layout made responsive
- `ChatInput` trims keyboard hints and skips the keyboard push-to-talk shortcut on touch devices

## Testing

- [x] `npm test` (backend) passes — 116 files, 2235 tests
- [x] client tests pass — 58 files, 597 tests (incl. new `use-is-mobile.test.ts`, 52 lines covering both breakpoints)
- [x] `npm run lint` passes — clean
- [x] `npx tsc --noEmit` (backend) passes
- [x] `vue-tsc --noEmit` (client) passes — no type errors

Rebased onto `develop` @ `faa14e0` (v1.11.14). Six conflicts resolved, all in favour of the upstream behaviour:

- `WorkspacePage.vue` — the mobile `!isMobile` wrapper now sits around the *current* toolbar, so the whip control, the engine switch button, the active-session model badge and the delete-session menu item are all preserved
- `WorkspaceToolbarSelectors.vue` — the extracted component gained `canDeleteSession` / `activeSessionModelLabel` props and a `deleteSession` emit to carry those same upstream additions into both the inline and the overflow-menu layouts
- `ChatInput.vue` — upstream already moved the secondary shortcuts into a popup; the mobile treatment now only hides `Shift+Enter` and the shortcuts button
- `CreatePage.vue` — kept the new header markup, re-added `position: relative` for the toggle
- `SettingsPage.vue` / `SearchPage.vue` / `i18n/*` — import and key merges

## Internationalization

- [x] All user-visible strings use `$t()` / `t()` — no hardcoded text
- [x] Translation keys added to all 5 locale files (en, fr, de, es, it)

## Schema / migrations

No DB or `settings.json` schema change.

## Breaking changes

None. Desktop layout is unchanged — every new behaviour is gated behind a breakpoint.
