### PR TITLE
feat(client,server): tell the truth while working and when it fails

### DIFF
--- a/src/__tests__/logger.test.ts
+++ b/src/__tests__/logger.test.ts
@@ -1,0 +1,91 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+let tmpHome: string
+const previousHome = process.env.KOBO_HOME
+
+beforeEach(async () => {
+  tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'kobo-logger-test-'))
+  process.env.KOBO_HOME = tmpHome
+  const { _resetLoggerForTest } = await import('../server/utils/logger.js')
+  _resetLoggerForTest()
+})
+
+afterEach(() => {
+  if (previousHome === undefined) delete process.env.KOBO_HOME
+  else process.env.KOBO_HOME = previousHome
+  if (tmpHome && fs.existsSync(tmpHome)) fs.rmSync(tmpHome, { recursive: true, force: true })
+})
+
+describe('structured logger', () => {
+  it('writes one JSON line per event, under the Kōbō home', async () => {
+    const { getLogFilePath, logError } = await import('../server/utils/logger.js')
+
+    logError('purge', 'stopAgent failed', { workspaceId: 'w1' })
+
+    const contents = fs.readFileSync(getLogFilePath(), 'utf-8').trim().split('\n')
+    expect(contents).toHaveLength(1)
+    const entry = JSON.parse(contents[0]) as { level: string; scope: string; message: string; meta: unknown }
+    expect(entry.level).toBe('error')
+    expect(entry.scope).toBe('purge')
+    expect(entry.message).toBe('stopAgent failed')
+    expect(entry.meta).toEqual({ workspaceId: 'w1' })
+  })
+
+  it('reads back the most recent entries, newest first', async () => {
+    const { logInfo, logWarn, readRecentLogs } = await import('../server/utils/logger.js')
+
+    logInfo('a', 'first')
+    logWarn('b', 'second')
+
+    const recent = readRecentLogs({ limit: 10 })
+    expect(recent.map((e) => e.message)).toEqual(['second', 'first'])
+  })
+
+  it('filters by level so an incident hunt is not drowned in info lines', async () => {
+    const { logError, logInfo, readRecentLogs } = await import('../server/utils/logger.js')
+
+    logInfo('a', 'noise')
+    logError('b', 'the actual problem')
+
+    const errors = readRecentLogs({ level: 'error' })
+    expect(errors.map((e) => e.message)).toEqual(['the actual problem'])
+  })
+
+  it('rotates the file instead of growing without bound', async () => {
+    const { getLogFilePath, log, _resetLoggerForTest } = await import('../server/utils/logger.js')
+    _resetLoggerForTest()
+
+    // Each entry carries a large meta blob so the size cap is reached fast.
+    const blob = 'x'.repeat(64 * 1024)
+    for (let i = 0; i < 120; i++) log('info', 'bulk', `entry ${i}`, { blob })
+
+    expect(fs.existsSync(`${getLogFilePath()}.1`)).toBe(true)
+    expect(fs.statSync(getLogFilePath()).size).toBeLessThan(6 * 1024 * 1024)
+  })
+
+  it('never throws when the log directory cannot be written', async (ctx) => {
+    // Root ignores `chmod 0444` and writes anyway: the assertion below would
+    // pass without ever reaching the failure path it claims to cover — a
+    // false green, which is exactly what this suite exists to prevent.
+    if (process.getuid?.() === 0) {
+      ctx.skip('running as root: chmod 0444 is not a write barrier, the test would be a false green')
+    }
+    const { log, _resetLoggerForTest } = await import('../server/utils/logger.js')
+
+    // A read-only KOBO_HOME reliably rejects `mkdir logs/` with EACCES, unlike
+    // a synthetic path (e.g. under /proc) whose recursive-mkdir behavior is
+    // platform-dependent and can hang instead of failing fast.
+    fs.chmodSync(tmpHome, 0o444)
+    _resetLoggerForTest()
+
+    try {
+      // A logging failure must never take down the operation being logged.
+      expect(() => log('error', 'x', 'y')).not.toThrow()
+    } finally {
+      fs.chmodSync(tmpHome, 0o755) // restore so afterEach can remove the directory
+    }
+  })
+})

--- a/src/__tests__/routes-health.test.ts
+++ b/src/__tests__/routes-health.test.ts
@@ -163,3 +163,40 @@ describe('GET /api/health/report — active state', () => {
     expect(body.active.devServersRunning[0]?.name).toBe('Live')
   })
 })
+
+describe('GET /api/health/logs', () => {
+  beforeEach(async () => {
+    await resetDb()
+    const { getDb } = await import('../server/db/index.js')
+    getDb(dbPath)
+    process.env.KOBO_HOME = tmpDir
+    const { _resetLoggerForTest } = await import('../server/utils/logger.js')
+    _resetLoggerForTest()
+    const healthRouter = (await import('../server/routes/health.js')).default
+    app = new Hono()
+    app.route('/api/health', healthRouter)
+  })
+
+  it('returns the most recent entries, newest first', async () => {
+    const { logError, logInfo } = await import('../server/utils/logger.js')
+    logInfo('boot', 'started')
+    logError('purge', 'worktree removal failed')
+
+    const res = await app.request('/api/health/logs?limit=10')
+
+    expect(res.status).toBe(200)
+    const data = (await res.json()) as { entries: Array<{ scope: string; message: string }> }
+    expect(data.entries[0]).toMatchObject({ scope: 'purge', message: 'worktree removal failed' })
+  })
+
+  it('filters by level', async () => {
+    const { logError, logInfo } = await import('../server/utils/logger.js')
+    logInfo('boot', 'started')
+    logError('purge', 'worktree removal failed')
+
+    const res = await app.request('/api/health/logs?level=error')
+
+    const data = (await res.json()) as { entries: Array<{ message: string }> }
+    expect(data.entries.map((e) => e.message)).toEqual(['worktree removal failed'])
+  })
+})

--- a/src/__tests__/routes-workspaces.test.ts
+++ b/src/__tests__/routes-workspaces.test.ts
@@ -484,7 +484,11 @@ describe('GET /api/workspaces', () => {
 describe('POST /api/workspaces', () => {
   it('creates workspace without Notion URL', async () => {
     vi.mocked(workspaceService.createWorkspace).mockReturnValue(fakeWorkspace)
-    vi.mocked(worktreeService.createWorktree).mockReturnValue({ worktreePath: '/tmp/worktree', base: 'origin' })
+    vi.mocked(worktreeService.createWorktree).mockReturnValue({
+      worktreePath: '/tmp/worktree',
+      base: 'origin',
+      branchCreated: true,
+    })
     vi.mocked(workspaceService.listTasks).mockReturnValue([])
     vi.mocked(workspaceService.getWorkspaceWithTasks).mockReturnValue(fakeWorkspaceWithTasks)
 
@@ -513,8 +517,103 @@ describe('POST /api/workspaces', () => {
     expect(agentManager.startAgent).toHaveBeenCalledOnce()
   })
 
+  it('emits one named progress beat per creation step on the creationId channel', async () => {
+    vi.mocked(workspaceService.createWorkspace).mockReturnValue(fakeWorkspace)
+    vi.mocked(worktreeService.createWorktree).mockReturnValue({
+      worktreePath: '/tmp/worktree',
+      base: 'origin',
+      branchCreated: true,
+    })
+    vi.mocked(workspaceService.listTasks).mockReturnValue([])
+    vi.mocked(workspaceService.getWorkspaceWithTasks).mockReturnValue(fakeWorkspaceWithTasks)
+
+    const res = await app.request('/api/workspaces', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        name: 'Test Workspace',
+        projectPath: '/tmp/project',
+        sourceBranch: 'main',
+        workingBranch: 'feature/test',
+        creationId: 'create-abc',
+      }),
+    })
+
+    expect(res.status).toBe(201)
+
+    const steps = vi
+      .mocked(wsService.emitEphemeral)
+      .mock.calls.filter(([channel, type]) => channel === 'create-abc' && type === 'workspace:create-progress')
+      .map(([, , payload]) => (payload as { step: string }).step)
+
+    // The user must be able to tell a slow git fetch from a slow setup script.
+    expect(steps).toContain('fetch-source-branch')
+    expect(steps).toContain('create-record')
+    expect(steps).toContain('create-worktree')
+    expect(steps).toContain('build-prompt')
+    expect(steps).toContain('start-agent')
+    expect(steps.at(-1)).toBe('done')
+  })
+
+  it('stays silent when the caller sends no creationId', async () => {
+    vi.mocked(workspaceService.createWorkspace).mockReturnValue(fakeWorkspace)
+    vi.mocked(worktreeService.createWorktree).mockReturnValue({
+      worktreePath: '/tmp/worktree',
+      base: 'origin',
+      branchCreated: true,
+    })
+    vi.mocked(workspaceService.listTasks).mockReturnValue([])
+    vi.mocked(workspaceService.getWorkspaceWithTasks).mockReturnValue(fakeWorkspaceWithTasks)
+
+    await app.request('/api/workspaces', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        name: 'Test Workspace',
+        projectPath: '/tmp/project',
+        sourceBranch: 'main',
+        workingBranch: 'feature/test',
+      }),
+    })
+
+    const progressCalls = vi
+      .mocked(wsService.emitEphemeral)
+      .mock.calls.filter(([, type]) => type === 'workspace:create-progress')
+    expect(progressCalls).toEqual([])
+  })
+
+  it('names the failing step when worktree creation fails', async () => {
+    vi.mocked(workspaceService.createWorkspace).mockReturnValue(fakeWorkspace)
+    vi.mocked(worktreeService.createWorktree).mockImplementationOnce(() => {
+      throw new Error('fatal: File name too long')
+    })
+
+    const res = await app.request('/api/workspaces', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        name: 'Test Workspace',
+        projectPath: '/tmp/project',
+        sourceBranch: 'main',
+        workingBranch: 'feature/test',
+        creationId: 'create-def',
+      }),
+    })
+
+    expect(res.status).toBe(500)
+    const data = await res.json()
+    expect(data.step).toBe('create-worktree')
+
+    expect(wsService.emitEphemeral).toHaveBeenCalledWith(
+      'create-def',
+      'workspace:create-failed',
+      expect.objectContaining({ step: 'create-worktree' }),
+    )
+  })
+
   it('rolls back the workspace record when worktree creation fails (no orphan)', async () => {
     vi.mocked(workspaceService.createWorkspace).mockReturnValue(fakeWorkspace)
+    vi.mocked(workspaceService.getWorkspace).mockReturnValue(fakeWorkspace)
     vi.mocked(worktreeService.createWorktree).mockImplementationOnce(() => {
       throw new Error('fatal: File name too long')
     })
@@ -536,6 +635,202 @@ describe('POST /api/workspaces', () => {
     // The just-inserted workspace must be deleted, not left as an orphan 'error' record.
     expect(workspaceService.deleteWorkspace).toHaveBeenCalledWith('ws-1')
     expect(agentManager.startAgent).not.toHaveBeenCalled()
+  })
+
+  it('destroys everything it created when the agent fails to start', async () => {
+    vi.mocked(workspaceService.createWorkspace).mockReturnValue(fakeWorkspace)
+    vi.mocked(workspaceService.getWorkspace).mockReturnValue(fakeWorkspace)
+    vi.mocked(worktreeService.createWorktree).mockReturnValue({
+      worktreePath: '/tmp/worktree',
+      base: 'origin',
+      branchCreated: true,
+    })
+    vi.mocked(workspaceService.listTasks).mockReturnValue([])
+    vi.mocked(workspaceService.getWorkspaceWithTasks).mockReturnValue(fakeWorkspaceWithTasks)
+    vi.mocked(agentManager.startAgent).mockImplementationOnce(() => {
+      throw new Error('claude: command not found')
+    })
+
+    const res = await app.request('/api/workspaces', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        name: 'Test Workspace',
+        projectPath: '/tmp/project',
+        sourceBranch: 'main',
+        workingBranch: 'feature/test',
+        creationId: 'create-ghi',
+      }),
+    })
+
+    // A half-created workspace is exactly the kind of object whose existence
+    // lies to the user. Nothing is kept.
+    expect(res.status).toBe(500)
+    const data = await res.json()
+    expect(data.step).toBe('start-agent')
+    expect(data.error).toContain('claude: command not found')
+
+    // Worktree gone from disk, branch gone, row gone from the DB (cascading to
+    // tasks, sessions and events).
+    expect(worktreeService.removeWorktree).toHaveBeenCalledWith('/tmp/project', '/tmp/project/.worktrees/feature/test')
+    expect(gitOps.deleteLocalBranch).toHaveBeenCalledWith('/tmp/project', 'feature/test')
+    expect(workspaceService.deleteWorkspace).toHaveBeenCalledWith('ws-1')
+
+    // The progress stream must say the creation was undone, not sit on the last
+    // step it managed to reach.
+    expect(wsService.emitEphemeral).toHaveBeenCalledWith(
+      'create-ghi',
+      'workspace:create-progress',
+      expect.objectContaining({ step: 'rollback' }),
+    )
+    expect(wsService.emitEphemeral).toHaveBeenCalledWith(
+      'create-ghi',
+      'workspace:create-failed',
+      expect.objectContaining({ step: 'start-agent' }),
+    )
+  })
+
+  it('warns that the setup script may have left effects the rollback cannot undo', async () => {
+    vi.mocked(workspaceService.createWorkspace).mockReturnValue(fakeWorkspace)
+    vi.mocked(workspaceService.getWorkspace).mockReturnValue(fakeWorkspace)
+    vi.mocked(worktreeService.createWorktree).mockReturnValue({
+      worktreePath: '/tmp/worktree',
+      base: 'origin',
+      branchCreated: true,
+    })
+    vi.mocked(workspaceService.listTasks).mockReturnValue([])
+    vi.mocked(settingsService.getEffectiveSettings).mockReturnValue({
+      model: 'auto',
+      dangerouslySkipPermissions: true,
+      prPromptTemplate: '',
+      gitConventions: '',
+      sourceBranch: 'main',
+      devServer: null,
+      setupScript: '#!/bin/bash\necho setting up',
+      notionStatusProperty: '',
+      notionInProgressStatus: '',
+    })
+    vi.mocked(setupScriptService.runSetupScript).mockResolvedValue({ exitCode: 0 })
+    vi.mocked(agentManager.startAgent).mockImplementationOnce(() => {
+      throw new Error('engine handshake timed out')
+    })
+
+    const res = await app.request('/api/workspaces', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        name: 'Test Workspace',
+        projectPath: '/tmp/project',
+        sourceBranch: 'main',
+        workingBranch: 'feature/test',
+      }),
+    })
+
+    const data = await res.json()
+    // Docker containers, global caches, files written outside the worktree:
+    // the rollback cannot reach them, so it must not claim it did.
+    expect(data.error).toMatch(/setup script/i)
+    expect(data.rollback.done).toBe(true)
+  })
+
+  it('never lets a cleanup failure replace the original error', async () => {
+    vi.mocked(workspaceService.createWorkspace).mockReturnValue(fakeWorkspace)
+    vi.mocked(workspaceService.getWorkspace).mockReturnValue(fakeWorkspace)
+    vi.mocked(worktreeService.createWorktree).mockReturnValue({
+      worktreePath: '/tmp/worktree',
+      base: 'origin',
+      branchCreated: true,
+    })
+    vi.mocked(workspaceService.listTasks).mockReturnValue([])
+    vi.mocked(agentManager.startAgent).mockImplementationOnce(() => {
+      throw new Error('claude: command not found')
+    })
+    vi.mocked(worktreeService.removeWorktree).mockImplementationOnce(() => {
+      throw new Error('EACCES: permission denied')
+    })
+
+    const res = await app.request('/api/workspaces', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        name: 'Test Workspace',
+        projectPath: '/tmp/project',
+        sourceBranch: 'main',
+        workingBranch: 'feature/test',
+      }),
+    })
+
+    expect(res.status).toBe(500)
+    const data = await res.json()
+    // The reported cause stays the agent start; the cleanup failure rides along.
+    expect(data.error).toContain('claude: command not found')
+    expect(data.step).toBe('start-agent')
+    expect(data.rollback.warnings.join('\n')).toContain('EACCES')
+    // The DB row is deleted anyway — a stuck directory must not resurrect the
+    // half-created workspace.
+    expect(workspaceService.deleteWorkspace).toHaveBeenCalledWith('ws-1')
+  })
+
+  it('keeps a reused worktree and its branch when the agent fails to start', async () => {
+    const reused = { ...fakeWorkspace, worktreeOwned: false, worktreePath: '/tmp/user-worktree' }
+    vi.mocked(workspaceService.createWorkspace).mockReturnValue(reused)
+    vi.mocked(workspaceService.getWorkspace).mockReturnValue(reused)
+    vi.mocked(workspaceService.listTasks).mockReturnValue([])
+    // Once only: this must not leak into later tests, which rely on the
+    // module-wide default of `false` for their own `resolveUniqueBranchAndPath`
+    // disk checks (see branch-resolver.ts).
+    vi.mocked(fs.existsSync).mockReturnValueOnce(true)
+    vi.mocked(execFileSync)
+      .mockReturnValueOnce('/tmp/project/.git' as unknown as Buffer)
+      .mockReturnValueOnce('feature/reused' as unknown as Buffer)
+    vi.mocked(agentManager.startAgent).mockImplementationOnce(() => {
+      throw new Error('claude: command not found')
+    })
+
+    const res = await app.request('/api/workspaces', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        name: 'Test Workspace',
+        projectPath: '/tmp/project',
+        sourceBranch: 'main',
+        worktreePath: '/tmp/user-worktree',
+      }),
+    })
+
+    expect(res.status).toBe(500)
+    // The user brought this worktree and this branch — they are not ours to destroy.
+    expect(worktreeService.removeWorktree).not.toHaveBeenCalled()
+    expect(gitOps.deleteLocalBranch).not.toHaveBeenCalled()
+    expect(workspaceService.deleteWorkspace).toHaveBeenCalledWith('ws-1')
+  })
+
+  it('still creates the workspace when everything works', async () => {
+    vi.mocked(workspaceService.createWorkspace).mockReturnValue(fakeWorkspace)
+    vi.mocked(worktreeService.createWorktree).mockReturnValue({
+      worktreePath: '/tmp/worktree',
+      base: 'origin',
+      branchCreated: true,
+    })
+    vi.mocked(workspaceService.listTasks).mockReturnValue([])
+    vi.mocked(workspaceService.getWorkspaceWithTasks).mockReturnValue(fakeWorkspaceWithTasks)
+
+    const res = await app.request('/api/workspaces', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        name: 'Test Workspace',
+        projectPath: '/tmp/project',
+        sourceBranch: 'main',
+        workingBranch: 'feature/test',
+      }),
+    })
+
+    expect(res.status).toBe(201)
+    const data = await res.json()
+    expect(data.id).toBe('ws-1')
+    expect(data.warning).toBeUndefined()
+    expect(workspaceService.deleteWorkspace).not.toHaveBeenCalled()
   })
 
   it('creates new workspaces under the configured global worktrees path', async () => {
@@ -614,7 +909,11 @@ describe('POST /api/workspaces', () => {
       name: 'Notion Page Title',
       workingBranch: 'feature/TK-123--notion-page-title',
     } as never)
-    vi.mocked(worktreeService.createWorktree).mockReturnValue({ worktreePath: '/tmp/worktree', base: 'origin' })
+    vi.mocked(worktreeService.createWorktree).mockReturnValue({
+      worktreePath: '/tmp/worktree',
+      base: 'origin',
+      branchCreated: true,
+    })
     vi.mocked(workspaceService.listTasks).mockReturnValue([])
     vi.mocked(workspaceService.getWorkspaceWithTasks).mockReturnValue(fakeWorkspaceWithTasks)
 
@@ -646,7 +945,11 @@ describe('POST /api/workspaces', () => {
 
   it('calls fetchSourceBranch before createWorkspace on workspace creation', async () => {
     vi.mocked(workspaceService.createWorkspace).mockReturnValue(fakeWorkspace)
-    vi.mocked(worktreeService.createWorktree).mockReturnValue({ worktreePath: '/tmp/worktree', base: 'origin' })
+    vi.mocked(worktreeService.createWorktree).mockReturnValue({
+      worktreePath: '/tmp/worktree',
+      base: 'origin',
+      branchCreated: true,
+    })
     vi.mocked(workspaceService.listTasks).mockReturnValue([])
     vi.mocked(workspaceService.getWorkspaceWithTasks).mockReturnValue(fakeWorkspaceWithTasks)
 
@@ -700,7 +1003,11 @@ describe('POST /api/workspaces', () => {
   it('bases the worktree on origin and sets no fallback header when fetch succeeds', async () => {
     vi.mocked(workspaceService.createWorkspace).mockReturnValue(fakeWorkspace)
     vi.mocked(gitOps.fetchSourceBranch).mockImplementation(() => {})
-    vi.mocked(worktreeService.createWorktree).mockReturnValue({ worktreePath: '/tmp/wt', base: 'origin' })
+    vi.mocked(worktreeService.createWorktree).mockReturnValue({
+      worktreePath: '/tmp/wt',
+      base: 'origin',
+      branchCreated: true,
+    })
     vi.mocked(workspaceService.listTasks).mockReturnValue([])
     vi.mocked(workspaceService.getWorkspaceWithTasks).mockReturnValue(fakeWorkspaceWithTasks)
 
@@ -732,7 +1039,11 @@ describe('POST /api/workspaces', () => {
       throw new Error('no origin')
     })
     vi.mocked(gitOps.localBranchExists).mockReturnValue(true)
-    vi.mocked(worktreeService.createWorktree).mockReturnValue({ worktreePath: '/tmp/wt', base: 'local' })
+    vi.mocked(worktreeService.createWorktree).mockReturnValue({
+      worktreePath: '/tmp/wt',
+      base: 'local',
+      branchCreated: true,
+    })
     vi.mocked(workspaceService.listTasks).mockReturnValue([])
     vi.mocked(workspaceService.getWorkspaceWithTasks).mockReturnValue(fakeWorkspaceWithTasks)
 
@@ -905,7 +1216,11 @@ describe('POST /api/workspaces', () => {
 
   it('runs setup script when configured and continues on success', async () => {
     vi.mocked(workspaceService.createWorkspace).mockReturnValue(fakeWorkspace)
-    vi.mocked(worktreeService.createWorktree).mockReturnValue({ worktreePath: '/tmp/worktree', base: 'origin' })
+    vi.mocked(worktreeService.createWorktree).mockReturnValue({
+      worktreePath: '/tmp/worktree',
+      base: 'origin',
+      branchCreated: true,
+    })
     vi.mocked(workspaceService.listTasks).mockReturnValue([])
     vi.mocked(workspaceService.getWorkspaceWithTasks).mockReturnValue(fakeWorkspaceWithTasks)
     vi.mocked(settingsService.getEffectiveSettings).mockReturnValue({
@@ -938,7 +1253,11 @@ describe('POST /api/workspaces', () => {
 
   it('returns workspace in error status when setup script fails', async () => {
     vi.mocked(workspaceService.createWorkspace).mockReturnValue(fakeWorkspace)
-    vi.mocked(worktreeService.createWorktree).mockReturnValue({ worktreePath: '/tmp/worktree', base: 'origin' })
+    vi.mocked(worktreeService.createWorktree).mockReturnValue({
+      worktreePath: '/tmp/worktree',
+      base: 'origin',
+      branchCreated: true,
+    })
     vi.mocked(workspaceService.listTasks).mockReturnValue([])
     vi.mocked(workspaceService.getWorkspaceWithTasks).mockReturnValue(fakeWorkspaceWithTasks)
     vi.mocked(settingsService.getEffectiveSettings).mockReturnValue({
@@ -971,9 +1290,251 @@ describe('POST /api/workspaces', () => {
     expect(agentManager.startAgent).not.toHaveBeenCalled()
   })
 
+  it('emits create-failed and never emits done when the setup script fails', async () => {
+    vi.mocked(workspaceService.createWorkspace).mockReturnValue(fakeWorkspace)
+    vi.mocked(worktreeService.createWorktree).mockReturnValue({
+      worktreePath: '/tmp/worktree',
+      base: 'origin',
+      branchCreated: true,
+    })
+    vi.mocked(workspaceService.listTasks).mockReturnValue([])
+    vi.mocked(workspaceService.getWorkspaceWithTasks).mockReturnValue(fakeWorkspaceWithTasks)
+    vi.mocked(settingsService.getEffectiveSettings).mockReturnValue({
+      model: 'claude-opus-4-6',
+      dangerouslySkipPermissions: true,
+      prPromptTemplate: '',
+      gitConventions: '',
+      sourceBranch: 'main',
+      devServer: null,
+      setupScript: '#!/bin/bash\nexit 1',
+      notionStatusProperty: '',
+      notionInProgressStatus: '',
+    })
+    vi.mocked(setupScriptService.runSetupScript).mockResolvedValue({ exitCode: 1 })
+
+    const res = await app.request('/api/workspaces', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        name: 'test-ws',
+        projectPath: '/tmp/test',
+        sourceBranch: 'main',
+        workingBranch: 'feature/test',
+        creationId: 'create-setup-fail',
+      }),
+    })
+
+    expect(res.status).toBe(201)
+    // The channel must name the real failure — not lie by going silent...
+    expect(wsService.emitEphemeral).toHaveBeenCalledWith(
+      'create-setup-fail',
+      'workspace:create-failed',
+      expect.objectContaining({ step: 'setup-script' }),
+    )
+    // ...nor claim success afterwards: `done` must never fire on this path.
+    const doneCalls = vi
+      .mocked(wsService.emitEphemeral)
+      .mock.calls.filter(
+        ([channel, type, payload]) =>
+          channel === 'create-setup-fail' &&
+          type === 'workspace:create-progress' &&
+          (payload as { step: string }).step === 'done',
+      )
+    expect(doneCalls).toEqual([])
+  })
+
+  it('emits create-failed, rolls back and never emits done when startAgent throws', async () => {
+    // Updated by task 2: a failed agent start used to leave the workspace in
+    // `error` status and still answer 201 — a half-created object lying to
+    // the user. It now rolls back everything and answers 500 instead.
+    vi.mocked(workspaceService.createWorkspace).mockReturnValue(fakeWorkspace)
+    vi.mocked(workspaceService.getWorkspace).mockReturnValue(fakeWorkspace)
+    vi.mocked(worktreeService.createWorktree).mockReturnValue({
+      worktreePath: '/tmp/worktree',
+      base: 'origin',
+      branchCreated: true,
+    })
+    vi.mocked(workspaceService.listTasks).mockReturnValue([])
+    vi.mocked(workspaceService.getWorkspaceWithTasks).mockReturnValue(fakeWorkspaceWithTasks)
+    vi.mocked(agentManager.startAgent).mockImplementationOnce(() => {
+      throw new Error('engine unavailable')
+    })
+
+    const res = await app.request('/api/workspaces', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        name: 'Test Workspace',
+        projectPath: '/tmp/project',
+        sourceBranch: 'main',
+        workingBranch: 'feature/test',
+        creationId: 'create-agent-fail',
+      }),
+    })
+
+    expect(res.status).toBe(500)
+    expect(workspaceService.deleteWorkspace).toHaveBeenCalledWith('ws-1')
+    expect(wsService.emitEphemeral).toHaveBeenCalledWith(
+      'create-agent-fail',
+      'workspace:create-failed',
+      expect.objectContaining({ step: 'start-agent' }),
+    )
+    const doneCalls = vi
+      .mocked(wsService.emitEphemeral)
+      .mock.calls.filter(
+        ([channel, type, payload]) =>
+          channel === 'create-agent-fail' &&
+          type === 'workspace:create-progress' &&
+          (payload as { step: string }).step === 'done',
+      )
+    expect(doneCalls).toEqual([])
+  })
+
+  it('names the last-known step when an unforeseen error escapes every per-step handler', async () => {
+    vi.mocked(workspaceService.createWorkspace).mockReturnValue(fakeWorkspace)
+    vi.mocked(worktreeService.createWorktree).mockReturnValue({
+      worktreePath: '/tmp/worktree',
+      base: 'origin',
+      branchCreated: true,
+    })
+    vi.mocked(workspaceService.listTasks).mockReturnValue([])
+    // Throws AFTER a successful startAgent call, outside any per-step try/catch —
+    // the outer catch must still name a step instead of responding with a bare error.
+    vi.mocked(workspaceService.getWorkspaceWithTasks).mockImplementationOnce(() => {
+      throw new Error('db connection lost')
+    })
+
+    const res = await app.request('/api/workspaces', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        name: 'Test Workspace',
+        projectPath: '/tmp/project',
+        sourceBranch: 'main',
+        workingBranch: 'feature/test',
+        creationId: 'create-unexpected',
+      }),
+    })
+
+    expect(res.status).toBe(500)
+    const data = await res.json()
+    expect(data.step).toBe('start-agent')
+    expect(wsService.emitEphemeral).toHaveBeenCalledWith(
+      'create-unexpected',
+      'workspace:create-failed',
+      expect.objectContaining({ step: 'start-agent', message: expect.stringContaining('db connection lost') }),
+    )
+  })
+
+  it('rolls back the record when an unforeseen error escapes before the agent starts', async () => {
+    // The outer catch used to answer 500 without demolishing anything, while
+    // the client told the user "the server undoes everything it created".
+    // Every step past `create-record` is now covered, not just the two that
+    // had their own handler.
+    vi.mocked(workspaceService.createWorkspace).mockReturnValue(fakeWorkspace)
+    vi.mocked(workspaceService.getWorkspace).mockReturnValue(fakeWorkspace)
+    vi.mocked(worktreeService.createWorktree).mockReturnValue({
+      worktreePath: '/tmp/worktree',
+      base: 'origin',
+      branchCreated: true,
+    })
+    // Throws while the prompt is being built — no agent is running yet, so the
+    // workspace really is half-created and demolishing it loses nothing.
+    vi.mocked(workspaceService.listTasks).mockImplementationOnce(() => {
+      throw new Error('db connection lost')
+    })
+
+    const res = await app.request('/api/workspaces', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        name: 'Test Workspace',
+        projectPath: '/tmp/project',
+        sourceBranch: 'main',
+        workingBranch: 'feature/test',
+        creationId: 'create-late-failure',
+      }),
+    })
+
+    expect(res.status).toBe(500)
+    const data = await res.json()
+    // The original cause still wins: the rollback rides along, never replaces.
+    expect(data.error).toContain('db connection lost')
+    expect(data.rollback.done).toBe(true)
+    // No orphan left in the DB, no orphan worktree, no orphan branch.
+    expect(workspaceService.deleteWorkspace).toHaveBeenCalledWith('ws-1')
+    expect(worktreeService.removeWorktree).toHaveBeenCalledWith('/tmp/project', '/tmp/project/.worktrees/feature/test')
+    expect(gitOps.deleteLocalBranch).toHaveBeenCalledWith('/tmp/project', 'feature/test')
+    expect(wsService.emitEphemeral).toHaveBeenCalledWith(
+      'create-late-failure',
+      'workspace:create-progress',
+      expect.objectContaining({ step: 'rollback' }),
+    )
+  })
+
+  it('never demolishes a workspace whose agent already started', async () => {
+    // The rollback exists to clean up half-created objects. Once the agent is
+    // running the object is live: a late throw (a lost DB read, a header) must
+    // return 500 and leave the worktree — with an agent working in it — alone.
+    // Demolishing here would destroy work in progress to tidy up a failed read.
+    vi.mocked(workspaceService.createWorkspace).mockReturnValue(fakeWorkspace)
+    vi.mocked(workspaceService.getWorkspace).mockReturnValue(fakeWorkspace)
+    vi.mocked(worktreeService.createWorktree).mockReturnValue({
+      worktreePath: '/tmp/worktree',
+      base: 'origin',
+      branchCreated: true,
+    })
+    vi.mocked(workspaceService.listTasks).mockReturnValue([])
+    // startAgent is left succeeding; the throw lands strictly after it.
+    vi.mocked(workspaceService.getWorkspaceWithTasks).mockImplementationOnce(() => {
+      throw new Error('db connection lost')
+    })
+
+    const res = await app.request('/api/workspaces', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        name: 'Test Workspace',
+        projectPath: '/tmp/project',
+        sourceBranch: 'main',
+        workingBranch: 'feature/test',
+        creationId: 'create-live-failure',
+      }),
+    })
+
+    expect(res.status).toBe(500)
+    const data = await res.json()
+    expect(data.error).toContain('db connection lost')
+    // Nothing was undone, and the response does not claim otherwise.
+    expect(data.rollback).toBeUndefined()
+    expect(workspaceService.deleteWorkspace).not.toHaveBeenCalled()
+    expect(worktreeService.removeWorktree).not.toHaveBeenCalled()
+    expect(gitOps.deleteLocalBranch).not.toHaveBeenCalled()
+  })
+
+  it('has nothing to roll back when the failure precedes the record', async () => {
+    const res = await app.request('/api/workspaces', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: 'not json at all',
+    })
+
+    expect(res.status).toBe(500)
+    const data = await res.json()
+    expect(data.step).toBe('validate')
+    // Nothing existed yet: the response must not claim an undo that never
+    // happened, and no demolition may run.
+    expect(data.rollback).toBeUndefined()
+    expect(workspaceService.deleteWorkspace).not.toHaveBeenCalled()
+  })
+
   it('does not run setup script when not configured', async () => {
     vi.mocked(workspaceService.createWorkspace).mockReturnValue(fakeWorkspace)
-    vi.mocked(worktreeService.createWorktree).mockReturnValue({ worktreePath: '/tmp/worktree', base: 'origin' })
+    vi.mocked(worktreeService.createWorktree).mockReturnValue({
+      worktreePath: '/tmp/worktree',
+      base: 'origin',
+      branchCreated: true,
+    })
     vi.mocked(workspaceService.listTasks).mockReturnValue([])
     vi.mocked(workspaceService.getWorkspaceWithTasks).mockReturnValue(fakeWorkspaceWithTasks)
     vi.mocked(settingsService.getEffectiveSettings).mockReturnValue({
@@ -1005,7 +1566,11 @@ describe('POST /api/workspaces', () => {
 
   it('POST / brainstorm prompt advertises kobo__set_workspace_agent_description with the user-description boundary', async () => {
     vi.mocked(workspaceService.createWorkspace).mockReturnValue(fakeWorkspace)
-    vi.mocked(worktreeService.createWorktree).mockReturnValue({ worktreePath: '/tmp/worktree', base: 'origin' })
+    vi.mocked(worktreeService.createWorktree).mockReturnValue({
+      worktreePath: '/tmp/worktree',
+      base: 'origin',
+      branchCreated: true,
+    })
     vi.mocked(workspaceService.listTasks).mockReturnValue([])
     vi.mocked(workspaceService.getWorkspaceWithTasks).mockReturnValue(fakeWorkspaceWithTasks)
 
@@ -1044,7 +1609,11 @@ describe('POST /api/workspaces', () => {
       brainstormModel: 'claude-opus-4-8',
       autoLoop: true,
     })
-    vi.mocked(worktreeService.createWorktree).mockReturnValue({ worktreePath: '/tmp/worktree', base: 'origin' })
+    vi.mocked(worktreeService.createWorktree).mockReturnValue({
+      worktreePath: '/tmp/worktree',
+      base: 'origin',
+      branchCreated: true,
+    })
     vi.mocked(workspaceService.listTasks).mockReturnValue([])
     vi.mocked(workspaceService.getWorkspaceWithTasks).mockReturnValue(fakeWorkspaceWithTasks)
 
@@ -1086,7 +1655,11 @@ describe('POST /api/workspaces', () => {
       brainstormModel: null,
       autoLoop: true,
     })
-    vi.mocked(worktreeService.createWorktree).mockReturnValue({ worktreePath: '/tmp/worktree', base: 'origin' })
+    vi.mocked(worktreeService.createWorktree).mockReturnValue({
+      worktreePath: '/tmp/worktree',
+      base: 'origin',
+      branchCreated: true,
+    })
     vi.mocked(workspaceService.listTasks).mockReturnValue([])
     vi.mocked(workspaceService.getWorkspaceWithTasks).mockReturnValue(fakeWorkspaceWithTasks)
 
@@ -1117,7 +1690,11 @@ describe('POST /api/workspaces', () => {
       brainstormModel: 'claude-opus-4-8',
       autoLoop: false,
     })
-    vi.mocked(worktreeService.createWorktree).mockReturnValue({ worktreePath: '/tmp/worktree', base: 'origin' })
+    vi.mocked(worktreeService.createWorktree).mockReturnValue({
+      worktreePath: '/tmp/worktree',
+      base: 'origin',
+      branchCreated: true,
+    })
     vi.mocked(workspaceService.listTasks).mockReturnValue([])
     vi.mocked(workspaceService.getWorkspaceWithTasks).mockReturnValue(fakeWorkspaceWithTasks)
 
@@ -1142,7 +1719,11 @@ describe('POST /api/workspaces', () => {
 
   it('accepts engine: codex on creation', async () => {
     vi.mocked(workspaceService.createWorkspace).mockReturnValue(fakeWorkspace)
-    vi.mocked(worktreeService.createWorktree).mockReturnValue({ worktreePath: '/tmp/worktree', base: 'origin' })
+    vi.mocked(worktreeService.createWorktree).mockReturnValue({
+      worktreePath: '/tmp/worktree',
+      base: 'origin',
+      branchCreated: true,
+    })
     vi.mocked(workspaceService.listTasks).mockReturnValue([])
     vi.mocked(workspaceService.getWorkspaceWithTasks).mockReturnValue(fakeWorkspaceWithTasks)
 
@@ -1284,7 +1865,11 @@ describe('POST /api/workspaces — Notion/Sentry initial prompt injection', () =
       ...fakeWorkspace,
       name: 'Renamed by Notion/Sentry',
     } as never)
-    vi.mocked(worktreeService.createWorktree).mockReturnValue({ worktreePath: '/tmp/wt', base: 'origin' })
+    vi.mocked(worktreeService.createWorktree).mockReturnValue({
+      worktreePath: '/tmp/wt',
+      base: 'origin',
+      branchCreated: true,
+    })
     vi.mocked(workspaceService.listTasks).mockReturnValue([])
     vi.mocked(workspaceService.getWorkspaceWithTasks).mockReturnValue(fakeWorkspaceWithTasks)
   }
@@ -2525,7 +3110,11 @@ describe('DELETE /api/workspaces/archived', () => {
 describe('git conventions file creation on workspace create', () => {
   beforeEach(() => {
     vi.mocked(workspaceService.createWorkspace).mockReturnValue(fakeWorkspace as never)
-    vi.mocked(worktreeService.createWorktree).mockReturnValue({ worktreePath: '/tmp/worktree', base: 'origin' })
+    vi.mocked(worktreeService.createWorktree).mockReturnValue({
+      worktreePath: '/tmp/worktree',
+      base: 'origin',
+      branchCreated: true,
+    })
     vi.mocked(workspaceService.listTasks).mockReturnValue([])
     vi.mocked(workspaceService.getWorkspaceWithTasks).mockReturnValue(fakeWorkspaceWithTasks as never)
     vi.mocked(workspaceService.updateWorkspaceStatus).mockReturnValue(fakeWorkspace as never)
@@ -4694,7 +5283,11 @@ describe('POST /api/workspaces — pre-flight URL validation', () => {
       sentryUrl: 'https://my-org.sentry.io/issues/99/',
     })
     vi.mocked(wsService.getWorkspaceWithTasks).mockReturnValue(fakeWorkspaceWithTasks)
-    vi.mocked(worktreeService.createWorktree).mockReturnValue({ worktreePath: '/tmp/wt', base: 'origin' })
+    vi.mocked(worktreeService.createWorktree).mockReturnValue({
+      worktreePath: '/tmp/wt',
+      base: 'origin',
+      branchCreated: true,
+    })
 
     await app.request('/api/workspaces', {
       method: 'POST',
@@ -5084,7 +5677,11 @@ describe('POST /api/workspaces — Working directory in brainstorm prompt', () =
   it('passes "Working directory: <path>" to agentManager.startAgent', async () => {
     vi.mocked(fs.existsSync).mockReturnValue(false)
     vi.mocked(workspaceService.createWorkspace).mockReturnValue(fakeWorkspace)
-    vi.mocked(worktreeService.createWorktree).mockReturnValue({ worktreePath: '/tmp/worktree', base: 'origin' })
+    vi.mocked(worktreeService.createWorktree).mockReturnValue({
+      worktreePath: '/tmp/worktree',
+      base: 'origin',
+      branchCreated: true,
+    })
     vi.mocked(workspaceService.listTasks).mockReturnValue([])
     vi.mocked(workspaceService.getWorkspaceWithTasks).mockReturnValue(fakeWorkspaceWithTasks)
 

--- a/src/__tests__/worktree-service.test.ts
+++ b/src/__tests__/worktree-service.test.ts
@@ -113,6 +113,21 @@ describe('createWorktree(projectPath, branchName, baseRef)', () => {
     expect(fs.existsSync(worktreePath)).toBe(true)
   })
 
+  // `branchCreated` decides whether a failed creation may `git branch -D` on
+  // rollback. Reporting `true` for a branch that was already there deletes work
+  // Kobo never owned, so the flag has to come from the code that knows which
+  // git command actually ran — not from the caller's optimistic assumption.
+  it('reports branchCreated=false when the branch already existed', () => {
+    gitSetup(repoDir, ['branch', 'feature/pre-existing'])
+    const { branchCreated } = createWorktree(repoDir, 'feature/pre-existing', 'origin/main')
+    expect(branchCreated).toBe(false)
+  })
+
+  it('reports branchCreated=true when it created the branch itself', () => {
+    const { branchCreated } = createWorktree(repoDir, 'feature/brand-new', 'origin/main')
+    expect(branchCreated).toBe(true)
+  })
+
   it('creates a worktree from a local branch when base ref has no origin/ prefix', () => {
     // `main` exists locally in repoDir (the clone). Base directly off it.
     const { worktreePath, base } = createWorktree(repoDir, 'feature/local-base', 'main')

--- a/src/client/src/__tests__/api.test.ts
+++ b/src/client/src/__tests__/api.test.ts
@@ -1,0 +1,111 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { ApiError, ApiTimeoutError, apiFetch } from '../utils/api'
+
+function jsonResponse(status: number, body: unknown, ok = status < 400) {
+  return {
+    ok,
+    status,
+    text: async () => JSON.stringify(body),
+  } as unknown as Response
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('apiFetch', () => {
+  it('keeps the server error message instead of an HTTP code', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(jsonResponse(422, { error: 'Failed to extract Notion page: token missing' })),
+    )
+
+    await expect(apiFetch('/api/workspaces')).rejects.toMatchObject({
+      name: 'ApiError',
+      status: 422,
+      message: 'Failed to extract Notion page: token missing',
+    })
+  })
+
+  it('carries the server discriminator code when present', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse(409, { error: 'dirty', code: 'dirty_worktree' })))
+
+    const err = await apiFetch('/api/workspaces/w1/rebase', { method: 'POST' }).catch((e: unknown) => e)
+    expect(err).toBeInstanceOf(ApiError)
+    expect((err as ApiError).code).toBe('dirty_worktree')
+  })
+
+  it('falls back to the HTTP code only when the body carries no message', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status: 502, text: async () => '' } as Response))
+
+    await expect(apiFetch('/api/settings')).rejects.toThrow('HTTP 502')
+  })
+
+  it('serialises a plain object body as JSON with the right header', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse(200, { ok: true }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    await apiFetch('/api/settings/global', { method: 'PUT', body: { editorCommand: 'code' } })
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(init.body).toBe('{"editorCommand":"code"}')
+    expect((init.headers as Record<string, string>)['Content-Type']).toBe('application/json')
+  })
+
+  it('aborts and reports a timeout when the server never answers', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(
+        (_url: string, init?: RequestInit) =>
+          new Promise((_resolve, reject) => {
+            init?.signal?.addEventListener('abort', () => reject(new DOMException('Aborted', 'AbortError')))
+          }),
+      ),
+    )
+
+    await expect(apiFetch('/api/workspaces', { timeoutMs: 5 })).rejects.toBeInstanceOf(ApiTimeoutError)
+  })
+
+  it('wraps a non-JSON body on a successful response in ApiError instead of throwing a raw SyntaxError', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({ ok: true, status: 200, text: async () => 'not json at all' } as Response),
+    )
+
+    const err = await apiFetch('/api/settings').catch((e: unknown) => e)
+    expect(err).toBeInstanceOf(ApiError)
+    expect((err as ApiError).message).toContain('non-JSON body')
+    expect((err as ApiError).status).toBe(200)
+  })
+
+  it('truncates an oversized non-JSON error body instead of leaking it whole', async () => {
+    const oversized = 'x'.repeat(1000)
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({ ok: false, status: 502, text: async () => oversized } as Response),
+    )
+
+    const err = await apiFetch('/api/settings').catch((e: unknown) => e)
+    expect(err).toBeInstanceOf(ApiError)
+    expect((err as ApiError).message.length).toBe(500)
+    expect((err as ApiError).body).toBe(oversized)
+  })
+
+  it('lets the caller abort without disguising it as a timeout', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(
+        (_url: string, init?: RequestInit) =>
+          new Promise((_resolve, reject) => {
+            init?.signal?.addEventListener('abort', () => reject(new DOMException('Aborted', 'AbortError')))
+          }),
+      ),
+    )
+
+    const controller = new AbortController()
+    const promise = apiFetch('/api/workspaces', { signal: controller.signal, timeoutMs: 10_000 })
+    controller.abort()
+
+    await expect(promise).rejects.toSatisfy((err: unknown) => !(err instanceof ApiTimeoutError))
+  })
+})

--- a/src/client/src/__tests__/create-overrides.test.ts
+++ b/src/client/src/__tests__/create-overrides.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest'
+import { resolveCreateOverrides } from '../utils/create-overrides'
+
+describe('resolveCreateOverrides', () => {
+  it('leaves the user choices untouched when nothing forces an override', () => {
+    expect(
+      resolveCreateOverrides({
+        useExistingWorktree: false,
+        skipSetupScript: false,
+        autoLoop: false,
+        agentPermissionMode: 'plan',
+      }),
+    ).toEqual({ skipSetupScript: false, agentPermissionMode: 'plan', applied: [] })
+  })
+
+  it('forces skipSetupScript when reusing an existing worktree, and says so', () => {
+    const resolved = resolveCreateOverrides({
+      useExistingWorktree: true,
+      skipSetupScript: false,
+      autoLoop: false,
+      agentPermissionMode: 'bypass',
+    })
+    expect(resolved.skipSetupScript).toBe(true)
+    expect(resolved.applied).toContain('setup-script-forced')
+  })
+
+  it('downgrades plan to bypass under auto-loop, and says so', () => {
+    const resolved = resolveCreateOverrides({
+      useExistingWorktree: false,
+      skipSetupScript: false,
+      autoLoop: true,
+      agentPermissionMode: 'plan',
+    })
+    expect(resolved.agentPermissionMode).toBe('bypass')
+    expect(resolved.applied).toContain('permission-mode-downgraded')
+  })
+
+  it('does not claim a downgrade when auto-loop runs on a non-plan mode', () => {
+    const resolved = resolveCreateOverrides({
+      useExistingWorktree: false,
+      skipSetupScript: false,
+      autoLoop: true,
+      agentPermissionMode: 'strict',
+    })
+    expect(resolved.agentPermissionMode).toBe('strict')
+    expect(resolved.applied).toEqual([])
+  })
+
+  it('does not claim a forced skip when the user asked for it themselves', () => {
+    const resolved = resolveCreateOverrides({
+      useExistingWorktree: false,
+      skipSetupScript: true,
+      autoLoop: false,
+      agentPermissionMode: 'bypass',
+    })
+    expect(resolved.skipSetupScript).toBe(true)
+    expect(resolved.applied).toEqual([])
+  })
+
+  it('applies both overrides at once when reusing a worktree and auto-looping on plan', () => {
+    const resolved = resolveCreateOverrides({
+      useExistingWorktree: true,
+      skipSetupScript: false,
+      autoLoop: true,
+      agentPermissionMode: 'plan',
+    })
+    expect(resolved.skipSetupScript).toBe(true)
+    expect(resolved.agentPermissionMode).toBe('bypass')
+    expect(resolved.applied).toEqual(expect.arrayContaining(['setup-script-forced', 'permission-mode-downgraded']))
+    expect(resolved.applied).toHaveLength(2)
+  })
+})

--- a/src/client/src/__tests__/git-output.test.ts
+++ b/src/client/src/__tests__/git-output.test.ts
@@ -1,0 +1,54 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { needsScrollableOutput } from '../utils/git-output'
+
+describe('needsScrollableOutput', () => {
+  it('keeps a short one-line failure in a toast', () => {
+    expect(needsScrollableOutput('fatal: not a git repository')).toBe(false)
+  })
+
+  it('sends multi-line git output to a scrollable dialog', () => {
+    const conflict = [
+      'CONFLICT (content): Merge conflict in src/a.ts',
+      'CONFLICT (content): Merge conflict in src/b.ts',
+      'Automatic merge failed; fix conflicts and then commit the result.',
+    ].join('\n')
+    expect(needsScrollableOutput(conflict)).toBe(true)
+  })
+
+  it('sends a long single line to a scrollable dialog too', () => {
+    expect(needsScrollableOutput('x'.repeat(201))).toBe(true)
+  })
+
+  it('treats an empty message as inline', () => {
+    expect(needsScrollableOutput('')).toBe(false)
+    expect(needsScrollableOutput('   ')).toBe(false)
+  })
+})
+
+// The old file content used to stay on screen under the NEW file's name,
+// because disposeEditor() ran AFTER the request. Ordering is the whole fix,
+// so lock it as source-level invariant — the component itself is not unit
+// tested (type-check + manual smoke, per the project's testing discipline).
+describe('DiffViewer load ordering', () => {
+  const source = readFileSync(join(process.cwd(), 'src/components/DiffViewer.vue'), 'utf-8')
+
+  it('disposes the editor before requesting the new file', () => {
+    // `indexOf('disposeEditor()')` alone would match the FUNCTION DECLARATION
+    // (`function disposeEditor() {`), which always precedes every call site in
+    // source order regardless of the bug — so it can't tell a fixed file from
+    // a broken one. Skip past the declaration to find the first CALL site.
+    const definitionIdx = source.indexOf('function disposeEditor()')
+    expect(definitionIdx).toBeGreaterThan(-1)
+    const disposeCallIdx = source.indexOf('disposeEditor()', definitionIdx + 'function disposeEditor()'.length)
+    const fetchIdx = source.indexOf('/diff-file?')
+    expect(disposeCallIdx).toBeGreaterThan(-1)
+    expect(fetchIdx).toBeGreaterThan(-1)
+    expect(disposeCallIdx).toBeLessThan(fetchIdx)
+  })
+
+  it('records a load failure in a reactive state instead of only the console', () => {
+    expect(source).toMatch(/fileLoadError\s*(\.value)?\s*=/)
+  })
+})

--- a/src/client/src/__tests__/i18n-parity.test.ts
+++ b/src/client/src/__tests__/i18n-parity.test.ts
@@ -1,0 +1,30 @@
+// The project ships five locales and the rule is absolute: every user-visible
+// string goes through $t() with a key present in ALL of them. Nothing enforced
+// that until now — i18n.test.ts checks five accessibility keys and
+// i18n-message-compile.test.ts never compares locales against each other.
+import { describe, expect, it } from 'vitest'
+import de from '../i18n/de'
+import en from '../i18n/en'
+import es from '../i18n/es'
+import fr from '../i18n/fr'
+import itLocale from '../i18n/it'
+
+const reference = en as Record<string, string>
+const others = { fr, de, es, it: itLocale } as const
+
+describe('i18n locale parity', () => {
+  it.each(Object.entries(others))('locale %s has exactly the keys of en', (_name, messages) => {
+    const dictionary = messages as Record<string, string>
+    const missing = Object.keys(reference).filter((k) => !(k in dictionary))
+    const extra = Object.keys(dictionary).filter((k) => !(k in reference))
+    expect({ missing, extra }).toEqual({ missing: [], extra: [] })
+  })
+
+  it.each(Object.entries({ en, ...others }))('locale %s has no empty message', (_name, messages) => {
+    const dictionary = messages as Record<string, string>
+    const empty = Object.entries(dictionary)
+      .filter(([, value]) => typeof value !== 'string' || value.trim().length === 0)
+      .map(([key]) => key)
+    expect(empty).toEqual([])
+  })
+})

--- a/src/client/src/__tests__/notify-retryable.test.ts
+++ b/src/client/src/__tests__/notify-retryable.test.ts
@@ -1,0 +1,71 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const createMock = vi.fn()
+vi.mock('quasar', () => ({ Notify: { create: (...args: unknown[]) => createMock(...args) } }))
+
+import { notifyRetryableError } from '../utils/notifications'
+
+describe('notifyRetryableError', () => {
+  beforeEach(() => createMock.mockClear())
+
+  it('attaches a retry action that calls back', () => {
+    const onRetry = vi.fn()
+    notifyRetryableError('Rebase failed', { retryLabel: 'Retry', onRetry, dismissLabel: 'Dismiss' })
+
+    expect(createMock).toHaveBeenCalledOnce()
+    const config = createMock.mock.calls[0][0] as {
+      type: string
+      message: string
+      timeout: number
+      actions: Array<{ label: string; handler: () => void }>
+    }
+    expect(config.type).toBe('negative')
+    expect(config.message).toBe('Rebase failed')
+    const retry = config.actions.find((a) => a.label === 'Retry')
+    expect(retry).toBeDefined()
+    retry?.handler()
+    expect(onRetry).toHaveBeenCalledOnce()
+  })
+
+  it('stays on screen long enough to be acted on', () => {
+    notifyRetryableError('Push failed', { retryLabel: 'Retry', onRetry: vi.fn(), dismissLabel: 'Dismiss' })
+    const config = createMock.mock.calls[0][0] as { timeout: number }
+    // A six-second toast the user must click is a trap, not an affordance.
+    expect(config.timeout).toBe(0)
+  })
+
+  it('adds an optional details action when a handler is supplied', () => {
+    const onDetails = vi.fn()
+    notifyRetryableError('Merge failed', {
+      retryLabel: 'Retry',
+      onRetry: vi.fn(),
+      detailsLabel: 'Details',
+      onDetails,
+      dismissLabel: 'Dismiss',
+    })
+    const config = createMock.mock.calls[0][0] as { actions: Array<{ label: string; handler: () => void }> }
+    const details = config.actions.find((a) => a.label === 'Details')
+    expect(details).toBeDefined()
+    details?.handler()
+    expect(onDetails).toHaveBeenCalledOnce()
+  })
+
+  it('omits the details action when no handler is supplied', () => {
+    notifyRetryableError('Pull failed', {
+      retryLabel: 'Retry',
+      onRetry: vi.fn(),
+      detailsLabel: 'Details',
+      dismissLabel: 'Dismiss',
+    })
+    const config = createMock.mock.calls[0][0] as { actions: Array<{ label: string }> }
+    expect(config.actions.map((a) => a.label)).toEqual(['Retry', 'Dismiss'])
+  })
+
+  it('uses the caller-supplied dismiss label, never a hardcoded English one', () => {
+    // This module has no i18n context: an internal fallback would be a string
+    // that no locale file can translate.
+    notifyRetryableError('Fetch failed', { retryLabel: 'Réessayer', onRetry: vi.fn(), dismissLabel: 'Ignorer' })
+    const config = createMock.mock.calls[0][0] as { actions: Array<{ label: string }> }
+    expect(config.actions.map((a) => a.label)).toEqual(['Réessayer', 'Ignorer'])
+  })
+})

--- a/src/client/src/__tests__/settings-store.test.ts
+++ b/src/client/src/__tests__/settings-store.test.ts
@@ -1,5 +1,5 @@
 import { createPinia, setActivePinia } from 'pinia'
-import { beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { useSettingsStore } from '../stores/settings'
 
 describe('settings store', () => {
@@ -7,6 +7,8 @@ describe('settings store', () => {
     setActivePinia(createPinia())
     localStorage.clear()
   })
+
+  afterEach(() => vi.unstubAllGlobals())
 
   describe('showVerboseSystemMessages', () => {
     it('defaults to false when localStorage is empty', () => {
@@ -149,6 +151,83 @@ describe('settings store', () => {
       audioPrMergedSound: 'inherit',
       audioPrMergedEnabled: false,
       audioPrMergedVolume: 1,
+    })
+  })
+
+  describe('load failure is not an empty configuration', () => {
+    it('records the server message and refuses to consider itself loaded', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({
+          ok: false,
+          status: 500,
+          text: async () => JSON.stringify({ error: 'settings.json is unreadable' }),
+        } as unknown as Response),
+      )
+      const store = useSettingsStore()
+
+      await store.fetchSettings()
+
+      expect(store.loadError).toBe('settings.json is unreadable')
+      expect(store.loaded).toBe(false)
+      expect(store.loading).toBe(false)
+    })
+
+    it('refuses to save global settings that were never loaded', async () => {
+      const fetchMock = vi.fn()
+      vi.stubGlobal('fetch', fetchMock)
+      const store = useSettingsStore()
+      store.loaded = false
+
+      // The whole point: a failed load leaves the form on DEFAULTS, and saving
+      // those defaults would silently destroy the real configuration on disk.
+      await expect(store.updateGlobal({ editorCommand: 'code' })).rejects.toThrow(/never loaded/i)
+      expect(fetchMock).not.toHaveBeenCalled()
+    })
+
+    it('refuses to write a project whose settings were never loaded', async () => {
+      const fetchMock = vi.fn()
+      vi.stubGlobal('fetch', fetchMock)
+      const store = useSettingsStore()
+      store.loaded = false
+
+      await expect(store.upsertProject('/tmp/proj', { displayName: 'X' })).rejects.toThrow(/never loaded/i)
+      await expect(store.deleteProject('/tmp/proj')).rejects.toThrow(/never loaded/i)
+      expect(fetchMock).not.toHaveBeenCalled()
+    })
+
+    it('clears the failure and unlocks writes once a load succeeds', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({
+          ok: true,
+          status: 200,
+          text: async () => JSON.stringify({ global: { editorCommand: 'vim' }, projects: [] }),
+        } as unknown as Response),
+      )
+      const store = useSettingsStore()
+      store.loadError = 'previous failure'
+
+      await store.fetchSettings()
+
+      expect(store.loadError).toBeNull()
+      expect(store.loaded).toBe(true)
+      expect(store.global.editorCommand).toBe('vim')
+    })
+
+    it('surfaces the server message when saving fails', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({
+          ok: false,
+          status: 400,
+          text: async () => JSON.stringify({ error: 'worktreesPath must be relative' }),
+        } as unknown as Response),
+      )
+      const store = useSettingsStore()
+      store.loaded = true
+
+      await expect(store.updateGlobal({ worktreesPath: '/abs' })).rejects.toThrow('worktreesPath must be relative')
     })
   })
 })

--- a/src/client/src/__tests__/terminal-reconnect.test.ts
+++ b/src/client/src/__tests__/terminal-reconnect.test.ts
@@ -1,0 +1,65 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import {
+  shouldConnectOnFocus,
+  TERMINAL_RECONNECT_MAX_ATTEMPTS,
+  terminalReconnectDelayMs,
+} from '../utils/terminal-reconnect'
+
+describe('terminalReconnectDelayMs', () => {
+  it('reconnects almost immediately on the first attempt', () => {
+    expect(terminalReconnectDelayMs(1)).toBe(500)
+  })
+
+  it('backs off so a dead backend is not hammered', () => {
+    const delays = [1, 2, 3, 4].map(terminalReconnectDelayMs)
+    expect(delays).toEqual([500, 1000, 2000, 4000])
+  })
+
+  it('caps the delay so a returning backend is picked up quickly', () => {
+    expect(terminalReconnectDelayMs(TERMINAL_RECONNECT_MAX_ATTEMPTS)).toBeLessThanOrEqual(10_000)
+  })
+
+  it('gives up past the last attempt so the user is not left waiting forever', () => {
+    expect(terminalReconnectDelayMs(TERMINAL_RECONNECT_MAX_ATTEMPTS + 1)).toBeNull()
+  })
+})
+
+describe('TerminalPanel close handling', () => {
+  const source = readFileSync(join(process.cwd(), 'src/components/TerminalPanel.vue'), 'utf-8')
+
+  it('does more on close than blanking the socket reference', () => {
+    expect(source).toMatch(/ws\.onclose\s*=\s*\(\)\s*=>\s*\{[\s\S]{0,600}scheduleReconnect/)
+  })
+
+  it('exposes a disconnected state distinct from exited', () => {
+    expect(source).toMatch(/disconnected/)
+    expect(source).toMatch(/terminal\.disconnected/)
+  })
+
+  it('cancels a pending reconnect timer before deciding to connect on workspace focus', () => {
+    // Regression: switching away from a workspace while a reconnect backoff
+    // is armed, then switching back, used to fire an immediate connectWs
+    // from this watcher on top of the still-pending timer — two sockets
+    // racing to replace the same entry.
+    const watchBlock = source.match(/watch\(workspaceId,[\s\S]*?\n\}\)/)?.[0]
+    expect(watchBlock).toBeDefined()
+    expect(watchBlock).toMatch(/clearReconnectTimer/)
+    expect(watchBlock).toMatch(/shouldConnectOnFocus/)
+  })
+})
+
+describe('shouldConnectOnFocus', () => {
+  it('reconnects a closed-but-alive terminal on focus', () => {
+    expect(shouldConnectOnFocus({ wsOpen: false, exited: false })).toBe(true)
+  })
+
+  it('does not reconnect an already-open socket', () => {
+    expect(shouldConnectOnFocus({ wsOpen: true, exited: false })).toBe(false)
+  })
+
+  it('never reconnects a shell that exited on its own', () => {
+    expect(shouldConnectOnFocus({ wsOpen: false, exited: true })).toBe(false)
+  })
+})

--- a/src/client/src/__tests__/unsaved-guard.test.ts
+++ b/src/client/src/__tests__/unsaved-guard.test.ts
@@ -1,0 +1,72 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import {
+  _clearUnsavedScopesForTest,
+  hasUnsavedWork,
+  listDirtyScopes,
+  registerUnsavedScope,
+  unregisterUnsavedScope,
+} from '../utils/unsaved-guard'
+
+describe('unsaved-guard registry', () => {
+  beforeEach(() => _clearUnsavedScopesForTest())
+
+  it('reports nothing when no scope is registered', () => {
+    expect(hasUnsavedWork()).toBe(false)
+    expect(listDirtyScopes()).toEqual([])
+  })
+
+  it('reports a scope only while its predicate says dirty', () => {
+    let dirty = false
+    registerUnsavedScope('settings:global', () => dirty)
+
+    expect(hasUnsavedWork()).toBe(false)
+    dirty = true
+    expect(hasUnsavedWork()).toBe(true)
+    expect(listDirtyScopes()).toEqual(['settings:global'])
+  })
+
+  it('reports EVERY dirty scope, not just the active one', () => {
+    // The settings page used to compute its banner per tab, so switching tabs
+    // hid the warning and the user believed they had saved.
+    registerUnsavedScope('settings:global', () => true)
+    registerUnsavedScope('settings:project', () => true)
+    registerUnsavedScope('diff:file', () => false)
+
+    expect(listDirtyScopes().sort()).toEqual(['settings:global', 'settings:project'])
+  })
+
+  it('forgets a scope once it is unregistered', () => {
+    registerUnsavedScope('create:form', () => true)
+    unregisterUnsavedScope('create:form')
+    expect(hasUnsavedWork()).toBe(false)
+  })
+
+  it('tolerates unregistering a scope that is already gone', () => {
+    // The create page unregisters `create:form` on its success path (so the
+    // navigation it triggers itself never prompts) AND on unmount. The second
+    // call must be a harmless no-op that leaves the rest of the registry
+    // untouched.
+    registerUnsavedScope('create:form', () => true)
+    registerUnsavedScope('settings:global', () => true)
+
+    unregisterUnsavedScope('create:form')
+    expect(() => unregisterUnsavedScope('create:form')).not.toThrow()
+    unregisterUnsavedScope('never-registered')
+
+    expect(listDirtyScopes()).toEqual(['settings:global'])
+  })
+
+  it('replaces the predicate when the same id registers twice', () => {
+    registerUnsavedScope('diff:file', () => true)
+    registerUnsavedScope('diff:file', () => false)
+    expect(hasUnsavedWork()).toBe(false)
+  })
+
+  it('never lets a throwing predicate block navigation', () => {
+    registerUnsavedScope('broken', () => {
+      throw new Error('component was torn down mid-check')
+    })
+    expect(() => hasUnsavedWork()).not.toThrow()
+    expect(hasUnsavedWork()).toBe(false)
+  })
+})

--- a/src/client/src/__tests__/workspace-store.test.ts
+++ b/src/client/src/__tests__/workspace-store.test.ts
@@ -78,6 +78,54 @@ describe('workspace store', () => {
     })
   })
 
+  describe('creation progress', () => {
+    it('stores the step reported by the server so the create page can name it', () => {
+      const store = useWorkspaceStore()
+      expect(store.creationProgress).toBeNull()
+
+      store.setCreationProgress({ creationId: 'c1', step: 'setup-script', index: 11, total: 14 })
+      expect(store.creationProgress).toEqual({ creationId: 'c1', step: 'setup-script', index: 11, total: 14 })
+
+      store.clearCreationProgress()
+      expect(store.creationProgress).toBeNull()
+    })
+
+    it('rejects with the server message and the failing step name', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({
+          ok: false,
+          status: 500,
+          headers: { get: () => null },
+          json: async () => ({
+            error:
+              'Failed to start the agent: claude: command not found. The workspace, its worktree and its branch were removed.',
+            step: 'start-agent',
+            rollback: { done: true, warnings: [] },
+          }),
+        } as unknown as Response),
+      )
+      const store = useWorkspaceStore()
+
+      // The server destroys everything it created on this failure, so there is
+      // no workspace to push into the list — only an error to show, naming the
+      // step that broke.
+      const err = await store
+        .createWorkspace({
+          name: 'w9',
+          projectPath: '/tmp/proj',
+          sourceBranch: 'main',
+          workingBranch: 'feature/x',
+          creationId: 'c2',
+        })
+        .catch((e: unknown) => e)
+
+      expect((err as Error).message).toContain('claude: command not found')
+      expect((err as { code?: string }).code).toBe('start-agent')
+      expect(store.workspaces).toEqual([])
+    })
+  })
+
   describe('selectWorkspace', () => {
     it('clears sessions synchronously before the replacement fetch resolves', () => {
       const store = useWorkspaceStore()
@@ -1081,13 +1129,15 @@ describe('workspace store', () => {
       const second = store.fetchWorkspaceDetails('w1')
       resolveSecond({
         ok: true,
-        json: async () => ({ workspace: makeWorkspace({ id: 'w1', name: 'new' }), tasks: [] }),
-      } as Response)
+        status: 200,
+        text: async () => JSON.stringify({ workspace: makeWorkspace({ id: 'w1', name: 'new' }), tasks: [] }),
+      } as unknown as Response)
       await second
       resolveFirst({
         ok: true,
-        json: async () => ({ workspace: makeWorkspace({ id: 'w1', name: 'old' }), tasks: [] }),
-      } as Response)
+        status: 200,
+        text: async () => JSON.stringify({ workspace: makeWorkspace({ id: 'w1', name: 'old' }), tasks: [] }),
+      } as unknown as Response)
       await first
 
       expect(store.workspaces[0]?.name).toBe('new')
@@ -1102,12 +1152,14 @@ describe('workspace store', () => {
         'fetch',
         vi.fn().mockResolvedValue({
           ok: true,
-          json: async () => ({
-            ...makeWorkspace({ id: 'w1' }),
-            tasks: [],
-            agentLiveness: { status: 'running', agentSessionId: 's1', startedAt: 't0', lastEventAt: 't1' },
-          }),
-        } as Response),
+          status: 200,
+          text: async () =>
+            JSON.stringify({
+              ...makeWorkspace({ id: 'w1' }),
+              tasks: [],
+              agentLiveness: { status: 'running', agentSessionId: 's1', startedAt: 't0', lastEventAt: 't1' },
+            }),
+        } as unknown as Response),
       )
 
       await store.fetchWorkspaceDetails('w1')
@@ -1130,8 +1182,9 @@ describe('workspace store', () => {
         'fetch',
         vi.fn().mockResolvedValue({
           ok: true,
-          json: async () => ({ ...makeWorkspace({ id: 'w1' }), tasks: [], agentLiveness: null }),
-        } as Response),
+          status: 200,
+          text: async () => JSON.stringify({ ...makeWorkspace({ id: 'w1' }), tasks: [], agentLiveness: null }),
+        } as unknown as Response),
       )
 
       await store.fetchWorkspaceDetails('w1')
@@ -1165,12 +1218,14 @@ describe('workspace store', () => {
 
       resolveFetch({
         ok: true,
-        json: async () => ({
-          ...makeWorkspace({ id: 'w1', status: 'executing' }),
-          tasks: [],
-          agentLiveness: { status: 'running', agentSessionId: 's1', startedAt: 't0', lastEventAt: 't1' },
-        }),
-      } as Response)
+        status: 200,
+        text: async () =>
+          JSON.stringify({
+            ...makeWorkspace({ id: 'w1', status: 'executing' }),
+            tasks: [],
+            agentLiveness: { status: 'running', agentSessionId: 's1', startedAt: 't0', lastEventAt: 't1' },
+          }),
+      } as unknown as Response)
       await fetching
 
       // The stale `executing` from the in-flight request must not clobber
@@ -1259,8 +1314,10 @@ describe('workspace store', () => {
       store.workspaces = [makeWorkspace({ id: 'w1', status: 'idle' })]
       const fetchMock = vi.fn().mockResolvedValue({
         ok: true,
-        json: async () => ({ ...makeWorkspace({ id: 'w1', status: 'executing' }), tasks: [], agentLiveness: null }),
-      } as Response)
+        status: 200,
+        text: async () =>
+          JSON.stringify({ ...makeWorkspace({ id: 'w1', status: 'executing' }), tasks: [], agentLiveness: null }),
+      } as unknown as Response)
       vi.stubGlobal('fetch', fetchMock)
 
       store.updateWorkspaceFromEvent('w1', { status: 'executing' })
@@ -1277,8 +1334,9 @@ describe('workspace store', () => {
       const store = useWorkspaceStore()
       const fetchMock = vi.fn().mockResolvedValue({
         ok: true,
-        json: () =>
-          Promise.resolve({
+        status: 200,
+        text: async () =>
+          JSON.stringify({
             workspaces: [
               makeWorkspace({ id: 'ws-1', status: 'idle' }),
               makeWorkspace({ id: 'ws-2', status: 'executing' }),
@@ -1306,18 +1364,20 @@ describe('workspace store', () => {
       store.workspaces = [makeWorkspace({ id: 'w1', status: 'idle' })]
       const fetchMock = vi.fn().mockResolvedValue({
         ok: true,
-        json: async () => ({
-          ...makeWorkspace({ id: 'w1', status: 'executing' }),
-          tasks: [],
-          agentLiveness: { status: 'running', agentSessionId: 's1', startedAt: 't0', lastEventAt: 't1' },
-        }),
-      } as Response)
+        status: 200,
+        text: async () =>
+          JSON.stringify({
+            ...makeWorkspace({ id: 'w1', status: 'executing' }),
+            tasks: [],
+            agentLiveness: { status: 'running', agentSessionId: 's1', startedAt: 't0', lastEventAt: 't1' },
+          }),
+      } as unknown as Response)
       vi.stubGlobal('fetch', fetchMock)
 
       store.updateWorkspaceFromEvent('w1', { status: 'executing' })
       await vi.waitFor(() => expect(store.agentLiveness.w1).toBeDefined())
 
-      expect(fetchMock).toHaveBeenCalledWith('/api/workspaces/w1')
+      expect(fetchMock).toHaveBeenCalledWith('/api/workspaces/w1', expect.anything())
       expect(store.agentLiveness.w1).toEqual({
         status: 'running',
         agentSessionId: 's1',
@@ -1723,8 +1783,9 @@ describe('workspace store', () => {
     it('fetchWorkspacesInfo populates workspaces, prSnapshots and gitStatsCache', async () => {
       const fetchMock = vi.fn().mockResolvedValue({
         ok: true,
-        json: () =>
-          Promise.resolve({
+        status: 200,
+        text: async () =>
+          JSON.stringify({
             workspaces: [makeWorkspace({ id: 'ws-1', status: 'idle' })],
             prSnapshots: { 'ws-1': { number: 7, state: 'OPEN' } },
             gitStats: { 'ws-1': { commitCount: 9 } },
@@ -1744,8 +1805,9 @@ describe('workspace store', () => {
     it('fetchWorkspacesInfo never replaces fresher local git-stats with an older poll snapshot', async () => {
       const fetchMock = vi.fn().mockResolvedValue({
         ok: true,
-        json: () =>
-          Promise.resolve({
+        status: 200,
+        text: async () =>
+          JSON.stringify({
             workspaces: [makeWorkspace({ id: 'ws-1', status: 'idle' })],
             prSnapshots: {},
             // Stale server snapshot (older computedAt) — e.g. pre-rebase.
@@ -1767,8 +1829,9 @@ describe('workspace store', () => {
     it('fetchWorkspacesInfo applies a newer poll snapshot over older local git-stats', async () => {
       const fetchMock = vi.fn().mockResolvedValue({
         ok: true,
-        json: () =>
-          Promise.resolve({
+        status: 200,
+        text: async () =>
+          JSON.stringify({
             workspaces: [makeWorkspace({ id: 'ws-1', status: 'idle' })],
             prSnapshots: {},
             gitStats: { 'ws-1': { commitCount: 8, computedAt: 300 } },
@@ -1810,22 +1873,26 @@ describe('workspace store', () => {
       // Second (newer) call's network response lands first.
       resolveSecond({
         ok: true,
-        json: async () => ({
-          workspaces: [{ id: 'ws_1', name: 'Test', status: 'executing' }],
-          prSnapshots: { ws_1: { number: 2, updatedAt: '2026-08-07T00:01:00.000Z' } },
-          gitStats: {},
-        }),
+        status: 200,
+        text: async () =>
+          JSON.stringify({
+            workspaces: [{ id: 'ws_1', name: 'Test', status: 'executing' }],
+            prSnapshots: { ws_1: { number: 2, updatedAt: '2026-08-07T00:01:00.000Z' } },
+            gitStats: {},
+          }),
       })
       await secondCall
 
       // First (older, now-stale) call's response lands after.
       resolveFirst({
         ok: true,
-        json: async () => ({
-          workspaces: [{ id: 'ws_1', name: 'Test', status: 'idle' }],
-          prSnapshots: { ws_1: { number: 1, updatedAt: '2026-08-07T00:00:00.000Z' } },
-          gitStats: {},
-        }),
+        status: 200,
+        text: async () =>
+          JSON.stringify({
+            workspaces: [{ id: 'ws_1', name: 'Test', status: 'idle' }],
+            prSnapshots: { ws_1: { number: 1, updatedAt: '2026-08-07T00:00:00.000Z' } },
+            gitStats: {},
+          }),
       })
       await firstCall
 
@@ -1848,11 +1915,13 @@ describe('workspace store', () => {
       store.updateWorkspaceFromEvent('ws-live', { status: 'executing' })
       resolve({
         ok: true,
-        json: async () => ({
-          workspaces: [makeWorkspace({ id: 'ws-live', status: 'idle' })],
-          prSnapshots: {},
-          gitStats: {},
-        }),
+        status: 200,
+        text: async () =>
+          JSON.stringify({
+            workspaces: [makeWorkspace({ id: 'ws-live', status: 'idle' })],
+            prSnapshots: {},
+            gitStats: {},
+          }),
       } as Response)
       await poll
 
@@ -1882,11 +1951,13 @@ describe('workspace store', () => {
       await store.refreshPrSnapshot('ws-live')
       resolvePoll({
         ok: true,
-        json: async () => ({
-          workspaces: [makeWorkspace({ id: 'ws-live', status: 'idle' })],
-          prSnapshots: { 'ws-live': { number: 1, state: 'OPEN', updatedAt: '2026-08-07T00:00:00.000Z' } },
-          gitStats: {},
-        }),
+        status: 200,
+        text: async () =>
+          JSON.stringify({
+            workspaces: [makeWorkspace({ id: 'ws-live', status: 'idle' })],
+            prSnapshots: { 'ws-live': { number: 1, state: 'OPEN', updatedAt: '2026-08-07T00:00:00.000Z' } },
+            gitStats: {},
+          }),
       } as Response)
       await poll
 
@@ -1906,6 +1977,210 @@ describe('workspace store', () => {
       await store.refreshPrSnapshot('ws-1')
 
       expect(store.prSnapshots['ws-1']).toBeUndefined()
+    })
+  })
+
+  describe('list load failure', () => {
+    it('records the server message instead of showing an empty account', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({
+          ok: false,
+          status: 503,
+          text: async () => JSON.stringify({ error: 'database is locked' }),
+        } as unknown as Response),
+      )
+      const store = useWorkspaceStore()
+
+      await store.fetchWorkspaces()
+
+      expect(store.listLoadError).toBe('database is locked')
+      expect(store.workspaces).toEqual([])
+      expect(store.loading).toBe(false)
+    })
+
+    it('reports a transport failure with something other than an HTTP code', async () => {
+      vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new TypeError('Failed to fetch')))
+      const store = useWorkspaceStore()
+
+      await store.fetchWorkspaces()
+
+      expect(store.listLoadError).toBe('Failed to fetch')
+    })
+
+    it('clears the failure once a load succeeds', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({
+          ok: true,
+          status: 200,
+          text: async () => JSON.stringify({ workspaces: [makeWorkspace({ id: 'w1' })] }),
+        } as unknown as Response),
+      )
+      const store = useWorkspaceStore()
+      store.listLoadError = 'previous failure'
+
+      await store.fetchWorkspaces()
+
+      expect(store.listLoadError).toBeNull()
+      expect(store.workspaces).toHaveLength(1)
+    })
+
+    it('retryLoadWorkspaces reloads both the active and archived lists', async () => {
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        text: async () => JSON.stringify({ workspaces: [] }),
+      } as unknown as Response)
+      vi.stubGlobal('fetch', fetchMock)
+      const store = useWorkspaceStore()
+      store.archivedLoaded = true
+
+      await store.retryLoadWorkspaces()
+
+      const urls = fetchMock.mock.calls.map(([url]) => url as string)
+      expect(urls).toContain('/api/workspaces')
+      expect(urls).toContain('/api/workspaces/archived')
+    })
+
+    it('keeps the server message when starting a workspace fails', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({
+          ok: false,
+          status: 409,
+          text: async () => JSON.stringify({ error: 'An agent is already running for this workspace' }),
+        } as unknown as Response),
+      )
+      const store = useWorkspaceStore()
+
+      await expect(store.startWorkspace('w1')).rejects.toThrow('An agent is already running for this workspace')
+    })
+  })
+
+  describe('poll load failure', () => {
+    /** `/api/workspaces/info` mock: `null` fails the request, an object answers it. */
+    function stubInfoFetch(responses: Array<null | Record<string, unknown>>) {
+      let call = 0
+      const fetchMock = vi.fn(() => {
+        const body = responses[Math.min(call++, responses.length - 1)]
+        if (body === null || body === undefined) {
+          return Promise.resolve({
+            ok: false,
+            status: 502,
+            text: async () => JSON.stringify({ error: 'backend is gone' }),
+          } as unknown as Response)
+        }
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          text: async () => JSON.stringify(body),
+        } as unknown as Response)
+      })
+      vi.stubGlobal('fetch', fetchMock)
+      return fetchMock
+    }
+
+    const emptyInfo = { workspaces: [], prSnapshots: {}, gitStats: {} }
+
+    it('stays quiet on a single dropped poll', async () => {
+      stubInfoFetch([null])
+      const store = useWorkspaceStore()
+
+      await store.fetchWorkspacesInfo()
+
+      // One missed poll (a laptop waking up, a proxy blip) must not flash a
+      // "backend is down" banner at a user whose backend is fine.
+      expect(store.listLoadError).toBeNull()
+    })
+
+    it('raises the banner after two consecutive failed polls', async () => {
+      stubInfoFetch([null, null])
+      const store = useWorkspaceStore()
+
+      await store.fetchWorkspacesInfo()
+      await store.fetchWorkspacesInfo()
+
+      expect(store.listLoadError).toBe('backend is gone')
+    })
+
+    it('never empties the workspace list when a poll fails', async () => {
+      stubInfoFetch([null, null])
+      const store = useWorkspaceStore()
+      store.workspaces = [makeWorkspace({ id: 'ws-1' })]
+
+      await store.fetchWorkspacesInfo()
+      await store.fetchWorkspacesInfo()
+
+      // A failure records the failure. It never wipes data that is valid on
+      // screen — the user keeps their list, plus an honest banner.
+      expect(store.workspaces.map((w) => w.id)).toEqual(['ws-1'])
+    })
+
+    it('clears the banner as soon as a poll succeeds again', async () => {
+      stubInfoFetch([null, null, emptyInfo])
+      const store = useWorkspaceStore()
+
+      await store.fetchWorkspacesInfo()
+      await store.fetchWorkspacesInfo()
+      expect(store.listLoadError).toBe('backend is gone')
+
+      await store.fetchWorkspacesInfo()
+
+      // A banner posted at load time used to survive the backend coming back.
+      expect(store.listLoadError).toBeNull()
+    })
+
+    it('resets the failure streak on success, so one later failure stays quiet', async () => {
+      stubInfoFetch([null, emptyInfo, null])
+      const store = useWorkspaceStore()
+
+      await store.fetchWorkspacesInfo()
+      await store.fetchWorkspacesInfo()
+      await store.fetchWorkspacesInfo()
+
+      expect(store.listLoadError).toBeNull()
+    })
+
+    it('lets a successful archived load clear the banner', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({
+          ok: true,
+          status: 200,
+          text: async () => JSON.stringify([]),
+        } as unknown as Response),
+      )
+      const store = useWorkspaceStore()
+      store.listLoadError = 'previous failure'
+
+      await store.fetchArchivedWorkspaces()
+
+      expect(store.listLoadError).toBeNull()
+    })
+
+    it('does not let a successful archived load clear a banner raised by the active list', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn((input: string | URL | Request) => {
+          const url = String(input)
+          if (url === '/api/workspaces/archived') {
+            return Promise.resolve({ ok: true, status: 200, text: async () => '[]' } as unknown as Response)
+          }
+          return Promise.resolve({
+            ok: false,
+            status: 500,
+            text: async () => JSON.stringify({ error: 'database is locked' }),
+          } as unknown as Response)
+        }),
+      )
+      const store = useWorkspaceStore()
+      store.archivedLoaded = true
+
+      await store.retryLoadWorkspaces()
+
+      // The archived list has no authority over a failure of the main list.
+      expect(store.listLoadError).toBe('database is locked')
     })
   })
 })

--- a/src/client/src/components/DiffViewer.vue
+++ b/src/client/src/components/DiffViewer.vue
@@ -184,7 +184,30 @@
       </q-input>
       <q-scroll-area class="diff-file-list q-pa-xs" style="width: 100%; border-right: 1px solid #2a2a4a;">
         <q-spinner-dots v-if="loading" size="24px" color="grey-6" class="q-ma-md" />
-        <div v-else-if="files.length === 0" class="text-caption text-grey-8 q-pa-sm">{{ $t('diff.noChanges') }}</div>
+        <template v-else>
+        <!-- A file list that is empty because the request failed is NOT a
+             branch without changes. The banner sits above whatever was
+             already listed, so a failed refresh never wipes valid data. -->
+        <div v-if="fileListError" class="text-caption q-pa-sm">
+          <div class="row items-center q-gutter-xs">
+            <q-icon name="error" size="16px" color="negative" />
+            <span class="text-negative">{{ $t('diff.fileListLoadFailed') }}</span>
+          </div>
+          <div class="text-grey-6 q-mt-xs">{{ fileListError }}</div>
+          <div class="text-grey-7 q-mt-xs">{{ $t('diff.fileListLoadFailedHint') }}</div>
+          <q-btn
+            dense
+            flat
+            no-caps
+            class="q-mt-xs"
+            icon="refresh"
+            :label="$t('common.retry')"
+            @click="retryFileList"
+          />
+        </div>
+        <div v-if="files.length === 0 && !fileListError" class="text-caption text-grey-8 q-pa-sm">
+          {{ $t('diff.noChanges') }}
+        </div>
         <div v-else-if="noFilterMatch" class="text-caption text-grey-8 q-pa-sm">{{ $t('diff.noFileMatch') }}</div>
         <q-tree
           v-else
@@ -279,6 +302,7 @@
             </template>
           </template>
         </q-tree>
+        </template>
       </q-scroll-area>
         <div class="diff-file-list-resize-handle" @mousedown="startFileListResize" />
       </div>
@@ -287,6 +311,22 @@
       <div class="col column" style="min-width: 0; position: relative;">
         <div v-if="loadingFile" class="col column items-center justify-center">
           <q-spinner-dots size="32px" color="indigo-4" />
+        </div>
+        <!-- Explicit failure state — the editor was already disposed above, so
+             there is nothing stale left behind under the new file's name.
+             Same shape as the sidebar, the settings page and the git stats
+             card: icon, title, server message, hint, inline retry. This is
+             the ONLY report for this failure; the toast that used to double
+             it (in a second, unrelated convention) is gone. -->
+        <div
+          v-else-if="fileLoadError"
+          class="col column items-center justify-center text-caption q-gutter-xs q-pa-lg text-center"
+        >
+          <q-icon name="error" size="24px" color="negative" />
+          <div class="text-negative">{{ $t('diff.fileLoadFailed') }}</div>
+          <div class="text-grey-6">{{ fileLoadError }}</div>
+          <div class="text-grey-7">{{ $t('diff.fileLoadFailedHint') }}</div>
+          <q-btn dense flat no-caps icon="refresh" :label="$t('common.retry')" @click="retryFileDiff" />
         </div>
         <div
           v-else-if="!selectedFile"
@@ -346,9 +386,11 @@ import { useQuasar } from 'quasar'
 import { type ReviewComment, useReviewDraft } from 'src/composables/use-review-draft'
 import { useWebSocketStore } from 'src/stores/websocket'
 import { useWorkspaceStore } from 'src/stores/workspace'
+import { ApiError, apiFetch } from 'src/utils/api'
 import { buildPathTree, countLeaves, type PathTreeNode } from 'src/utils/build-path-tree'
 import { monacoLanguageForPath } from 'src/utils/monaco-language'
 import { takePendingDiffOpen } from 'src/utils/pending-diff-open'
+import { registerUnsavedScope, unregisterUnsavedScope } from 'src/utils/unsaved-guard'
 import { isBusyStatus } from 'src/utils/workspace-status'
 import { computed, nextTick, onMounted, onUnmounted, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
@@ -388,6 +430,9 @@ const workingBranch = ref('')
 const selectedFile = ref<string | null>(null)
 const loading = ref(false)
 const loadingFile = ref(false)
+const fileLoadError = ref<string | null>(null)
+/** Failure of the file-list request itself, told apart from "no changes". */
+const fileListError = ref<string | null>(null)
 const editorContainer = ref<HTMLElement | null>(null)
 const viewMode = ref<'side' | 'inline'>('side')
 // Compact mode: collapse unchanged regions in the Monaco diff editor so the
@@ -821,19 +866,28 @@ async function loadFiles() {
     if (!isCommitsMode.value && diffMode.value === 'branch' && includeUntracked.value) {
       params.set('includeUntracked', '1')
     }
-    const res = await fetch(`/api/workspaces/${props.workspaceId}/diff?${params}`, {
-      cache: 'no-store',
-    })
-    if (!res.ok) throw new Error(`HTTP ${res.status}`)
-    const data = await res.json()
+    const data = await apiFetch<{ files: DiffFile[]; sourceBranch?: string; workingBranch?: string }>(
+      `/api/workspaces/${props.workspaceId}/diff?${params}`,
+      { cache: 'no-store' },
+    )
     files.value = data.files
     sourceBranch.value = data.sourceBranch ?? ''
     workingBranch.value = data.workingBranch ?? ''
+    fileListError.value = null
   } catch (err) {
+    // This used to be a bare `console.error`, in the very component whose job
+    // is to show failures: the tree simply stayed empty and the user read it
+    // as "no changes". Record the failure; never clear `files`.
+    fileListError.value = err instanceof Error ? err.message : String(err)
     console.error('Failed to load diff files:', err)
   } finally {
     loading.value = false
   }
+}
+
+/** Retry button of the file-list failure state. */
+function retryFileList(): void {
+  void loadFiles()
 }
 
 async function loadFileDiff(filePath: string) {
@@ -841,6 +895,12 @@ async function loadFileDiff(filePath: string) {
   loadingFile.value = true
 
   try {
+    // Dispose FIRST. Disposing after the request left the PREVIOUS file's
+    // content on screen under the NEW file's name whenever the request failed
+    // — the user then reviewed a diff that was not the one they believed.
+    disposeEditor()
+    fileLoadError.value = null
+
     if (!monaco) {
       // Configure Monaco workers per language for proper syntax support
       self.MonacoEnvironment = {
@@ -876,13 +936,12 @@ async function loadFileDiff(filePath: string) {
     const fileQuery = isCommitsMode.value
       ? `path=${encodeURIComponent(filePath)}&mode=commits&from=${encodeURIComponent(props.compareFrom!)}&to=${encodeURIComponent(props.compareTo!)}`
       : `path=${encodeURIComponent(filePath)}&mode=${diffMode.value}`
-    const res = await fetch(`/api/workspaces/${props.workspaceId}/diff-file?${fileQuery}`, { cache: 'no-store' })
-    if (!res.ok) throw new Error(`HTTP ${res.status}`)
-    const data = await res.json()
+    const data = await apiFetch<{ original?: string; modified?: string; modifiedSha?: string }>(
+      `/api/workspaces/${props.workspaceId}/diff-file?${fileQuery}`,
+      { cache: 'no-store' },
+    )
 
     const language = monacoLanguageForPath(filePath)
-
-    disposeEditor()
 
     const originalModel = monaco.editor.createModel(data.original ?? '', language)
     const modifiedModel = monaco.editor.createModel(data.modified ?? '', language)
@@ -934,13 +993,23 @@ async function loadFileDiff(filePath: string) {
       renderCommentZonesForFile(filePath)
     }
   } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    fileLoadError.value = message
     console.error('Failed to load file diff:', err)
   } finally {
     loadingFile.value = false
   }
 }
 
-async function saveCurrentFile(): Promise<{ ok: true } | { ok: false; status: number; currentSha?: string }> {
+/** Retry button of the inline failure state — re-runs the load for the file
+ *  the user is looking at. */
+function retryFileDiff(): void {
+  if (selectedFile.value) void loadFileDiff(selectedFile.value)
+}
+
+async function saveCurrentFile(): Promise<
+  { ok: true } | { ok: false; status: number; currentSha?: string; message?: string }
+> {
   // Belt-and-braces: commits mode is a read-only historical diff (canEdit is
   // false, so this is already unreachable from the UI). Guard the save path
   // itself so a future regression can never write a historical commit's
@@ -955,34 +1024,42 @@ async function saveCurrentFile(): Promise<{ ok: true } | { ok: false; status: nu
   const sha = baseSha.value
   savingFile.value = true
   try {
-    const res = await fetch(`/api/workspaces/${wsId}/save-file`, {
+    await apiFetch(`/api/workspaces/${wsId}/save-file`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ path: filePath, content, baseSha: sha }),
+      body: { path: filePath, content, baseSha: sha },
     })
-    if (res.status === 204) {
-      // Refetch the diff so baseSha + baseContent reflect the new on-disk truth.
-      const refresh = await fetch(
+    // Refetch the diff so baseSha + baseContent reflect the new on-disk truth.
+    // A failed refresh does not undo the save: report the save as done and let
+    // the stale sha surface as a 412 on the next attempt.
+    try {
+      const data = await apiFetch<{ modified?: string; modifiedSha?: string }>(
         `/api/workspaces/${wsId}/diff-file?path=${encodeURIComponent(filePath)}&mode=${diffMode.value}`,
         { cache: 'no-store' },
       )
-      if (refresh.ok) {
-        const data = await refresh.json()
-        baseSha.value = data.modifiedSha ?? ''
-        baseContent.value = data.modified ?? ''
-        dirty.value = modifiedModel.getValue() !== baseContent.value
-      }
-      $q.notify({ type: 'positive', message: t('diffViewer.savedAt'), position: 'top', timeout: 1200 })
-      return { ok: true }
+      baseSha.value = data.modifiedSha ?? ''
+      baseContent.value = data.modified ?? ''
+      dirty.value = modifiedModel.getValue() !== baseContent.value
+    } catch (err) {
+      console.error('[DiffViewer] post-save refresh failed:', err)
     }
-    if (res.status === 412) {
-      const body = (await res.json().catch(() => ({}))) as { currentSha?: string }
-      return { ok: false, status: 412, currentSha: body.currentSha }
-    }
-    return { ok: false, status: res.status }
+    $q.notify({ type: 'positive', message: t('diffViewer.savedAt'), position: 'top', timeout: 1200 })
+    return { ok: true }
   } catch (err) {
     console.error('[DiffViewer] save failed:', err)
-    return { ok: false, status: 0 }
+    if (err instanceof ApiError) {
+      if (err.status === 412) {
+        let currentSha: string | undefined
+        try {
+          currentSha = (JSON.parse(err.body) as { currentSha?: string }).currentSha
+        } catch {
+          // The 412 body is expected to carry the on-disk sha; without it the
+          // conflict dialog still works, it just cannot pre-fill anything.
+        }
+        return { ok: false, status: 412, currentSha }
+      }
+      return { ok: false, status: err.status, message: err.message }
+    }
+    return { ok: false, status: 0, message: err instanceof Error ? err.message : undefined }
   } finally {
     savingFile.value = false
   }
@@ -997,7 +1074,12 @@ async function onSaveClicked(): Promise<void> {
   }
   $q.notify({
     type: 'negative',
-    message: result.status === 409 ? t('diffViewer.agentRunning') : t('diffViewer.saveFailed'),
+    message:
+      result.status === 409
+        ? t('diffViewer.agentRunning')
+        : result.message
+          ? t('diffViewer.saveFailedDetail', { error: result.message })
+          : t('diffViewer.saveFailed'),
     position: 'top',
   })
 }
@@ -1042,24 +1124,13 @@ function confirmRollback(filePath: string, fileStatus: DiffFile['status']) {
 
 async function rollbackFile(filePath: string) {
   try {
-    const res = await fetch(`/api/workspaces/${props.workspaceId}/rollback-file`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ path: filePath }),
-    })
-    if (!res.ok) {
-      const body = (await res.json().catch(() => ({}))) as { error?: string }
-      $q.notify({
-        type: 'negative',
-        message: body.error || t('diff.rollbackFailed'),
-        position: 'top',
-      })
-      return
-    }
-    const body = (await res.json().catch(() => ({}))) as { target?: 'remote' | 'head' | 'deleted' }
+    const body = await apiFetch<{ target?: 'remote' | 'head' | 'deleted' } | undefined>(
+      `/api/workspaces/${props.workspaceId}/rollback-file`,
+      { method: 'POST', body: { path: filePath } },
+    )
     let message = t('diff.rollbackDoneRemote')
-    if (body.target === 'head') message = t('diff.rollbackDoneHead')
-    else if (body.target === 'deleted') message = t('diff.rollbackDoneDeleted')
+    if (body?.target === 'head') message = t('diff.rollbackDoneHead')
+    else if (body?.target === 'deleted') message = t('diff.rollbackDoneDeleted')
     $q.notify({ type: 'positive', message, position: 'top' })
     await loadFiles()
     if (selectedFile.value === filePath) {
@@ -1074,7 +1145,14 @@ async function rollbackFile(filePath: string) {
     }
   } catch (err) {
     console.error('rollbackFile failed:', err)
-    $q.notify({ type: 'negative', message: t('diff.rollbackFailed'), position: 'top' })
+    // The server names the reason (dirty index, missing baseline, agent
+    // running). Showing it beats a flat "Rollback failed".
+    const detail = err instanceof ApiError ? err.message : null
+    $q.notify({
+      type: 'negative',
+      message: detail ? t('diff.rollbackFailedDetail', { error: detail }) : t('diff.rollbackFailed'),
+      position: 'top',
+    })
   }
 }
 
@@ -1271,6 +1349,7 @@ onMounted(() => {
     const path = takePendingDiffOpen(props.workspaceId)
     if (path) void selectRequestedFile(path)
   })
+  registerUnsavedScope('diff:file', () => dirty.value)
 })
 
 onUnmounted(() => {
@@ -1279,6 +1358,7 @@ onUnmounted(() => {
   // editor and (in Review mode) view zones / mounted Vue apps.
   reviewDraft.flush() // before disposeEditor in case the user closed mid-edit
   disposeEditor()
+  unregisterUnsavedScope('diff:file')
 })
 </script>
 

--- a/src/client/src/components/GitPanel.vue
+++ b/src/client/src/components/GitPanel.vue
@@ -70,6 +70,23 @@
         </div>
       </div>
 
+      <!-- Failed load — NOT the same thing as "nothing to show". Replaces the
+           Changes, Actions and Pull-request sub-cards, which used to vanish
+           silently when the stats request failed. -->
+      <div v-if="statsError" class="git-subcard git-subcard--error">
+        <div class="git-subcard-title text-negative">{{ $t('git.statsFailed') }}</div>
+        <div class="text-caption text-grey-6">{{ statsError }}</div>
+        <q-btn
+          dense
+          flat
+          no-caps
+          class="q-mt-xs"
+          icon="refresh"
+          :label="$t('common.retry')"
+          @click="loadGitStats({ freshFetch: true })"
+        />
+      </div>
+
       <!-- Changes sub-card -->
       <div v-if="gitStats" class="git-subcard">
         <div class="git-subcard-title">{{ $t('git.section.changes') }}</div>
@@ -676,6 +693,26 @@
       </q-card>
     </q-dialog>
 
+    <!-- Raw git output — readable, selectable, and it stays until dismissed.
+         Same shape as sourceChangeErrorDialog, generalised to every git call. -->
+    <q-dialog v-model="gitOutputDialog">
+      <q-card dark style="min-width: 480px; max-width: 760px;">
+        <q-card-section>
+          <div class="text-subtitle1 text-negative">
+            <q-icon name="error" class="q-mr-xs" />
+            {{ $t('git.outputDialogTitle') }}
+          </div>
+        </q-card-section>
+        <q-card-section class="q-pt-none" style="max-height: 50vh; overflow: auto;">
+          <div class="text-body2 text-grey-3 git-output-pre">{{ gitOutputText }}</div>
+        </q-card-section>
+        <q-card-actions align="right">
+          <q-btn flat no-caps :label="$t('common.copy')" color="grey-5" @click="copyGitOutput" />
+          <q-btn flat no-caps :label="$t('common.close')" color="grey-5" @click="gitOutputDialog = false" />
+        </q-card-actions>
+      </q-card>
+    </q-dialog>
+
     <!-- Diff viewer dialog (fullscreen). `diffInitialReview` selects which
          mode the viewer opens in — set to true by the "Diff v2" button. -->
     <q-dialog v-model="showDiff" maximized>
@@ -725,7 +762,10 @@ import PrPanel from 'src/components/PrPanel.vue'
 import { useSettingsStore } from 'src/stores/settings'
 import type { BranchCommit, ForgeInfo, GitStats, Workspace } from 'src/stores/workspace'
 import { useWorkspaceStore, WorkspaceActionError } from 'src/stores/workspace'
+import { copyToClipboard } from 'src/utils/clipboard'
+import { needsScrollableOutput } from 'src/utils/git-output'
 import { DEFAULT_TOAST_TIMEOUT_MS } from 'src/utils/notification-timeout'
+import { notifyRetryableError } from 'src/utils/notifications'
 import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import CompareCommitsDialog from './CompareCommitsDialog.vue'
 
@@ -940,6 +980,39 @@ function onSendToChat(text: string) {
 }
 const gitStats = ref<GitStats | null>(null)
 const loadingStats = ref(false)
+const statsError = ref<string | null>(null)
+
+// Raw git output — readable, selectable, and it stays until dismissed. A
+// merge conflict or a rejected pre-push hook is twenty lines the user needs
+// to read and copy, not a six-second toast.
+const gitOutputDialog = ref(false)
+const gitOutputText = ref('')
+
+/**
+ * Route a git failure to the right surface: a toast for a one-liner, a
+ * scrollable dialog for real git output. Both always offer a retry.
+ */
+function reportGitFailure(message: string, retry: () => void) {
+  if (needsScrollableOutput(message)) {
+    gitOutputText.value = message
+    gitOutputDialog.value = true
+    return
+  }
+  notifyRetryableError(message, {
+    retryLabel: t('common.retry'),
+    onRetry: retry,
+    detailsLabel: t('common.details'),
+    onDetails: () => {
+      gitOutputText.value = message
+      gitOutputDialog.value = true
+    },
+    dismissLabel: t('common.dismiss'),
+  })
+}
+
+function copyGitOutput() {
+  void copyToClipboard($q, t, gitOutputText.value)
+}
 
 const repoName = computed(() => {
   if (!props.workspace?.projectPath) return '-'
@@ -1058,8 +1131,13 @@ async function loadGitStats(opts: { freshFetch?: boolean } = {}) {
     if (controller.signal.aborted) return
     if (props.workspace?.id !== wsIdAtStart) return
     gitStats.value = stats
+    statsError.value = null
   } catch (err) {
     if ((err as Error)?.name === 'AbortError') return
+    // Blanking gitStats hides the Changes, Actions and Pull-request sub-cards
+    // at once, which reads as "nothing to show" instead of "the read failed".
+    // Keep the failure visible and offer a way out.
+    statsError.value = err instanceof Error ? err.message : String(err)
     gitStats.value = null
   } finally {
     // Only the still-current request may clear the loading flag — a
@@ -1093,6 +1171,7 @@ watch(
     // loader instead of stale info while the new fetch is in flight.
     if (newId !== oldId) {
       gitStats.value = null
+      statsError.value = null
       commits.value = []
       showCommits.value = false
       showWorkingTreeFiles.value = false
@@ -1211,7 +1290,7 @@ async function runRebase(opts?: { autostash?: boolean }) {
     loadGitStats()
   } catch (e) {
     const msg = e instanceof Error ? e.message : t('git.rebaseFailed')
-    $q.notify({ type: 'negative', message: msg, position: 'top', timeout: 6000 })
+    reportGitFailure(msg, () => void runRebase(opts))
   } finally {
     rebasing.value = false
   }
@@ -1256,7 +1335,7 @@ async function runMerge(opts?: { autostash?: boolean }) {
     loadGitStats()
   } catch (e) {
     const msg = e instanceof Error ? e.message : t('git.mergeFailed')
-    $q.notify({ type: 'negative', message: msg, position: 'top', timeout: 6000 })
+    reportGitFailure(msg, () => void runMerge(opts))
   } finally {
     merging.value = false
   }
@@ -1422,7 +1501,7 @@ async function abortGitOperation() {
     loadGitStats()
   } catch (e) {
     const msg = e instanceof Error ? e.message : 'Abort failed'
-    $q.notify({ type: 'negative', message: msg, position: 'top', timeout: 6000 })
+    reportGitFailure(msg, () => void abortGitOperation())
   } finally {
     conflictAborting.value = false
   }
@@ -1878,6 +1957,16 @@ async function handleOpenPr() {
   letter-spacing: 0.08em;
   text-transform: uppercase;
   margin-bottom: 6px;
+}
+
+.git-subcard--error {
+  border: 1px solid var(--kobo-danger);
+}
+
+.git-output-pre {
+  font-family: var(--kobo-font-mono);
+  white-space: pre-wrap;
+  word-break: break-word;
 }
 </style>
 

--- a/src/client/src/components/TerminalPanel.vue
+++ b/src/client/src/components/TerminalPanel.vue
@@ -37,6 +37,15 @@
       </q-btn>
     </div>
 
+    <div v-else-if="isDisconnected" class="col column items-center justify-center terminal-panel__state">
+      <q-icon name="link_off" size="20px" class="text-warning" />
+      <div>{{ t('terminal.disconnected') }}</div>
+      <div v-if="reconnectAttempt > 0 && reconnectAttempt <= reconnectMax" class="text-caption">
+        {{ t('terminal.reconnecting', { attempt: reconnectAttempt, max: reconnectMax }) }}
+      </div>
+      <q-btn dense flat no-caps icon="refresh" :label="t('terminal.reconnect')" @click="reconnectNow" />
+    </div>
+
     <div
       v-else-if="hasExited"
       class="col column items-center justify-center text-amber-6 text-caption"
@@ -81,6 +90,11 @@ import { Terminal } from '@xterm/xterm'
 import '@xterm/xterm/css/xterm.css'
 import { useWorkspaceStore } from 'src/stores/workspace'
 import { appendTokenToWsUrl, getToken } from 'src/utils/auth-token'
+import {
+  shouldConnectOnFocus,
+  TERMINAL_RECONNECT_MAX_ATTEMPTS,
+  terminalReconnectDelayMs,
+} from 'src/utils/terminal-reconnect'
 import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 
@@ -97,6 +111,11 @@ interface TerminalEntry {
   container: HTMLDivElement // persistent DOM container for this terminal
   opened: boolean // whether terminal.open() has been called
   onDataDisposable?: { dispose: () => void }
+  /** Connection lost while the shell is still alive — distinct from `exited`. */
+  disconnected: boolean
+  /** 1-based count of consecutive reconnection attempts. 0 when connected. */
+  reconnectAttempt: number
+  reconnectTimer?: ReturnType<typeof setTimeout>
 }
 
 // Singleton map — survives component remount
@@ -127,8 +146,11 @@ const currentEntry = computed(() => {
   return terminalMap.get(workspaceId.value) ?? null
 })
 
-const isOpen = computed(() => !!currentEntry.value && !currentEntry.value.exited)
+const isOpen = computed(() => !!currentEntry.value && !currentEntry.value.exited && !currentEntry.value.disconnected)
 const hasExited = computed(() => !!currentEntry.value?.exited)
+const isDisconnected = computed(() => !!currentEntry.value?.disconnected)
+const reconnectAttempt = computed(() => currentEntry.value?.reconnectAttempt ?? 0)
+const reconnectMax = TERMINAL_RECONNECT_MAX_ATTEMPTS
 const terminalError = computed(() => currentEntry.value?.error ?? null)
 
 function bumpState() {
@@ -158,6 +180,8 @@ function connectWs(wid: string, entry: TerminalEntry) {
 
       if (msg.type === 'ready') {
         entry.error = null
+        entry.disconnected = false
+        entry.reconnectAttempt = 0
         bumpState()
         try {
           entry.fitAddon.fit()
@@ -181,6 +205,7 @@ function connectWs(wid: string, entry: TerminalEntry) {
 
   ws.onclose = () => {
     entry.ws = null
+    scheduleReconnect(wid, entry)
   }
 
   ws.onerror = () => {
@@ -198,6 +223,44 @@ function connectWs(wid: string, entry: TerminalEntry) {
       entry.ws.send(new TextEncoder().encode(data))
     }
   })
+}
+
+// Shared cleanup gesture — reused at every site that must not leave a stale
+// reconnect timer armed: closing the terminal, reopening it, the manual
+// "Reconnect" button, and refocusing a workspace tab. Repeating the inline
+// `if (entry.reconnectTimer) clearTimeout(...)` at four call sites is exactly
+// how one of them gets missed; centralizing it here means there's only one
+// place to get right.
+function clearReconnectTimer(entry: TerminalEntry) {
+  if (entry.reconnectTimer) {
+    clearTimeout(entry.reconnectTimer)
+    entry.reconnectTimer = undefined
+  }
+}
+
+// Declared with `function` (hoisted) — connectWs's onclose calls this, and
+// this calls back into connectWs on the retry timer, so neither can be a
+// `const` without breaking the mutual reference.
+function scheduleReconnect(wid: string, target: TerminalEntry) {
+  // A shell that exited on its own must NOT be respawned — only a lost
+  // connection is retried.
+  if (target.exited) return
+  const attempt = target.reconnectAttempt + 1
+  const delay = terminalReconnectDelayMs(attempt)
+  if (delay === null) return // give up; the user gets a manual Reconnect button
+  target.reconnectAttempt = attempt
+  target.disconnected = true
+  bumpState()
+  // Light jitter (same 0.8-1.2x spread as the main WS store's
+  // `_scheduleReconnect`), applied here rather than inside
+  // `terminalReconnectDelayMs` so that function stays a deterministic,
+  // exactly-testable schedule. Without it, several workspaces with a
+  // terminal open would all resume in lockstep after one backend restart.
+  const jitteredDelay = Math.round(delay * (0.8 + Math.random() * 0.4))
+  target.reconnectTimer = setTimeout(() => {
+    if (target.exited) return
+    connectWs(wid, target)
+  }, jitteredDelay)
 }
 
 function openTerminal() {
@@ -233,6 +296,8 @@ function openTerminal() {
     error: null,
     container,
     opened: false,
+    disconnected: false,
+    reconnectAttempt: 0,
   }
 
   terminalMap.set(wid, entry)
@@ -253,8 +318,15 @@ function closeTerminal() {
     detachTerminal()
   }
 
-  if (entry.ws && entry.ws.readyState === WebSocket.OPEN) {
-    entry.ws.close()
+  // Clear any pending reconnect timer AND stop this close from scheduling a
+  // new one — the classic leak this kind of fix introduces if skipped:
+  // ws.close() fires `onclose` asynchronously, and by then the entry is gone
+  // from terminalMap but scheduleReconnect doesn't consult the map, so it
+  // would happily reconnect a terminal the user just closed.
+  clearReconnectTimer(entry)
+  if (entry.ws) {
+    entry.ws.onclose = null
+    if (entry.ws.readyState === WebSocket.OPEN) entry.ws.close()
   }
   entry.onDataDisposable?.dispose()
   entry.terminal.dispose()
@@ -268,8 +340,10 @@ function reopenTerminal() {
 
   const old = terminalMap.get(wid)
   if (old) {
-    if (old.ws && old.ws.readyState === WebSocket.OPEN) {
-      old.ws.close()
+    clearReconnectTimer(old)
+    if (old.ws) {
+      old.ws.onclose = null
+      if (old.ws.readyState === WebSocket.OPEN) old.ws.close()
     }
     old.terminal.dispose()
     terminalMap.delete(wid)
@@ -277,6 +351,15 @@ function reopenTerminal() {
   currentAttachedId = null
   bumpState()
   nextTick(() => openTerminal())
+}
+
+function reconnectNow() {
+  const wid = workspaceId.value
+  const entry = currentEntry.value
+  if (!wid || !entry) return
+  clearReconnectTimer(entry)
+  entry.reconnectAttempt = 0
+  connectWs(wid, entry)
 }
 
 function attachTerminal(wid: string, entry: TerminalEntry) {
@@ -316,10 +399,13 @@ watch(workspaceId, (newId, oldId) => {
     if (entry) {
       nextTick(() => {
         attachTerminal(newId, entry)
-        if (!entry.ws || entry.ws.readyState !== WebSocket.OPEN) {
-          if (!entry.exited) {
-            connectWs(newId, entry)
-          }
+        // A reconnect backoff may still be armed from before this workspace
+        // tab lost focus. Cancel it before deciding whether to connect now —
+        // otherwise the timer fires later and races this immediate call,
+        // opening two sockets for the same entry.
+        clearReconnectTimer(entry)
+        if (shouldConnectOnFocus({ wsOpen: entry.ws?.readyState === WebSocket.OPEN, exited: entry.exited })) {
+          connectWs(newId, entry)
         }
       })
     }
@@ -357,3 +443,11 @@ onBeforeUnmount(() => {
   detachTerminal()
 })
 </script>
+
+<style lang="scss" scoped>
+.terminal-panel__state {
+  gap: var(--kobo-space-sm);
+  padding: var(--kobo-space-2xl);
+  color: var(--kobo-text-3);
+}
+</style>

--- a/src/client/src/components/WorkspaceList.vue
+++ b/src/client/src/components/WorkspaceList.vue
@@ -672,9 +672,26 @@
         </div>
       </div>
 
+      <!-- Failed load — NOT the same thing as an empty account. -->
+      <div v-if="store.listLoadError" class="q-pa-lg text-center">
+        <q-icon name="cloud_off" size="28px" class="text-negative" />
+        <div class="text-caption text-negative q-mt-sm">{{ $t('workspaceList.loadFailed') }}</div>
+        <div class="text-caption text-grey-6 q-mt-xs">{{ store.listLoadError }}</div>
+        <div class="text-caption text-grey-7 q-mt-xs">{{ $t('workspaceList.loadFailedHint') }}</div>
+        <q-btn
+          dense
+          flat
+          no-caps
+          class="q-mt-sm"
+          icon="refresh"
+          :label="$t('common.retry')"
+          @click="store.retryLoadWorkspaces()"
+        />
+      </div>
+
       <!-- Empty state -->
       <div
-        v-if="filteredNeedsAttention.length === 0 && filteredRunning.length === 0 && filteredIdle.length === 0 && filteredArchived.length === 0"
+        v-else-if="filteredNeedsAttention.length === 0 && filteredRunning.length === 0 && filteredIdle.length === 0 && filteredArchived.length === 0"
         class="q-pa-lg text-center text-grey-6 text-caption"
       >
         <template v-if="store.loading">{{ $t('common.loading') }}</template>

--- a/src/client/src/i18n/de.ts
+++ b/src/client/src/i18n/de.ts
@@ -6,8 +6,10 @@ export default {
   // Common
   'common.save': 'Speichern',
   'common.cancel': 'Abbrechen',
+  'common.retry': 'Erneut versuchen',
   'common.delete': 'Löschen',
   'common.close': 'Schließen',
+  'common.dismiss': 'Verwerfen',
   'common.details': 'Details',
   'common.ok': 'OK',
   'whatsNew.title': 'Neuigkeiten',
@@ -121,6 +123,8 @@ export default {
   'workspaceList.idle': 'Inaktiv',
   'workspaceList.archived': 'Archiviert',
   'workspaceList.noWorkspaces': 'Noch keine Arbeitsbereiche',
+  'workspaceList.loadFailed': 'Deine Workspaces konnten nicht geladen werden',
+  'workspaceList.loadFailedHint': 'Das ist ein Verbindungsfehler, kein leeres Konto.',
   'workspaceList.footer': '{count} Arbeitsbereich | {count} Arbeitsbereiche',
   'workspaceList.footerRunning': '{count} aktiv',
   'workspaceList.deleteDialog.title': 'Arbeitsbereich löschen?',
@@ -234,6 +238,9 @@ export default {
   'terminal.noWorktree': 'Worktree noch nicht erstellt',
   'terminal.error': 'Terminalfehler',
   'terminal.exited': 'Terminal beendet',
+  'terminal.disconnected': 'Verbindung verloren',
+  'terminal.reconnecting': 'Verbindungsaufbau… (Versuch {attempt} von {max})',
+  'terminal.reconnect': 'Neu verbinden',
 
   // Chat Input
   'chatInput.placeholder': 'Nachricht... (/ für Skills)',
@@ -379,6 +386,28 @@ export default {
   'createPage.validationName': 'Bitte geben Sie einen Arbeitsbereichnamen an.',
   'createPage.validationPath': 'Bitte geben Sie den Projektpfad ein.',
   'createPage.validationBranch': 'Bitte wählen Sie einen Branch aus.',
+  'createPage.progress.validate': 'Anfrage wird geprüft…',
+  'createPage.progress.fetch-source-branch': 'Source-Branch wird von origin geholt…',
+  'createPage.progress.inspect-worktree': 'Bestehender Worktree wird geprüft…',
+  'createPage.progress.extract-notion': 'Notion-Seite wird extrahiert…',
+  'createPage.progress.extract-sentry': 'Sentry-Issue wird extrahiert…',
+  'createPage.progress.create-record': 'Workspace wird erstellt…',
+  'createPage.progress.create-tasks': 'Tasks und Akzeptanzkriterien werden erstellt…',
+  'createPage.progress.create-worktree': 'Git-Worktree wird erstellt…',
+  'createPage.progress.write-conventions': 'Git-Konventionen werden geschrieben…',
+  'createPage.progress.write-context-files': 'Kontextdateien werden geschrieben…',
+  'createPage.progress.build-prompt': 'Initialer Prompt wird erstellt…',
+  'createPage.progress.setup-script': 'Dein Setup-Skript läuft…',
+  'createPage.progress.start-agent': 'Agent wird gestartet…',
+  'createPage.progress.rollback': 'Fehlgeschlagene Erstellung wird rückgängig gemacht…',
+  'createPage.progress.done': 'Fertig',
+  'createPage.progress.step': 'Schritt {index} von {total}',
+  'createPage.errorAtStep': 'Erstellung im Schritt „{step}“ fehlgeschlagen: {message}',
+  'createPage.override.title': 'Zwei deiner Einstellungen wurden überschrieben',
+  'createPage.override.setup-script-forced':
+    'Setup-Skript übersprungen: ein erneuter Lauf auf einem bereits vorbereiteten Worktree könnte dessen Inhalt zerstören.',
+  'createPage.override.permission-mode-downgraded':
+    'Berechtigungsmodus von Plan auf Bypass geändert: eine autonome Schleife kann nicht in Plan laufen, der Tools und Änderungen blockiert.',
 
   // Settings Page
   'settings.title': 'Einstellungen',
@@ -838,6 +867,8 @@ export default {
 
   // Git Panel
   'git.title': 'Git',
+  'git.outputDialogTitle': 'Git hat einen Fehler gemeldet',
+  'git.statsFailed': 'Der Git-Status konnte nicht gelesen werden',
   'git.section.repository': 'Repository',
   'git.section.changes': 'Änderungen',
   'git.section.pullRequest': 'Pull Request',
@@ -1164,6 +1195,7 @@ export default {
     '{path} dauerhaft löschen? Diese Datei wird nicht von Git verfolgt — ihr Inhalt geht verloren.',
   'diff.deleteUntrackedConfirmOk': 'Löschen',
   'diff.rollbackFailed': 'Rollback fehlgeschlagen',
+  'diff.rollbackFailedDetail': 'Rollback fehlgeschlagen: {error}',
   'diff.modeInspect': 'Bearbeiten',
   'diff.modeReview': 'Review',
   'diff.addComment': 'Kommentar hinzufügen',
@@ -1185,6 +1217,10 @@ export default {
   'diff.searchFiles': 'Dateien suchen…',
   'diff.noFileMatch': 'Keine passende Datei',
   'diff.selectFile': 'Datei auswählen, um den Diff anzuzeigen',
+  'diff.fileLoadFailed': 'Dieser Diff konnte nicht geladen werden',
+  'diff.fileLoadFailedHint': 'Die Datei auf der Festplatte ist unverändert — nur der Diff konnte nicht geladen werden.',
+  'diff.fileListLoadFailed': 'Die Dateiliste konnte nicht geladen werden',
+  'diff.fileListLoadFailedHint': 'Das ist eine fehlgeschlagene Anfrage, kein Branch ohne Änderungen.',
   'diff.addToChat': 'Zum Chat hinzufügen',
   'diff.compareTitle': 'Commits vergleichen',
   'diff.compareFrom': 'Von',
@@ -1195,6 +1231,7 @@ export default {
   'diffViewer.save': 'Speichern',
   'diffViewer.savedAt': 'Gespeichert',
   'diffViewer.saveFailed': 'Speichern fehlgeschlagen',
+  'diffViewer.saveFailedDetail': 'Speichern fehlgeschlagen: {error}',
   'diffViewer.unsavedChanges.title': 'Nicht gespeicherte Änderungen',
   'diffViewer.unsavedChanges.message': 'Du hast nicht gespeicherte Änderungen. Was möchtest du tun?',
   'diffViewer.unsavedChanges.save': 'Speichern',
@@ -1354,6 +1391,9 @@ export default {
     'Dieses Projekt hat nicht gespeicherte Änderungen. Ein Projektwechsel verwirft sie.',
   'settings.unsavedChanges.discard': 'Verwerfen und wechseln',
   'settings.unsavedChanges.cancel': 'Abbrechen',
+  'settings.loadFailed': 'Einstellungen konnten nicht geladen werden',
+  'settings.loadFailedHint':
+    'Speichern ist deaktiviert: das Formular zeigt Standardwerte, und sie zu schreiben würde deine echte Konfiguration überschreiben.',
   'health.title': 'Status',
   'health.tooltip': 'Systemstatus',
   'changelog.title': 'Änderungsprotokoll',
@@ -1590,4 +1630,10 @@ export default {
   'network.login.unreachable': 'Kōbō ist nicht erreichbar — prüfe deine Verbindung.',
   'layout.toggleWorkspaces': 'Workspaces-Leiste ein-/ausblenden',
   'layout.togglePanel': 'Seitenleiste ein-/ausblenden',
+
+  // Unsaved-work navigation guard
+  'unsaved.title': 'Ohne Speichern verlassen?',
+  'unsaved.message': 'Du hast ungespeicherte Änderungen. Diese Seite zu verlassen verwirft sie.',
+  'unsaved.leave': 'Verlassen',
+  'unsaved.stay': 'Bleiben',
 }

--- a/src/client/src/i18n/en.ts
+++ b/src/client/src/i18n/en.ts
@@ -6,8 +6,10 @@ export default {
   // Common
   'common.save': 'Save',
   'common.cancel': 'Cancel',
+  'common.retry': 'Retry',
   'common.delete': 'Delete',
   'common.close': 'Close',
+  'common.dismiss': 'Dismiss',
   'common.details': 'Details',
   'common.ok': 'OK',
   'whatsNew.title': "What's new",
@@ -121,6 +123,8 @@ export default {
   'workspaceList.idle': 'Idle',
   'workspaceList.archived': 'Archived',
   'workspaceList.noWorkspaces': 'No workspaces yet',
+  'workspaceList.loadFailed': 'Could not load your workspaces',
+  'workspaceList.loadFailedHint': 'This is a connection failure, not an empty account.',
   'workspaceList.footer': '{count} workspace | {count} workspaces',
   'workspaceList.footerRunning': '{count} running',
   'workspaceList.deleteDialog.title': 'Delete workspace?',
@@ -232,6 +236,9 @@ export default {
   'terminal.noWorktree': 'Worktree not created yet',
   'terminal.error': 'Terminal error',
   'terminal.exited': 'Terminal exited',
+  'terminal.disconnected': 'Connection lost',
+  'terminal.reconnecting': 'Reconnecting… (attempt {attempt} of {max})',
+  'terminal.reconnect': 'Reconnect',
 
   // Chat Input
   'chatInput.placeholder': 'Message... (/ for skills)',
@@ -376,6 +383,28 @@ export default {
   'createPage.validationName': 'Please provide a workspace name.',
   'createPage.validationPath': 'Please enter the project path.',
   'createPage.validationBranch': 'Please select a branch.',
+  'createPage.progress.validate': 'Validating the request…',
+  'createPage.progress.fetch-source-branch': 'Fetching the source branch from origin…',
+  'createPage.progress.inspect-worktree': 'Inspecting the existing worktree…',
+  'createPage.progress.extract-notion': 'Extracting the Notion page…',
+  'createPage.progress.extract-sentry': 'Extracting the Sentry issue…',
+  'createPage.progress.create-record': 'Creating the workspace…',
+  'createPage.progress.create-tasks': 'Creating tasks and acceptance criteria…',
+  'createPage.progress.create-worktree': 'Creating the git worktree…',
+  'createPage.progress.write-conventions': 'Writing git conventions…',
+  'createPage.progress.write-context-files': 'Writing context files…',
+  'createPage.progress.build-prompt': 'Building the initial prompt…',
+  'createPage.progress.setup-script': 'Running your setup script…',
+  'createPage.progress.start-agent': 'Starting the agent…',
+  'createPage.progress.rollback': 'Undoing the failed creation…',
+  'createPage.progress.done': 'Done',
+  'createPage.progress.step': 'Step {index} of {total}',
+  'createPage.errorAtStep': 'Creation failed at step "{step}": {message}',
+  'createPage.override.title': 'Two of your choices were overridden',
+  'createPage.override.setup-script-forced':
+    'Setup script skipped: re-running it on a worktree you already prepared could destroy its contents.',
+  'createPage.override.permission-mode-downgraded':
+    'Permission mode moved from Plan to Bypass: an auto-loop cannot run in Plan, which blocks tools and edits.',
 
   // Settings Page
   'settings.title': 'Settings',
@@ -829,6 +858,8 @@ export default {
 
   // Git Panel
   'git.title': 'Git',
+  'git.outputDialogTitle': 'Git reported an error',
+  'git.statsFailed': 'Git status could not be read',
   'git.section.repository': 'Repository',
   'git.section.changes': 'Changes',
   'git.section.pullRequest': 'Pull request',
@@ -1149,6 +1180,7 @@ export default {
   'diff.deleteUntrackedConfirm': 'Permanently delete {path}? This file is not tracked — its content will be lost.',
   'diff.deleteUntrackedConfirmOk': 'Delete',
   'diff.rollbackFailed': 'Rollback failed',
+  'diff.rollbackFailedDetail': 'Rollback failed: {error}',
   'diff.modeInspect': 'Edit',
   'diff.modeReview': 'Review',
   'diff.addComment': 'Add comment',
@@ -1169,6 +1201,10 @@ export default {
   'diff.searchFiles': 'Search files…',
   'diff.noFileMatch': 'No file matches',
   'diff.selectFile': 'Select a file to view diff',
+  'diff.fileLoadFailed': 'This diff could not be loaded',
+  'diff.fileLoadFailedHint': 'The file is unchanged on disk — only its diff failed to load.',
+  'diff.fileListLoadFailed': 'The file list could not be loaded',
+  'diff.fileListLoadFailedHint': 'This is a failed request, not a branch without changes.',
   'diff.addToChat': 'Add to chat',
   'diff.compareTitle': 'Compare commits',
   'diff.compareFrom': 'From',
@@ -1179,6 +1215,7 @@ export default {
   'diffViewer.save': 'Save',
   'diffViewer.savedAt': 'Saved',
   'diffViewer.saveFailed': 'Save failed',
+  'diffViewer.saveFailedDetail': 'Save failed: {error}',
   'diffViewer.unsavedChanges.title': 'Unsaved changes',
   'diffViewer.unsavedChanges.message': 'You have unsaved edits. What do you want to do?',
   'diffViewer.unsavedChanges.save': 'Save',
@@ -1334,6 +1371,9 @@ export default {
   'settings.unsavedChanges.message': 'This project has unsaved changes. Switching projects will discard them.',
   'settings.unsavedChanges.discard': 'Discard and switch',
   'settings.unsavedChanges.cancel': 'Cancel',
+  'settings.loadFailed': 'Settings could not be loaded',
+  'settings.loadFailedHint':
+    'Saving is disabled: the form is showing default values, and writing them would overwrite your real configuration.',
   'health.title': 'Health',
   'health.tooltip': 'System health',
   'changelog.title': 'Changelog',
@@ -1566,4 +1606,10 @@ export default {
   'network.login.unreachable': 'Kōbō is unreachable — check your connection.',
   'layout.toggleWorkspaces': 'Toggle workspaces panel',
   'layout.togglePanel': 'Toggle side panel',
+
+  // Unsaved-work navigation guard
+  'unsaved.title': 'Leave without saving?',
+  'unsaved.message': 'You have unsaved changes. Leaving this page discards them.',
+  'unsaved.leave': 'Leave',
+  'unsaved.stay': 'Stay',
 }

--- a/src/client/src/i18n/es.ts
+++ b/src/client/src/i18n/es.ts
@@ -6,8 +6,10 @@ export default {
   // Common
   'common.save': 'Guardar',
   'common.cancel': 'Cancelar',
+  'common.retry': 'Reintentar',
   'common.delete': 'Eliminar',
   'common.close': 'Cerrar',
+  'common.dismiss': 'Descartar',
   'common.details': 'Detalles',
   'common.ok': 'OK',
   'whatsNew.title': 'Novedades',
@@ -122,6 +124,8 @@ export default {
   'workspaceList.idle': 'Inactivo',
   'workspaceList.archived': 'Archivados',
   'workspaceList.noWorkspaces': 'Aún no hay workspaces',
+  'workspaceList.loadFailed': 'No se pudieron cargar tus workspaces',
+  'workspaceList.loadFailedHint': 'Es un fallo de conexión, no una cuenta vacía.',
   'workspaceList.footer': '{count} workspace | {count} workspaces',
   'workspaceList.footerRunning': '{count} en ejecución',
   'workspaceList.deleteDialog.title': '¿Eliminar workspace?',
@@ -235,6 +239,9 @@ export default {
   'terminal.noWorktree': 'Worktree aún no creado',
   'terminal.error': 'Error del terminal',
   'terminal.exited': 'Terminal cerrado',
+  'terminal.disconnected': 'Conexión perdida',
+  'terminal.reconnecting': 'Reconectando… (intento {attempt} de {max})',
+  'terminal.reconnect': 'Reconectar',
 
   // Chat Input
   'chatInput.placeholder': 'Mensaje... (/ para skills)',
@@ -379,6 +386,28 @@ export default {
   'createPage.validationName': 'Indica un nombre para el workspace.',
   'createPage.validationPath': 'Introduce la ruta del proyecto.',
   'createPage.validationBranch': 'Selecciona una rama.',
+  'createPage.progress.validate': 'Validando la solicitud…',
+  'createPage.progress.fetch-source-branch': 'Obteniendo la rama de origen desde origin…',
+  'createPage.progress.inspect-worktree': 'Inspeccionando el worktree existente…',
+  'createPage.progress.extract-notion': 'Extrayendo la página de Notion…',
+  'createPage.progress.extract-sentry': 'Extrayendo la incidencia de Sentry…',
+  'createPage.progress.create-record': 'Creando el workspace…',
+  'createPage.progress.create-tasks': 'Creando tareas y criterios de aceptación…',
+  'createPage.progress.create-worktree': 'Creando el worktree de git…',
+  'createPage.progress.write-conventions': 'Escribiendo las convenciones de git…',
+  'createPage.progress.write-context-files': 'Escribiendo los archivos de contexto…',
+  'createPage.progress.build-prompt': 'Construyendo el prompt inicial…',
+  'createPage.progress.setup-script': 'Ejecutando tu script de instalación…',
+  'createPage.progress.start-agent': 'Iniciando el agente…',
+  'createPage.progress.rollback': 'Deshaciendo la creación fallida…',
+  'createPage.progress.done': 'Listo',
+  'createPage.progress.step': 'Paso {index} de {total}',
+  'createPage.errorAtStep': 'La creación falló en el paso «{step}»: {message}',
+  'createPage.override.title': 'Dos de tus opciones fueron sustituidas',
+  'createPage.override.setup-script-forced':
+    'Script de instalación omitido: volver a ejecutarlo en un worktree que ya preparaste podría destruir su contenido.',
+  'createPage.override.permission-mode-downgraded':
+    'Modo de permisos cambiado de Plan a Bypass: un bucle autónomo no puede ejecutarse en Plan, que bloquea herramientas y ediciones.',
 
   // Settings Page
   'settings.title': 'Ajustes',
@@ -837,6 +866,8 @@ export default {
 
   // Git Panel
   'git.title': 'Git',
+  'git.outputDialogTitle': 'Git informó de un error',
+  'git.statsFailed': 'No se pudo leer el estado de git',
   'git.section.repository': 'Repositorio',
   'git.section.changes': 'Cambios',
   'git.section.pullRequest': 'Pull request',
@@ -1161,6 +1192,7 @@ export default {
     '¿Eliminar definitivamente {path}? Este archivo no está rastreado por git — su contenido se perderá.',
   'diff.deleteUntrackedConfirmOk': 'Eliminar',
   'diff.rollbackFailed': 'Falló el rollback',
+  'diff.rollbackFailedDetail': 'Rollback fallido: {error}',
   'diff.modeInspect': 'Editar',
   'diff.modeReview': 'Review',
   'diff.addComment': 'Añadir comentario',
@@ -1182,6 +1214,10 @@ export default {
   'diff.searchFiles': 'Buscar archivos…',
   'diff.noFileMatch': 'Ningún archivo coincide',
   'diff.selectFile': 'Selecciona un archivo para ver el diff',
+  'diff.fileLoadFailed': 'No se pudo cargar este diff',
+  'diff.fileLoadFailedHint': 'El archivo en disco está intacto — solo falló la carga del diff.',
+  'diff.fileListLoadFailed': 'No se pudo cargar la lista de archivos',
+  'diff.fileListLoadFailedHint': 'Es un fallo de la petición, no una rama sin cambios.',
   'diff.addToChat': 'Añadir al chat',
   'diff.compareTitle': 'Comparar commits',
   'diff.compareFrom': 'Desde',
@@ -1192,6 +1228,7 @@ export default {
   'diffViewer.save': 'Guardar',
   'diffViewer.savedAt': 'Guardado',
   'diffViewer.saveFailed': 'Error al guardar',
+  'diffViewer.saveFailedDetail': 'Error al guardar: {error}',
   'diffViewer.unsavedChanges.title': 'Cambios sin guardar',
   'diffViewer.unsavedChanges.message': 'Tienes cambios sin guardar. ¿Qué quieres hacer?',
   'diffViewer.unsavedChanges.save': 'Guardar',
@@ -1349,6 +1386,9 @@ export default {
   'settings.unsavedChanges.message': 'Este proyecto tiene cambios sin guardar. Cambiar de proyecto los descartará.',
   'settings.unsavedChanges.discard': 'Descartar y cambiar',
   'settings.unsavedChanges.cancel': 'Cancelar',
+  'settings.loadFailed': 'No se pudieron cargar los ajustes',
+  'settings.loadFailedHint':
+    'Guardar está desactivado: el formulario muestra valores por defecto y escribirlos sobrescribiría tu configuración real.',
   'health.title': 'Salud',
   'health.tooltip': 'Estado del sistema',
   'changelog.title': 'Changelog',
@@ -1586,4 +1626,10 @@ export default {
   'network.login.unreachable': 'Kōbō no es accesible — comprueba tu conexión.',
   'layout.toggleWorkspaces': 'Mostrar/ocultar el panel de espacios',
   'layout.togglePanel': 'Mostrar/ocultar el panel lateral',
+
+  // Unsaved-work navigation guard
+  'unsaved.title': '¿Salir sin guardar?',
+  'unsaved.message': 'Tienes cambios sin guardar. Salir de esta página los descarta.',
+  'unsaved.leave': 'Salir',
+  'unsaved.stay': 'Quedarme',
 }

--- a/src/client/src/i18n/fr.ts
+++ b/src/client/src/i18n/fr.ts
@@ -6,8 +6,10 @@ export default {
   // Common
   'common.save': 'Enregistrer',
   'common.cancel': 'Annuler',
+  'common.retry': 'Réessayer',
   'common.delete': 'Supprimer',
   'common.close': 'Fermer',
+  'common.dismiss': 'Ignorer',
   'common.details': 'Détails',
   'common.ok': 'OK',
   'whatsNew.title': 'Quoi de neuf',
@@ -123,6 +125,8 @@ export default {
   'workspaceList.idle': 'Inactif',
   'workspaceList.archived': 'Archivés',
   'workspaceList.noWorkspaces': 'Aucun espace de travail',
+  'workspaceList.loadFailed': 'Impossible de charger vos workspaces',
+  'workspaceList.loadFailedHint': 'Il s’agit d’un échec de connexion, pas d’un compte vide.',
   'workspaceList.footer': '{count} espace de travail | {count} espaces de travail',
   'workspaceList.footerRunning': '{count} en cours',
   'workspaceList.deleteDialog.title': "Supprimer l'espace de travail ?",
@@ -237,6 +241,9 @@ export default {
   'terminal.noWorktree': 'Worktree pas encore créé',
   'terminal.error': 'Erreur du terminal',
   'terminal.exited': 'Terminal fermé',
+  'terminal.disconnected': 'Connexion perdue',
+  'terminal.reconnecting': 'Reconnexion… (essai {attempt} sur {max})',
+  'terminal.reconnect': 'Reconnecter',
 
   // Chat Input
   'chatInput.placeholder': 'Message... (/ pour les skills)',
@@ -382,6 +389,28 @@ export default {
   'createPage.validationName': "Veuillez fournir un nom d'espace de travail.",
   'createPage.validationPath': 'Veuillez entrer le chemin du projet.',
   'createPage.validationBranch': 'Veuillez sélectionner une branche.',
+  'createPage.progress.validate': 'Validation de la demande…',
+  'createPage.progress.fetch-source-branch': 'Récupération de la branche source depuis origin…',
+  'createPage.progress.inspect-worktree': 'Inspection du worktree existant…',
+  'createPage.progress.extract-notion': 'Extraction de la page Notion…',
+  'createPage.progress.extract-sentry': 'Extraction de l’issue Sentry…',
+  'createPage.progress.create-record': 'Création du workspace…',
+  'createPage.progress.create-tasks': 'Création des tâches et critères d’acceptation…',
+  'createPage.progress.create-worktree': 'Création du worktree git…',
+  'createPage.progress.write-conventions': 'Écriture des conventions git…',
+  'createPage.progress.write-context-files': 'Écriture des fichiers de contexte…',
+  'createPage.progress.build-prompt': 'Construction du prompt initial…',
+  'createPage.progress.setup-script': 'Exécution de votre script d’installation…',
+  'createPage.progress.start-agent': 'Démarrage de l’agent…',
+  'createPage.progress.rollback': 'Annulation de la création échouée…',
+  'createPage.progress.done': 'Terminé',
+  'createPage.progress.step': 'Étape {index} sur {total}',
+  'createPage.errorAtStep': 'La création a échoué à l’étape « {step} » : {message}',
+  'createPage.override.title': 'Deux de vos choix ont été remplacés',
+  'createPage.override.setup-script-forced':
+    'Script d’installation ignoré : le relancer sur un worktree que vous avez déjà préparé pourrait en détruire le contenu.',
+  'createPage.override.permission-mode-downgraded':
+    'Mode de permission passé de Plan à Bypass : une boucle autonome ne peut pas tourner en Plan, qui bloque les outils et les modifications.',
 
   // Settings Page
   'settings.title': 'Paramètres',
@@ -839,6 +868,8 @@ export default {
 
   // Git Panel
   'git.title': 'Git',
+  'git.outputDialogTitle': 'Git a signalé une erreur',
+  'git.statsFailed': 'L’état git n’a pas pu être lu',
   'git.section.repository': 'Dépôt',
   'git.section.changes': 'Modifications',
   'git.section.pullRequest': 'Pull request',
@@ -1164,6 +1195,7 @@ export default {
     "Supprimer définitivement {path} ? Ce fichier n'est pas suivi par git — son contenu sera perdu.",
   'diff.deleteUntrackedConfirmOk': 'Supprimer',
   'diff.rollbackFailed': 'Échec du rollback',
+  'diff.rollbackFailedDetail': 'Échec du rollback : {error}',
   'diff.modeInspect': 'Édition',
   'diff.modeReview': 'Review',
   'diff.addComment': 'Ajouter un commentaire',
@@ -1184,6 +1216,10 @@ export default {
   'diff.searchFiles': 'Rechercher des fichiers…',
   'diff.noFileMatch': 'Aucun fichier correspondant',
   'diff.selectFile': 'Sélectionnez un fichier pour voir le diff',
+  'diff.fileLoadFailed': 'Ce diff n’a pas pu être chargé',
+  'diff.fileLoadFailedHint': 'Le fichier sur le disque est intact — seul le chargement du diff a échoué.',
+  'diff.fileListLoadFailed': 'La liste des fichiers n’a pas pu être chargée',
+  'diff.fileListLoadFailedHint': 'Il s’agit d’un échec de requête, pas d’une branche sans modification.',
   'diff.addToChat': 'Ajouter au chat',
   'diff.compareTitle': 'Comparer des commits',
   'diff.compareFrom': 'De',
@@ -1194,6 +1230,7 @@ export default {
   'diffViewer.save': 'Enregistrer',
   'diffViewer.savedAt': 'Enregistré',
   'diffViewer.saveFailed': 'Échec de l’enregistrement',
+  'diffViewer.saveFailedDetail': 'Échec de l’enregistrement : {error}',
   'diffViewer.unsavedChanges.title': 'Modifications non enregistrées',
   'diffViewer.unsavedChanges.message': 'Tu as des modifications non enregistrées. Que veux-tu faire ?',
   'diffViewer.unsavedChanges.save': 'Enregistrer',
@@ -1351,6 +1388,9 @@ export default {
   'settings.unsavedChanges.message': 'Ce projet a des modifications non enregistrées. Changer de projet les annulera.',
   'settings.unsavedChanges.discard': 'Ignorer et changer',
   'settings.unsavedChanges.cancel': 'Annuler',
+  'settings.loadFailed': 'Les réglages n’ont pas pu être chargés',
+  'settings.loadFailedHint':
+    'L’enregistrement est désactivé : le formulaire affiche les valeurs par défaut, et les écrire remplacerait votre configuration réelle.',
   'health.title': 'Santé',
   'health.tooltip': 'Santé du système',
   'changelog.title': 'Journal des changements',
@@ -1588,4 +1628,10 @@ export default {
   'network.login.unreachable': 'Kōbō est injoignable — vérifie ta connexion.',
   'layout.toggleWorkspaces': 'Afficher/masquer les espaces de travail',
   'layout.togglePanel': 'Afficher/masquer le panneau latéral',
+
+  // Unsaved-work navigation guard
+  'unsaved.title': 'Quitter sans enregistrer ?',
+  'unsaved.message': 'Vous avez des modifications non enregistrées. Quitter cette page les abandonne.',
+  'unsaved.leave': 'Quitter',
+  'unsaved.stay': 'Rester',
 }

--- a/src/client/src/i18n/it.ts
+++ b/src/client/src/i18n/it.ts
@@ -6,8 +6,10 @@ export default {
   // Common
   'common.save': 'Salva',
   'common.cancel': 'Annulla',
+  'common.retry': 'Riprova',
   'common.delete': 'Elimina',
   'common.close': 'Chiudi',
+  'common.dismiss': 'Ignora',
   'common.details': 'Dettagli',
   'common.ok': 'OK',
   'whatsNew.title': 'Novità',
@@ -123,6 +125,8 @@ export default {
   'workspaceList.idle': 'Inattivo',
   'workspaceList.archived': 'Archiviati',
   'workspaceList.noWorkspaces': 'Nessun workspace ancora',
+  'workspaceList.loadFailed': 'Impossibile caricare i tuoi workspace',
+  'workspaceList.loadFailedHint': 'È un errore di connessione, non un account vuoto.',
   'workspaceList.footer': '{count} workspace | {count} workspace',
   'workspaceList.footerRunning': '{count} in esecuzione',
   'workspaceList.deleteDialog.title': 'Eliminare il workspace?',
@@ -237,6 +241,9 @@ export default {
   'terminal.noWorktree': 'Worktree non ancora creato',
   'terminal.error': 'Errore del terminale',
   'terminal.exited': 'Terminale chiuso',
+  'terminal.disconnected': 'Connessione persa',
+  'terminal.reconnecting': 'Riconnessione… (tentativo {attempt} di {max})',
+  'terminal.reconnect': 'Riconnetti',
 
   // Chat Input
   'chatInput.placeholder': 'Messaggio... (/ per le skill)',
@@ -382,6 +389,28 @@ export default {
   'createPage.validationName': 'Indica un nome per il workspace.',
   'createPage.validationPath': 'Inserisci il percorso del progetto.',
   'createPage.validationBranch': 'Seleziona un branch.',
+  'createPage.progress.validate': 'Validazione della richiesta…',
+  'createPage.progress.fetch-source-branch': 'Recupero del branch sorgente da origin…',
+  'createPage.progress.inspect-worktree': 'Ispezione del worktree esistente…',
+  'createPage.progress.extract-notion': 'Estrazione della pagina Notion…',
+  'createPage.progress.extract-sentry': 'Estrazione dell’issue Sentry…',
+  'createPage.progress.create-record': 'Creazione del workspace…',
+  'createPage.progress.create-tasks': 'Creazione di task e criteri di accettazione…',
+  'createPage.progress.create-worktree': 'Creazione del worktree git…',
+  'createPage.progress.write-conventions': 'Scrittura delle convenzioni git…',
+  'createPage.progress.write-context-files': 'Scrittura dei file di contesto…',
+  'createPage.progress.build-prompt': 'Costruzione del prompt iniziale…',
+  'createPage.progress.setup-script': 'Esecuzione del tuo script di installazione…',
+  'createPage.progress.start-agent': 'Avvio dell’agente…',
+  'createPage.progress.rollback': 'Annullamento della creazione fallita…',
+  'createPage.progress.done': 'Fatto',
+  'createPage.progress.step': 'Passo {index} di {total}',
+  'createPage.errorAtStep': 'Creazione fallita al passo «{step}»: {message}',
+  'createPage.override.title': 'Due delle tue scelte sono state sostituite',
+  'createPage.override.setup-script-forced':
+    'Script di installazione saltato: rieseguirlo su un worktree già preparato potrebbe distruggerne il contenuto.',
+  'createPage.override.permission-mode-downgraded':
+    'Modalità permessi passata da Plan a Bypass: un ciclo autonomo non può girare in Plan, che blocca strumenti e modifiche.',
 
   // Settings Page
   'settings.title': 'Impostazioni',
@@ -836,6 +865,8 @@ export default {
 
   // Git Panel
   'git.title': 'Git',
+  'git.outputDialogTitle': 'Git ha segnalato un errore',
+  'git.statsFailed': 'Impossibile leggere lo stato git',
   'git.section.repository': 'Repository',
   'git.section.changes': 'Modifiche',
   'git.section.pullRequest': 'Pull request',
@@ -1161,6 +1192,7 @@ export default {
     'Eliminare definitivamente {path}? Questo file non è tracciato da git — il suo contenuto andrà perso.',
   'diff.deleteUntrackedConfirmOk': 'Elimina',
   'diff.rollbackFailed': 'Rollback fallito',
+  'diff.rollbackFailedDetail': 'Rollback non riuscito: {error}',
   'diff.modeInspect': 'Modifica',
   'diff.modeReview': 'Review',
   'diff.addComment': 'Aggiungi commento',
@@ -1181,6 +1213,10 @@ export default {
   'diff.searchFiles': 'Cerca file…',
   'diff.noFileMatch': 'Nessun file corrispondente',
   'diff.selectFile': 'Seleziona un file per visualizzare il diff',
+  'diff.fileLoadFailed': 'Impossibile caricare questo diff',
+  'diff.fileLoadFailedHint': 'Il file su disco è intatto — è fallito solo il caricamento del diff.',
+  'diff.fileListLoadFailed': 'Impossibile caricare l’elenco dei file',
+  'diff.fileListLoadFailedHint': 'È una richiesta fallita, non un branch senza modifiche.',
   'diff.addToChat': 'Aggiungi alla chat',
   'diff.compareTitle': 'Confronta commit',
   'diff.compareFrom': 'Da',
@@ -1191,6 +1227,7 @@ export default {
   'diffViewer.save': 'Salva',
   'diffViewer.savedAt': 'Salvato',
   'diffViewer.saveFailed': 'Salvataggio non riuscito',
+  'diffViewer.saveFailedDetail': 'Salvataggio non riuscito: {error}',
   'diffViewer.unsavedChanges.title': 'Modifiche non salvate',
   'diffViewer.unsavedChanges.message': 'Hai modifiche non salvate. Cosa vuoi fare?',
   'diffViewer.unsavedChanges.save': 'Salva',
@@ -1348,6 +1385,9 @@ export default {
   'settings.unsavedChanges.message': 'Questo progetto ha modifiche non salvate. Cambiando progetto andranno perse.',
   'settings.unsavedChanges.discard': 'Scarta e cambia',
   'settings.unsavedChanges.cancel': 'Annulla',
+  'settings.loadFailed': 'Impossibile caricare le impostazioni',
+  'settings.loadFailedHint':
+    'Il salvataggio è disattivato: il modulo mostra i valori predefiniti e scriverli sovrascriverebbe la tua configurazione reale.',
   'health.title': 'Stato',
   'health.tooltip': 'Stato del sistema',
   'changelog.title': 'Changelog',
@@ -1587,4 +1627,10 @@ export default {
   'network.login.unreachable': 'Kōbō non è raggiungibile — controlla la connessione.',
   'layout.toggleWorkspaces': 'Mostra/nascondi il pannello degli spazi',
   'layout.togglePanel': 'Mostra/nascondi il pannello laterale',
+
+  // Unsaved-work navigation guard
+  'unsaved.title': 'Uscire senza salvare?',
+  'unsaved.message': 'Hai modifiche non salvate. Uscire da questa pagina le scarta.',
+  'unsaved.leave': 'Esci',
+  'unsaved.stay': 'Resta',
 }

--- a/src/client/src/pages/CreatePage.vue
+++ b/src/client/src/pages/CreatePage.vue
@@ -7,6 +7,26 @@
         <div class="text-body1 text-grey-5 q-mt-xs">{{ $t('createPage.subtitle') }}</div>
       </header>
 
+      <!--
+        Both silent overrides (forced skip-setup-script, plan->bypass under
+        auto-loop) are surfaced here, at the top of the form, rather than only
+        as a note buried inside a collapsed "Advanced options" / "Configure
+        agent" panel. A change of security posture (permission mode) in
+        particular deserves to be seen without the user having to go looking
+        for it. `resolvedOverrides` is the single source of truth also used to
+        build the request payload, so this can never drift from what actually
+        gets sent.
+      -->
+      <div v-if="resolvedOverrides.applied.length > 0" class="create-page__overrides q-mb-lg">
+        <div class="create-page__overrides-title text-caption">
+          <q-icon name="info" size="16px" />
+          {{ $t('createPage.override.title') }}
+        </div>
+        <div v-for="id in resolvedOverrides.applied" :key="id" class="create-page__overrides-item text-caption">
+          {{ $t(`createPage.override.${id}`) }}
+        </div>
+      </div>
+
       <div class="create-sections column">
         <q-card flat bordered class="create-section-card">
           <q-card-section class="row items-start no-wrap q-gutter-md">
@@ -510,7 +530,10 @@
                     {{ reasoningOptions.find((item) => item.value === reasoningEffort)?.label ?? reasoningEffort }}
                   </q-chip>
                   <q-chip dense color="grey-9" text-color="grey-3" :icon="agentPermissionModeIcon">
-                    {{ agentPermissionModeOptions.find((item) => item.value === agentPermissionMode)?.label ?? agentPermissionMode }}
+                    {{
+                      agentPermissionModeOptions.find((item) => item.value === resolvedOverrides.agentPermissionMode)
+                        ?.label ?? resolvedOverrides.agentPermissionMode
+                    }}
                   </q-chip>
                 </q-item-label>
               </q-item-section>
@@ -582,7 +605,7 @@
               </div>
               <div class="col-12 col-sm-6">
                 <q-select
-                  v-model="agentPermissionMode"
+                  :model-value="resolvedOverrides.agentPermissionMode"
                   :options="agentPermissionModeOptions"
                   dark
                   dense
@@ -596,6 +619,7 @@
                   :disable="autoLoop"
                   :label="$t('agentPermissionMode.label')"
                   :hint="autoLoop ? $t('agentPermissionMode.autoLoopLocked') : undefined"
+                  @update:model-value="(val) => (agentPermissionMode = val as AgentPermissionMode)"
                 />
               </div>
             </q-card-section>
@@ -696,6 +720,12 @@
               />
             </div>
           </q-card-section>
+
+          <q-card-section v-if="submitting && creationStepLabel" class="create-page__progress text-caption q-pt-none">
+            <q-spinner-dots size="18px" />
+            <span class="create-page__progress-step">{{ creationStepLabel }}</span>
+            <span v-if="creationStepCounter" class="create-page__progress-counter">{{ creationStepCounter }}</span>
+          </q-card-section>
         </q-card>
       </div>
     </div>
@@ -715,10 +745,12 @@ import { useSettingsStore } from 'src/stores/settings'
 import { useTemplatesStore } from 'src/stores/templates'
 import { useWebSocketStore } from 'src/stores/websocket'
 import { useWorkspaceStore } from 'src/stores/workspace'
+import { resolveCreateOverrides } from 'src/utils/create-overrides'
 import { loadCreatePagePrefs, saveCreatePagePrefs } from 'src/utils/create-page-prefs'
 import { buildTemplateVars, expandTemplate } from 'src/utils/expand-template'
 import { playNotificationSound } from 'src/utils/notifications'
 import { projectNameForPath } from 'src/utils/project-color'
+import { registerUnsavedScope, unregisterUnsavedScope } from 'src/utils/unsaved-guard'
 import { computed, nextTick, onMounted, onUnmounted, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useRouter } from 'vue-router'
@@ -750,7 +782,7 @@ const router = useRouter()
 const $q = useQuasar()
 const store = useWorkspaceStore()
 const settingsStore = useSettingsStore()
-const { t } = useI18n()
+const { t, te } = useI18n()
 
 const pathFilterOptions = ref<string[]>([])
 
@@ -837,7 +869,7 @@ function deriveDefaultAgentPermissionMode(projectPath: string, engineId: string)
 const agentPermissionMode = ref<AgentPermissionMode>(deriveDefaultAgentPermissionMode('', selectedEngineId.value))
 
 const agentPermissionModeIcon = computed<string>(() => {
-  switch (agentPermissionMode.value) {
+  switch (resolvedOverrides.value.agentPermissionMode) {
     case 'plan':
       return 'visibility'
     case 'bypass':
@@ -866,6 +898,24 @@ const branches = ref<string[]>([])
 const branchFilterOptions = ref<string[]>([])
 const loadingBranches = ref(false)
 const submitting = ref(false)
+const creationId = ref<string | null>(null)
+
+/** Human label for the step the server is currently on. Empty when idle. */
+const creationStepLabel = computed(() => {
+  const progress = store.creationProgress
+  if (!progress || progress.creationId !== creationId.value) return ''
+  const key = `createPage.progress.${progress.step}`
+  // Steps are server-defined and may grow over time (or briefly be a step
+  // name this build doesn't know yet, right after an upgrade). Fall back to
+  // the raw step id rather than showing nothing or throwing.
+  return te(key) ? t(key) : progress.step
+})
+
+const creationStepCounter = computed(() => {
+  const progress = store.creationProgress
+  if (!progress || progress.creationId !== creationId.value || progress.index < 0) return ''
+  return t('createPage.progress.step', { index: progress.index + 1, total: progress.total })
+})
 
 function filterBranches(val: string, update: (fn: () => void) => void) {
   update(() => {
@@ -1189,15 +1239,13 @@ function toggleNotion() {
 const useSentry = ref(false)
 const autoLoop = ref(false)
 const autoLoopSessionMode = ref<'per_task' | 'continuous'>('per_task')
-// Auto-loop ON forces 'bypass' (plan would deadlock the loop).
-watch(
-  () => autoLoop.value,
-  (enabled) => {
-    if (enabled && agentPermissionMode.value !== 'bypass') {
-      agentPermissionMode.value = 'bypass'
-    }
-  },
-)
+// NOTE: auto-loop no longer mutates `agentPermissionMode` directly. Doing so
+// used to permanently clobber the user's stored preference (e.g. 'plan')
+// with 'bypass' the moment auto-loop was enabled, so turning auto-loop back
+// off could never restore what the user actually picked. `resolvedOverrides`
+// (see below) now derives the effective, send-to-server mode from the raw
+// preference + autoLoop on every read — for both the request payload and
+// everywhere the mode is displayed — without ever touching the ref itself.
 
 function toggleAutoLoop() {
   autoLoop.value = !autoLoop.value
@@ -1226,6 +1274,19 @@ const useExistingWorktree = ref(false)
 const selectedWorktreePath = ref<string | null>(null)
 const orphanWorktrees = ref<Array<{ path: string; branch: string; head: string; suggestedSourceBranch: string }>>([])
 const loadingOrphanWorktrees = ref(false)
+
+// Single source of truth for both silent overrides this form applies
+// (forced skip-setup-script on worktree reuse, plan->bypass under auto-loop).
+// The template and the request payload both read from here, so what the UI
+// displays can never drift from what actually goes out over the wire.
+const resolvedOverrides = computed(() =>
+  resolveCreateOverrides({
+    useExistingWorktree: useExistingWorktree.value,
+    skipSetupScript: skipSetupScript.value,
+    autoLoop: autoLoop.value,
+    agentPermissionMode: agentPermissionMode.value,
+  }),
+)
 
 async function fetchOrphans() {
   if (!projectPath.value.trim()) {
@@ -1440,6 +1501,14 @@ onMounted(async () => {
   window.addEventListener('keyup', onCreateWindowKeyUp)
   window.addEventListener('blur', onCreateWindowBlur)
   document.addEventListener('visibilitychange', onCreateVisibilityChange)
+  // Only a form the user actually filled in is worth defending — a pristine
+  // page must never prompt.
+  registerUnsavedScope(
+    'create:form',
+    () =>
+      !submitting.value &&
+      (description.value.trim().length > 0 || manualTasks.value.length > 0 || manualCriteria.value.length > 0),
+  )
 })
 
 // Cleanup debounce timer on unmount
@@ -1449,6 +1518,7 @@ onUnmounted(() => {
   window.removeEventListener('keyup', onCreateWindowKeyUp)
   window.removeEventListener('blur', onCreateWindowBlur)
   document.removeEventListener('visibilitychange', onCreateVisibilityChange)
+  unregisterUnsavedScope('create:form')
   if (createVoiceTimeoutRef.value) {
     clearTimeout(createVoiceTimeoutRef.value)
     createVoiceTimeoutRef.value = null
@@ -1558,6 +1628,16 @@ async function handleCreate() {
   }
 
   submitting.value = true
+  // Subscribe BEFORE posting: the first progress beats are emitted while the
+  // POST is still in flight, and an unsubscribed channel drops them silently.
+  const wsStoreForProgress = useWebSocketStore()
+  const newCreationId =
+    typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function'
+      ? `create-${crypto.randomUUID()}`
+      : `create-${Date.now()}-${Math.random().toString(36).slice(2)}`
+  creationId.value = newCreationId
+  store.clearCreationProgress()
+  wsStoreForProgress.subscribeChannel(newCreationId)
   try {
     const name = getFinalName()
 
@@ -1580,11 +1660,13 @@ async function handleCreate() {
       name,
       projectPath: projectPath.value.trim(),
       sourceBranch: branch.value as string,
+      creationId: newCreationId,
       // Reuse-an-existing-worktree branch: skip generating a workingBranch
-      // (backend ignores it when worktreePath is set) and force skipSetupScript.
+      // (backend ignores it when worktreePath is set). skipSetupScript is
+      // resolved once, below, via `resolvedOverrides`.
       // Standard branch: keep the generated workingBranch as before.
       ...(useExistingWorktree.value && selectedWorktreePath.value
-        ? { worktreePath: selectedWorktreePath.value, skipSetupScript: true, workingBranch }
+        ? { worktreePath: selectedWorktreePath.value, workingBranch }
         : { workingBranch }),
       engine: selectedEngineId.value,
       model: model.value,
@@ -1595,7 +1677,7 @@ async function handleCreate() {
       ...(showManualSections.value && manualCriteria.value.length > 0
         ? { acceptanceCriteria: manualCriteria.value }
         : {}),
-      ...(skipSetupScript.value && !useExistingWorktree.value ? { skipSetupScript: true } : {}),
+      ...(resolvedOverrides.value.skipSetupScript ? { skipSetupScript: true } : {}),
       ...(description.value.trim() ? { description: description.value.trim() } : {}),
       ...(autoLoop.value
         ? {
@@ -1605,9 +1687,9 @@ async function handleCreate() {
             brainstormReasoningEffort: brainstormReasoningEffort.value,
           }
         : {}),
-      // Auto-loop cannot run in 'plan' (blocks MCP + edits) — promote to bypass.
-      agentPermissionMode:
-        autoLoop.value && agentPermissionMode.value === 'plan' ? 'bypass' : agentPermissionMode.value,
+      // Resolved in exactly one place (utils/create-overrides) so what the page
+      // displays and what the request carries can never drift apart.
+      agentPermissionMode: resolvedOverrides.value.agentPermissionMode,
     }
 
     const workspace = await store.createWorkspace(payload)
@@ -1652,18 +1734,38 @@ async function handleCreate() {
     })
 
     // Subscribe to receive WebSocket events for this workspace
-    const wsStore = useWebSocketStore()
-    wsStore.subscribe(workspace.id)
+    wsStoreForProgress.subscribe(workspace.id)
     store.selectWorkspace(workspace.id)
+    // The form has nothing left to save: the workspace exists. Drop the scope
+    // BEFORE navigating — the `finally` below resets `submitting` synchronously,
+    // so by the time the router guard runs (a microtask later) the predicate
+    // would be true again and every successful creation would pop the
+    // "unsaved work" dialog, with "Stay" trapping the user on the form of a
+    // workspace that was already created. `onUnmounted` unregisters again; the
+    // registry tolerates that (see unsaved-guard.test.ts).
+    unregisterUnsavedScope('create:form')
     void router.push({ name: 'workspace', params: { id: workspace.id } })
   } catch (err) {
+    // The server undoes what it created when a step fails — every step past
+    // `create-record` — so there is nothing half-built to navigate to, only an
+    // error worth reading. The message itself flags whatever the rollback
+    // could not reach. The step name is the whole point: "it failed" is what
+    // the page said before.
+    const step = (err as { code?: string })?.code
+    const message = err instanceof Error && err.message ? err.message : t('createPage.errorCreating')
     $q.notify({
       type: 'negative',
-      message: err instanceof Error && err.message ? err.message : t('createPage.errorCreating'),
       position: 'top',
+      timeout: 0,
+      multiLine: true,
+      message: step ? t('createPage.errorAtStep', { step, message }) : message,
+      actions: [{ label: t('common.close'), color: 'white' }],
     })
   } finally {
     submitting.value = false
+    wsStoreForProgress.unsubscribe(newCreationId)
+    creationId.value = null
+    store.clearCreationProgress()
   }
 }
 </script>
@@ -1681,6 +1783,39 @@ async function handleCreate() {
   top: var(--kobo-space-md);
   left: var(--kobo-space-md);
   z-index: 1;
+}
+
+.create-page__progress {
+  display: flex;
+  align-items: center;
+  gap: var(--kobo-space-sm);
+  color: var(--kobo-text-2);
+}
+
+.create-page__progress-counter {
+  font-family: var(--kobo-font-mono);
+  color: var(--kobo-text-3);
+}
+
+.create-page__overrides {
+  display: flex;
+  flex-direction: column;
+  gap: var(--kobo-space-xs);
+  padding: var(--kobo-space-md);
+  border: 1px solid var(--kobo-border-subtle);
+  border-radius: var(--kobo-radius-sm);
+  background: var(--kobo-surface-2);
+}
+
+.create-page__overrides-title {
+  display: flex;
+  align-items: center;
+  gap: var(--kobo-space-xs);
+  color: var(--kobo-text-2);
+}
+
+.create-page__overrides-item {
+  color: var(--kobo-text-3);
 }
 
 .create-inner {

--- a/src/client/src/pages/SettingsPage.vue
+++ b/src/client/src/pages/SettingsPage.vue
@@ -1,5 +1,15 @@
 <template>
   <q-page class="settings-page">
+    <div v-if="store.loadError" class="settings-load-error">
+      <q-icon name="error" size="18px" />
+      <div class="column">
+        <span class="settings-load-error__title">{{ $t('settings.loadFailed') }}</span>
+        <span class="settings-load-error__detail">{{ store.loadError }}</span>
+        <span class="settings-load-error__hint">{{ $t('settings.loadFailedHint') }}</span>
+      </div>
+      <q-space />
+      <q-btn dense flat no-caps icon="refresh" :label="$t('common.retry')" @click="reloadSettings" />
+    </div>
     <div class="settings-layout">
       <!-- Sidebar nav (desktop: fixed aside) -->
       <aside v-if="!isMobile" class="settings-nav">
@@ -1726,6 +1736,7 @@ where ffmpeg</pre>
                 size="sm"
                 color="primary"
                 :loading="savingGlobal"
+                :disable="!!store.loadError"
                 :class="{ 'save-btn--dirty': isGlobalDirty }"
                 @click="saveGlobal"
               />
@@ -2281,6 +2292,7 @@ where ffmpeg</pre>
                       size="sm"
                       color="primary"
                       :loading="savingProject"
+                      :disable="!!store.loadError"
                       :class="{ 'save-btn--dirty': isProjectDirty }"
                       @click="saveProject"
                     />
@@ -2511,6 +2523,7 @@ import {
 } from 'src/utils/notification-sounds'
 import { playNotificationSound } from 'src/utils/notifications'
 import { PROJECT_COLOR_PALETTE, type ProjectColor } from 'src/utils/project-color'
+import { registerUnsavedScope, unregisterUnsavedScope } from 'src/utils/unsaved-guard'
 import { getWhipVolumeAvailability } from 'src/utils/whip-settings'
 import { DEFAULT_WHIP_SHORTCUT } from 'src/utils/whip-shortcut'
 import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
@@ -3555,14 +3568,22 @@ const isGlobalDirty = computed(() => captureGlobalSnapshot() !== globalSavedSnap
 const isProjectDirty = computed(() => captureProjectSnapshot() !== projectSavedSnapshot.value)
 
 const savebarVisible = computed(() => {
-  if (activeTab.value === 'projects')
-    return isProjectDirty.value && (selectedProject.value !== null || isNewProject.value)
-  if (activeTab.value === 'templates') return false
-  return isGlobalDirty.value
+  // A failed load must never offer a Save: the form is on defaults.
+  if (store.loadError) return false
+  // Any dirty scope keeps the bar up, whichever tab is showing. Computing it
+  // per tab made the warning vanish on tab switch, and the user believed they
+  // had saved (see unsaved-guard.ts).
+  if (isGlobalDirty.value) return true
+  return isProjectDirty.value && (selectedProject.value !== null || isNewProject.value)
 })
-const savebarLoading = computed(() => (activeTab.value === 'projects' ? savingProject.value : saving.value))
+const savebarLoading = computed(() => {
+  // Mirrors savebarSave's own condition rather than the active tab, for the
+  // same reason: the dirty scope, not the visible tab, decides what happens.
+  if (isProjectDirty.value && (selectedProject.value !== null || isNewProject.value)) return savingProject.value
+  return saving.value
+})
 function savebarSave() {
-  if (activeTab.value === 'projects') saveProject()
+  if (isProjectDirty.value && (selectedProject.value !== null || isNewProject.value)) saveProject()
   else saveGlobal()
 }
 
@@ -4157,6 +4178,11 @@ function filterBranches(val: string, update: (fn: () => void) => void) {
   })
 }
 
+async function reloadSettings() {
+  await store.fetchSettings()
+  if (!store.loadError) syncGlobalForm()
+}
+
 // Init
 onMounted(async () => {
   await Promise.all([store.fetchSettings(), store.fetchActiveMcpServers(), fetchAvailableSkills()])
@@ -4171,12 +4197,16 @@ onMounted(async () => {
   syncGlobalForm()
   if (store.global.notionEnabled) loadNotionUsers().catch(() => {})
   void fetchNetwork()
+  registerUnsavedScope('settings:global', () => isGlobalDirty.value)
+  registerUnsavedScope('settings:project', () => isProjectDirty.value)
 })
 
 // Cleanup debounce timer on unmount
 onUnmounted(() => {
   if (pathDebounce) clearTimeout(pathDebounce)
   stopVoiceModelsPolling()
+  unregisterUnsavedScope('settings:global')
+  unregisterUnsavedScope('settings:project')
 })
 </script>
 
@@ -4186,6 +4216,8 @@ onUnmounted(() => {
   position: relative;
   padding: 0;
   min-height: 100vh;
+  display: flex;
+  flex-direction: column;
 }
 
 .purge-docs {
@@ -4205,9 +4237,28 @@ onUnmounted(() => {
   word-break: break-all;
 }
 
+.settings-load-error {
+  display: flex;
+  align-items: flex-start;
+  flex-shrink: 0;
+  gap: var(--kobo-space-sm);
+  padding: var(--kobo-space-md);
+  border: 1px solid var(--kobo-danger);
+  border-radius: var(--kobo-radius-sm);
+  background: var(--kobo-surface);
+  color: var(--kobo-text);
+}
+
+.settings-load-error__detail,
+.settings-load-error__hint {
+  font-size: 12px;
+  color: var(--kobo-text-3);
+}
+
 .settings-layout {
-  position: absolute;
-  inset: 0;
+  position: relative;
+  flex: 1 1 auto;
+  min-height: 0;
   display: flex;
   align-items: stretch;
   overflow: hidden;

--- a/src/client/src/router/index.ts
+++ b/src/client/src/router/index.ts
@@ -1,3 +1,6 @@
+import { Dialog } from 'quasar'
+import i18n from 'src/i18n'
+import { hasUnsavedWork } from 'src/utils/unsaved-guard'
 import { createRouter, createWebHashHistory } from 'vue-router'
 import { defineRouter } from '#q-app'
 import routes from './routes'
@@ -7,6 +10,34 @@ export default defineRouter(() => {
     scrollBehavior: () => ({ left: 0, top: 0 }),
     routes,
     history: createWebHashHistory(),
+  })
+
+  // No guard existed anywhere in the client: modified settings, a filled-in
+  // creation form and a file edited in the diff viewer all vanished silently.
+  Router.beforeEach((to, from, next) => {
+    if (to.fullPath === from.fullPath || !hasUnsavedWork()) {
+      next()
+      return
+    }
+    const t = i18n.global.t
+    Dialog.create({
+      title: t('unsaved.title'),
+      message: t('unsaved.message'),
+      dark: true,
+      cancel: { flat: true, label: t('unsaved.stay'), color: 'grey-5' },
+      ok: { flat: true, label: t('unsaved.leave'), color: 'negative' },
+    })
+      .onOk(() => next())
+      .onCancel(() => next(false))
+  })
+
+  // Tab close / reload: modern browsers ignore any custom message here and
+  // show their own generic prompt, so we only ever set returnValue to signal
+  // "something to lose" — unsaved.title/message are never rendered by this path.
+  window.addEventListener('beforeunload', (event) => {
+    if (!hasUnsavedWork()) return
+    event.preventDefault()
+    event.returnValue = ''
   })
 
   return Router

--- a/src/client/src/stores/settings.ts
+++ b/src/client/src/stores/settings.ts
@@ -1,4 +1,5 @@
 import { defineStore } from 'pinia'
+import { ApiError, apiFetch } from 'src/utils/api'
 import { DEFAULT_PR_NOTIFICATION_AUDIO_SETTINGS } from 'src/utils/notification-sounds'
 import type { ProjectColor } from 'src/utils/project-color'
 import { DEFAULT_WHIP_SHORTCUT } from 'src/utils/whip-shortcut'
@@ -296,6 +297,12 @@ export const useSettingsStore = defineStore('settings', {
     activeMcpServers: [] as ActiveMcpServer[],
     projects: [] as ProjectSettings[],
     loading: false,
+    /** True only after a settings load that actually succeeded. Every write
+     *  path checks it: a failed load leaves the form on the DEFAULT values
+     *  declared above, and saving those would overwrite the real config. */
+    loaded: false,
+    /** Server message of the last failed load, null when the last load worked. */
+    loadError: null as string | null,
     showVerboseSystemMessages: localStorage.getItem('kobo:showVerboseSystemMessages') === 'true',
   }),
 
@@ -306,15 +313,27 @@ export const useSettingsStore = defineStore('settings', {
   },
 
   actions: {
+    /** Throws unless a settings load has actually succeeded. Guards every write. */
+    _assertLoaded() {
+      if (!this.loaded) {
+        throw new Error('Settings were never loaded successfully — refusing to overwrite the stored configuration')
+      }
+    },
+
     async fetchSettings() {
       this.loading = true
       try {
-        const res = await fetch('/api/settings')
-        if (!res.ok) throw new Error(`HTTP ${res.status}`)
-        const data = await res.json()
+        const data = await apiFetch<{ global: GlobalSettings; projects: ProjectSettings[] }>('/api/settings')
         this.global = data.global
         this.projects = data.projects
+        this.loadError = null
+        this.loaded = true
       } catch (err) {
+        // NEVER pretend a failed load is an empty configuration: the form would
+        // render the store defaults, and one click on Save would write them
+        // over the user's real scripts, conventions and tokens.
+        this.loadError = err instanceof Error ? err.message : String(err)
+        this.loaded = false
         console.error('[settings store] fetchSettings failed:', err)
       } finally {
         this.loading = false
@@ -323,9 +342,7 @@ export const useSettingsStore = defineStore('settings', {
 
     async fetchActiveMcpServers() {
       try {
-        const res = await fetch('/api/settings/mcp-servers')
-        if (!res.ok) throw new Error(`HTTP ${res.status}`)
-        this.activeMcpServers = await res.json()
+        this.activeMcpServers = await apiFetch<ActiveMcpServer[]>('/api/settings/mcp-servers')
       } catch (err) {
         console.error('[settings store] fetchActiveMcpServers failed:', err)
         this.activeMcpServers = []
@@ -342,46 +359,26 @@ export const useSettingsStore = defineStore('settings', {
       sentryInitialPromptTemplate: string
       changeSourceBranchScript: string
     }> {
-      const res = await fetch('/api/settings/defaults')
-      if (!res.ok) throw new Error(`HTTP ${res.status}`)
-      return res.json()
+      return apiFetch('/api/settings/defaults')
     },
 
     async updateGlobal(data: Partial<GlobalSettings>) {
-      try {
-        const res = await fetch('/api/settings/global', {
-          method: 'PUT',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify(data),
-        })
-        if (!res.ok) throw new Error(`HTTP ${res.status}`)
-        const updated = await res.json()
-        this.global = updated
-      } catch (err) {
-        console.error('[settings store] updateGlobal failed:', err)
-        throw err
-      }
+      this._assertLoaded()
+      this.global = await apiFetch<GlobalSettings>('/api/settings/global', { method: 'PUT', body: data })
     },
 
     async upsertProject(projectPath: string, data: Partial<Omit<ProjectSettings, 'path'>>) {
-      try {
-        const encoded = toBase64Url(projectPath)
-        const res = await fetch(`/api/settings/projects/${encoded}`, {
-          method: 'PUT',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify(data),
-        })
-        if (!res.ok) throw new Error(`HTTP ${res.status}`)
-        const project = await res.json()
-        const idx = this.projects.findIndex((p) => p.path === projectPath)
-        if (idx >= 0) {
-          this.projects[idx] = project
-        } else {
-          this.projects.push(project)
-        }
-      } catch (err) {
-        console.error('[settings store] upsertProject failed:', err)
-        throw err
+      this._assertLoaded()
+      const encoded = toBase64Url(projectPath)
+      const project = await apiFetch<ProjectSettings>(`/api/settings/projects/${encoded}`, {
+        method: 'PUT',
+        body: data,
+      })
+      const idx = this.projects.findIndex((p) => p.path === projectPath)
+      if (idx >= 0) {
+        this.projects[idx] = project
+      } else {
+        this.projects.push(project)
       }
     },
 
@@ -395,27 +392,20 @@ export const useSettingsStore = defineStore('settings', {
     },
 
     async deleteProject(projectPath: string) {
-      try {
-        const encoded = toBase64Url(projectPath)
-        const res = await fetch(`/api/settings/projects/${encoded}`, { method: 'DELETE' })
-        if (!res.ok) throw new Error(`HTTP ${res.status}`)
-        this.projects = this.projects.filter((p) => p.path !== projectPath)
-      } catch (err) {
-        console.error('[settings store] deleteProject failed:', err)
-        throw err
-      }
+      this._assertLoaded()
+      const encoded = toBase64Url(projectPath)
+      await apiFetch(`/api/settings/projects/${encoded}`, { method: 'DELETE' })
+      this.projects = this.projects.filter((p) => p.path !== projectPath)
     },
 
     async fetchVoiceModels() {
       this.voiceModelsLoading = true
       try {
-        const res = await fetch('/api/voice/models')
-        if (!res.ok) throw new Error(`HTTP ${res.status}`)
-        const data = (await res.json()) as {
+        const data = await apiFetch<{
           modelsDir: string
           available: VoiceModelStatus[]
           activeModel: string | null
-        }
+        }>('/api/voice/models')
         this.voiceModels = data.available
         this.voiceModelsDir = data.modelsDir
         this.global.voiceModel = data.activeModel
@@ -427,30 +417,31 @@ export const useSettingsStore = defineStore('settings', {
     },
 
     async cancelVoiceModelDownload(name: string) {
-      const res = await fetch(`/api/voice/models/${encodeURIComponent(name)}/download`, { method: 'DELETE' })
-      if (!res.ok && res.status !== 404) throw new Error(`HTTP ${res.status}`)
+      try {
+        await apiFetch(`/api/voice/models/${encodeURIComponent(name)}/download`, { method: 'DELETE' })
+      } catch (err) {
+        // A 404 means the download already finished or was never armed — not
+        // a failure from the user's point of view.
+        if (!(err instanceof ApiError) || err.status !== 404) throw err
+      }
       await this.fetchVoiceModels()
     },
 
     async fetchVoiceRuntime() {
       try {
-        const res = await fetch('/api/voice/runtime')
-        if (!res.ok) throw new Error(`HTTP ${res.status}`)
-        this.voiceRuntime = (await res.json()) as VoiceRuntimeStatus
+        this.voiceRuntime = await apiFetch<VoiceRuntimeStatus>('/api/voice/runtime')
       } catch (err) {
         console.error('[settings store] fetchVoiceRuntime failed:', err)
       }
     },
 
     async downloadVoiceModel(name: string) {
-      const res = await fetch(`/api/voice/models/${encodeURIComponent(name)}/download`, { method: 'POST' })
-      if (!res.ok) throw new Error(`HTTP ${res.status}`)
+      await apiFetch(`/api/voice/models/${encodeURIComponent(name)}/download`, { method: 'POST' })
       await this.fetchVoiceModels()
     },
 
     async deleteVoiceModel(name: string) {
-      const res = await fetch(`/api/voice/models/${encodeURIComponent(name)}`, { method: 'DELETE' })
-      if (!res.ok) throw new Error(`HTTP ${res.status}`)
+      await apiFetch(`/api/voice/models/${encodeURIComponent(name)}`, { method: 'DELETE' })
       await this.fetchVoiceModels()
     },
   },

--- a/src/client/src/stores/websocket.ts
+++ b/src/client/src/stores/websocket.ts
@@ -581,6 +581,20 @@ export const useWebSocketStore = defineStore('websocket', {
       })
     },
 
+    /**
+     * Subscribe to a non-workspace broadcast channel — currently the
+     * `creationId` a POST /api/workspaces progress stream is published on.
+     * Unlike `subscribe`, this sends NO `sync:request`: the channel has no
+     * persisted history to replay (the server uses `emitEphemeral`), and
+     * asking for one would query ws_events for an id that does not exist.
+     */
+    subscribeChannel(channelId: string) {
+      this._send({
+        type: 'subscribe',
+        payload: { workspaceId: channelId },
+      })
+    },
+
     sendChatMessage(
       workspaceId: string,
       content: string,
@@ -1350,6 +1364,36 @@ export const useWebSocketStore = defineStore('websocket', {
                       ? 'notification.autoLoopAwaitingClarification'
                       : null // 'manual'/'user-action' → user disabled it themselves, don't notify
             if (titleKey) notify(t(titleKey, { name: wsName }), undefined, wid)
+          }
+          break
+        }
+
+        case 'workspace:create-progress': {
+          const step = typeof payload.step === 'string' ? payload.step : ''
+          const creationId = typeof payload.creationId === 'string' ? payload.creationId : ''
+          if (creationId && step) {
+            workspaceStore.setCreationProgress({
+              creationId,
+              step,
+              index: typeof payload.index === 'number' ? payload.index : 0,
+              total: typeof payload.total === 'number' ? payload.total : 0,
+            })
+          }
+          break
+        }
+
+        case 'workspace:create-failed': {
+          // The step name is what makes the failure actionable — the page
+          // renders it; clearing the progress here would erase it.
+          const creationId = typeof payload.creationId === 'string' ? payload.creationId : ''
+          const step = typeof payload.step === 'string' ? payload.step : ''
+          if (creationId && step) {
+            workspaceStore.setCreationProgress({
+              creationId,
+              step,
+              index: -1,
+              total: 0,
+            })
           }
           break
         }

--- a/src/client/src/stores/workspace.ts
+++ b/src/client/src/stores/workspace.ts
@@ -1,4 +1,5 @@
 import { defineStore } from 'pinia'
+import { apiFetch } from 'src/utils/api'
 import type { ProviderId, UsageSnapshot } from '../types/usage'
 import { hasPrAttention } from '../utils/pr-status'
 import { isBusyStatus } from '../utils/workspace-status'
@@ -113,6 +114,11 @@ export interface CreateWorkspaceInput {
   acceptanceCriteria?: string[]
   autoLoop?: boolean
   autoLoopSessionMode?: 'per_task' | 'continuous'
+  // Client-generated channel id the caller subscribed to (via
+  // websocketStore.subscribeChannel) *before* this call, so it can receive
+  // `workspace:create-progress` / `workspace:create-failed` beats for a
+  // workspace that doesn't have an id yet.
+  creationId?: string
 }
 
 export class WorkspaceActionError extends Error {
@@ -387,6 +393,22 @@ export const useWorkspaceStore = defineStore('workspace', {
     archivedWorkspaces: [] as Workspace[],
     archivedLoaded: false,
     loading: false,
+    // Server message (or transport error) from the most recent failed
+    // fetchWorkspaces/fetchArchivedWorkspaces/fetchWorkspacesInfo call. Null
+    // means the last load succeeded — this is what lets the sidebar tell a
+    // dead backend apart from a genuinely empty account, which used to render
+    // identically.
+    listLoadError: null as string | null,
+    // Consecutive failures of the 30s `/api/workspaces/info` poll. The banner
+    // only goes up on the second one: a single dropped poll (a laptop waking
+    // up, a proxy blip) must not flash "backend is down" at a user whose
+    // backend is fine. The initial load has no such delay — someone who just
+    // opened the app is waiting for an answer.
+    listPollFailureStreak: 0,
+    // True when the last load of the ACTIVE list failed. Keeps a successful
+    // archived load from clearing a banner it has no authority over:
+    // `retryLoadWorkspaces` runs both loaders back to back.
+    activeListLoadFailed: false,
     loadingOlderEvents: false,
     hasMoreEvents: {} as Record<string, boolean>,
     providerUsage: {} as Record<ProviderId, UsageSnapshot | undefined>,
@@ -405,6 +427,10 @@ export const useWorkspaceStore = defineStore('workspace', {
     prSnapshots: {} as Record<string, PrSnapshot>,
     autoLoopStates: {} as Record<string, AutoLoopStatus>,
     crons: {} as Record<string, PendingCron[]>,
+    // Live step of an in-flight POST /api/workspaces, fed by the ephemeral
+    // `workspace:create-progress` events the server emits on the creationId
+    // channel. Null whenever no creation is running.
+    creationProgress: null as { creationId: string; step: string; index: number; total: number } | null,
     // Server-side memory truth. A workspace absent from this map has no agent,
     // whatever its `status` column says.
     agentLiveness: {} as Record<string, AgentLiveness>,
@@ -532,6 +558,14 @@ export const useWorkspaceStore = defineStore('workspace', {
       localStorage.removeItem(`kobo:session:${id}`)
     },
 
+    setCreationProgress(progress: { creationId: string; step: string; index: number; total: number }) {
+      this.creationProgress = progress
+    },
+
+    clearCreationProgress() {
+      this.creationProgress = null
+    },
+
     async toggleFavorite(id: string) {
       // Resolve by id both before and after the network call — the workspace
       // array can be reordered (or the workspace removed) by a concurrent
@@ -614,19 +648,19 @@ export const useWorkspaceStore = defineStore('workspace', {
     async fetchOrphanWorktrees(
       projectPath: string,
     ): Promise<Array<{ path: string; branch: string; head: string; suggestedSourceBranch: string }>> {
-      const url = `/api/git/orphan-worktrees?projectPath=${encodeURIComponent(projectPath)}`
-      const res = await fetch(url, { cache: 'no-store' })
-      if (!res.ok) throw new Error(`HTTP ${res.status}`)
-      return res.json()
+      return apiFetch(`/api/git/orphan-worktrees?projectPath=${encodeURIComponent(projectPath)}`, {
+        cache: 'no-store',
+      })
     },
 
     async fetchWorkspaces() {
       this.loading = true
       try {
-        const res = await fetch('/api/workspaces')
-        if (!res.ok) throw new Error(`HTTP ${res.status}`)
-        const data = await res.json()
-        this.workspaces = data.workspaces ?? data
+        const data = await apiFetch<{ workspaces?: Workspace[] } | Workspace[]>('/api/workspaces')
+        this.workspaces = Array.isArray(data) ? data : (data.workspaces ?? [])
+        this.listLoadError = null
+        this.activeListLoadFailed = false
+        this.listPollFailureStreak = 0
         // Finalize orphan sub-agents for workspaces that came back in a
         // terminal state. Covers the rare case where `session:ended` was
         // missed (WS reconnect, browser tab returning from sleep, etc.)
@@ -637,19 +671,34 @@ export const useWorkspaceStore = defineStore('workspace', {
           }
         }
       } catch (err) {
+        // A dead backend and an empty account used to render identically.
+        // Recording the failure — without touching `this.workspaces` — is
+        // what lets the sidebar say which one it is, without wiping out a
+        // list that was already showing on screen.
+        this.listLoadError = err instanceof Error ? err.message : String(err)
+        this.activeListLoadFailed = true
         console.error('[workspace store] fetchWorkspaces failed:', err)
       } finally {
         this.loading = false
       }
     },
 
+    /** Re-runs the loaders behind the sidebar's Retry button after a failed load. */
+    async retryLoadWorkspaces() {
+      await this.fetchWorkspaces()
+      if (this.archivedLoaded) await this.fetchArchivedWorkspaces()
+    },
+
     async fetchArchivedWorkspaces() {
       try {
-        const res = await fetch('/api/workspaces/archived')
-        if (!res.ok) throw new Error(`HTTP ${res.status}`)
-        this.archivedWorkspaces = await res.json()
+        this.archivedWorkspaces = await apiFetch<Workspace[]>('/api/workspaces/archived')
         this.archivedLoaded = true
+        // This loader used to post the banner and never lift it, so a failure
+        // survived the backend coming back. It clears its own failure — but
+        // never one the active list raised, which it knows nothing about.
+        if (!this.activeListLoadFailed) this.listLoadError = null
       } catch (err) {
+        this.listLoadError = err instanceof Error ? err.message : String(err)
         console.error('[workspace store] fetchArchivedWorkspaces failed:', err)
       }
     },
@@ -659,9 +708,9 @@ export const useWorkspaceStore = defineStore('workspace', {
       _workspaceDetailsRequestVersions.set(id, requestVersion)
       const eventVersionAtStart = _workspaceEventVersions.get(id) ?? 0
       try {
-        const res = await fetch(`/api/workspaces/${id}`)
-        if (!res.ok) throw new Error(`HTTP ${res.status}`)
-        const data = await res.json()
+        const data = await apiFetch<{ workspace?: Workspace; tasks?: Task[] } & Partial<Workspace>>(
+          `/api/workspaces/${id}`,
+        )
 
         // Guard against stale response: user may have switched workspace while
         // this request was in flight.
@@ -689,7 +738,7 @@ export const useWorkspaceStore = defineStore('workspace', {
           if (aIdx >= 0) {
             this.archivedWorkspaces[aIdx] = { ...this.archivedWorkspaces[aIdx], ...incoming }
           } else if (incoming?.archivedAt) {
-            this.archivedWorkspaces.unshift(incoming)
+            this.archivedWorkspaces.unshift(incoming as Workspace)
           }
         }
 
@@ -731,14 +780,24 @@ export const useWorkspaceStore = defineStore('workspace', {
 
     async createWorkspace(input: CreateWorkspaceInput) {
       try {
+        // Kept on raw fetch on purpose: this is the only call that reads the
+        // X-Kobo-Branch-Adjusted / X-Kobo-Source-Fallback response headers,
+        // which apiFetch deliberately does not expose. The error path below
+        // already reads the server message, so F43 does not apply here.
         const res = await fetch('/api/workspaces', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify(input),
         })
         if (!res.ok) {
-          const body = (await res.json().catch(() => ({}))) as { error?: unknown }
-          throw new Error(typeof body.error === 'string' ? body.error : `HTTP ${res.status}`)
+          // The server destroys what it created when a creation step fails —
+          // every step past `create-record`, not just a couple of them — so
+          // there is nothing to push into the list, only an error to show. It
+          // names the step that broke, and says what the rollback could not
+          // reach (setup-script side effects outside the worktree).
+          const body = (await res.json().catch(() => ({}))) as { error?: unknown; step?: unknown }
+          const message = typeof body.error === 'string' ? body.error : `HTTP ${res.status}`
+          throw new WorkspaceActionError(message, typeof body.step === 'string' ? body.step : undefined)
         }
         // The server appends a `-<HASH>` suffix to the working branch (and
         // matching worktree path) when the requested name was already taken.
@@ -776,15 +835,10 @@ export const useWorkspaceStore = defineStore('workspace', {
 
     async startWorkspace(id: string, prompt?: string, agentSessionId?: string, resume?: boolean) {
       try {
-        const res = await fetch(`/api/workspaces/${id}/start`, {
+        await apiFetch(`/api/workspaces/${id}/start`, {
           method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ prompt, agentSessionId, resume }),
+          body: { prompt, agentSessionId, resume },
         })
-        if (!res.ok) {
-          const body = await res.json().catch(() => ({}))
-          throw new Error(body.error ?? `HTTP ${res.status}`)
-        }
         await this.fetchWorkspaces()
       } catch (err) {
         console.error('[workspace store] startWorkspace failed:', err)
@@ -1080,9 +1134,7 @@ export const useWorkspaceStore = defineStore('workspace', {
 
     async fetchGitStats(id: string, opts: { freshFetch?: boolean; signal?: AbortSignal } = {}): Promise<GitStats> {
       const url = `/api/workspaces/${id}/git-stats${opts.freshFetch ? '?freshFetch=1' : ''}`
-      const res = await fetch(url, { signal: opts.signal })
-      if (!res.ok) throw new Error(`HTTP ${res.status}`)
-      const stats = (await res.json()) as GitStats
+      const stats = await apiFetch<GitStats>(url, { signal: opts.signal, timeoutMs: 60_000 })
       this.gitStatsCache[id] = stats
       return stats
     },
@@ -1510,14 +1562,18 @@ export const useWorkspaceStore = defineStore('workspace', {
       const eventVersionsAtStart = new Map(_workspaceEventVersions)
       const prVersionsAtStart = new Map(_prSnapshotVersions)
       try {
-        const res = await fetch('/api/workspaces/info', { cache: 'no-store' })
-        if (!res.ok) return
-        const data = (await res.json()) as {
+        const data = await apiFetch<{
           workspaces: Workspace[]
           prSnapshots: Record<string, PrSnapshot>
           gitStats: Record<string, GitStats>
           agentLiveness?: Record<string, AgentLiveness>
-        }
+        }>('/api/workspaces/info', { cache: 'no-store' })
+        // The backend answered: that is true whether or not this particular
+        // response is still the freshest one, so lift the banner before the
+        // staleness check below.
+        this.listPollFailureStreak = 0
+        this.activeListLoadFailed = false
+        this.listLoadError = null
         if (requestToken !== _workspacesInfoRequestToken) return
         // Full replacement, never a merge: an entry that disappeared means the
         // controller is gone, which is the single most important thing to show.
@@ -1557,6 +1613,16 @@ export const useWorkspaceStore = defineStore('workspace', {
         this.gitStatsCache = mergedStats
       } catch (err) {
         console.error('[workspace-store] fetchWorkspacesInfo failed:', err)
+        // A backend that dies AFTER the initial load is the dominant real
+        // case — the user leaves the tab open. The poll used to swallow that
+        // entirely, leaving a list that looked live but was frozen. Record
+        // the failure, and never touch `this.workspaces`: an error must not
+        // wipe data that is still valid on screen.
+        this.listPollFailureStreak += 1
+        if (this.listPollFailureStreak >= 2) {
+          this.activeListLoadFailed = true
+          this.listLoadError = err instanceof Error ? err.message : String(err)
+        }
       }
     },
 

--- a/src/client/src/utils/api.ts
+++ b/src/client/src/utils/api.ts
@@ -1,0 +1,147 @@
+/**
+ * The single network entry point for the client.
+ *
+ * It sits ON TOP of the `window.fetch` override installed by
+ * `boot/network-auth.ts` — token injection and the 401 login prompt keep
+ * working untouched. What it adds is what 153 raw call sites lacked: a
+ * request deadline, cancellation, and above all the SERVER's error message.
+ * The backend answers `{ error: "<descriptive message>" }` on every failure;
+ * 65 call sites used to throw that away to show `HTTP 500` instead.
+ */
+
+export class ApiError extends Error {
+  readonly status: number
+  readonly code: string | undefined
+  readonly body: string
+
+  constructor(message: string, status: number, code: string | undefined, body: string) {
+    super(message)
+    this.name = 'ApiError'
+    this.status = status
+    this.code = code
+    this.body = body
+  }
+}
+
+export class ApiTimeoutError extends Error {
+  readonly timeoutMs: number
+
+  constructor(timeoutMs: number) {
+    super(`Request timed out after ${timeoutMs} ms`)
+    this.name = 'ApiTimeoutError'
+    this.timeoutMs = timeoutMs
+  }
+}
+
+/** Long enough for a slow git fetch behind the API, short enough that a hung
+ *  request never leaves a spinner turning forever. Pass 0 to disable. */
+export const DEFAULT_API_TIMEOUT_MS = 30_000
+
+export interface ApiOptions extends Omit<RequestInit, 'body' | 'signal'> {
+  /** Plain object → JSON.stringify + Content-Type. String/FormData/Blob → sent as-is. */
+  body?: unknown
+  /** Milliseconds before the request is aborted. 0 disables the deadline. */
+  timeoutMs?: number
+  /** Caller-owned cancellation, composed with the deadline. */
+  signal?: AbortSignal
+}
+
+function extractError(raw: string, status: number): { message: string; code: string | undefined } {
+  const trimmed = raw.trim()
+  if (trimmed.length === 0) return { message: `HTTP ${status}`, code: undefined }
+  try {
+    const parsed = JSON.parse(trimmed) as { error?: unknown; message?: unknown; code?: unknown }
+    const code = typeof parsed.code === 'string' ? parsed.code : undefined
+    if (typeof parsed.error === 'string' && parsed.error.length > 0) return { message: parsed.error, code }
+    if (typeof parsed.message === 'string' && parsed.message.length > 0) return { message: parsed.message, code }
+    return { message: `HTTP ${status}`, code }
+  } catch {
+    // Not JSON (an HTML error page, a proxy banner…). Show a bounded excerpt
+    // rather than an opaque status code.
+    return { message: trimmed.slice(0, 500), code: undefined }
+  }
+}
+
+/**
+ * Fetches `path` and parses a successful JSON response as `T`.
+ *
+ * TYPE HONESTY NOTE — read before trusting the `T` you asked for: on a `204
+ * No Content`, or any 2xx response with an empty body, this resolves to
+ * `undefined`, not `T`. Nothing at compile time can stop that — the generic
+ * is a promise about what a body-bearing response contains, not a guarantee
+ * that a body exists. Callers of endpoints that may legitimately answer with
+ * no body (DELETE-style routes, `204` acks, etc.) must write
+ * `apiFetch<Workspace | undefined>(...)` or check the result before use;
+ * callers of endpoints that always return a body can use `apiFetch<Workspace>(...)`
+ * as documentation of intent, understanding it is not runtime-enforced.
+ */
+export async function apiFetch<T = unknown>(path: string, options: ApiOptions = {}): Promise<T> {
+  const { body, timeoutMs = DEFAULT_API_TIMEOUT_MS, signal, headers, ...rest } = options
+
+  // Composed manually rather than via AbortSignal.any/timeout: those are not
+  // uniformly present across the browsers Kōbō is opened in from a phone, and
+  // the manual version is what lets us tell a deadline apart from a caller
+  // abort in the catch below.
+  const controller = new AbortController()
+  let timedOut = false
+  const timer =
+    timeoutMs > 0
+      ? setTimeout(() => {
+          timedOut = true
+          controller.abort()
+        }, timeoutMs)
+      : null
+  const onCallerAbort = () => controller.abort()
+  signal?.addEventListener('abort', onCallerAbort)
+
+  const init: RequestInit = { ...rest, signal: controller.signal }
+  if (body !== undefined) {
+    if (typeof body === 'string' || body instanceof FormData || body instanceof Blob) {
+      init.body = body as BodyInit
+      if (headers) init.headers = headers
+    } else {
+      init.body = JSON.stringify(body)
+      init.headers = { 'Content-Type': 'application/json', ...((headers as Record<string, string>) ?? {}) }
+    }
+  } else if (headers) {
+    init.headers = headers
+  }
+
+  let res: Response
+  try {
+    res = await fetch(path, init)
+  } catch (err) {
+    if (timedOut) throw new ApiTimeoutError(timeoutMs)
+    throw err
+  } finally {
+    if (timer !== null) clearTimeout(timer)
+    signal?.removeEventListener('abort', onCallerAbort)
+  }
+
+  if (!res.ok) {
+    const raw = await res.text().catch(() => '')
+    const { message, code } = extractError(raw, res.status)
+    throw new ApiError(message, res.status, code, raw)
+  }
+
+  // No body to parse: 204 by convention, or a 2xx with an empty payload.
+  // See the type-honesty note above — the caller's `T` is not honored here.
+  if (res.status === 204) return undefined as T
+  const text = await res.text()
+  if (text.length === 0) return undefined as T
+
+  try {
+    return JSON.parse(text) as T
+  } catch (err) {
+    // A 2xx response whose body isn't valid JSON is still a failure the
+    // caller needs to handle — wrap it in ApiError so every failure path
+    // (HTTP error, timeout, bad body) is catchable the same way.
+    const reason = err instanceof Error ? err.message : String(err)
+    throw new ApiError(
+      `Server returned a non-JSON body for a successful response: ${reason}`,
+      res.status,
+      undefined,
+      text,
+    )
+  }
+}

--- a/src/client/src/utils/create-overrides.ts
+++ b/src/client/src/utils/create-overrides.ts
@@ -1,0 +1,49 @@
+/**
+ * Two settings on the create page are silently overridden by the form itself.
+ * Both used to live as inline ternaries inside the request payload, so nothing
+ * guaranteed the UI showed what the network actually sent — and the user could
+ * flip a toggle that had no effect, with no explanation.
+ *
+ * This resolves both in one place and, crucially, REPORTS which overrides
+ * applied so the page can say so out loud.
+ */
+
+export type CreateOverrideId = 'setup-script-forced' | 'permission-mode-downgraded'
+
+export type CreateAgentPermissionMode = 'plan' | 'bypass' | 'strict' | 'interactive'
+
+export interface CreateFormInput {
+  useExistingWorktree: boolean
+  skipSetupScript: boolean
+  autoLoop: boolean
+  agentPermissionMode: CreateAgentPermissionMode
+}
+
+export interface CreateResolvedOverrides {
+  skipSetupScript: boolean
+  agentPermissionMode: CreateAgentPermissionMode
+  applied: CreateOverrideId[]
+}
+
+export function resolveCreateOverrides(input: CreateFormInput): CreateResolvedOverrides {
+  const applied: CreateOverrideId[] = []
+
+  // Reusing a worktree the user curated: re-running the setup script could be
+  // destructive (dropping a warmed node_modules / vendor tree), so the server
+  // ignores the flag. Report it rather than leaving a live toggle that lies.
+  let skipSetupScript = input.skipSetupScript
+  if (input.useExistingWorktree && !skipSetupScript) {
+    skipSetupScript = true
+    applied.push('setup-script-forced')
+  }
+
+  // Plan mode blocks MCP calls and edits, which an auto-loop needs. The
+  // downgrade is a real change of security posture, not a UI detail.
+  let agentPermissionMode = input.agentPermissionMode
+  if (input.autoLoop && agentPermissionMode === 'plan') {
+    agentPermissionMode = 'bypass'
+    applied.push('permission-mode-downgraded')
+  }
+
+  return { skipSetupScript, agentPermissionMode, applied }
+}

--- a/src/client/src/utils/git-output.ts
+++ b/src/client/src/utils/git-output.ts
@@ -1,0 +1,19 @@
+/**
+ * Git failures come in two very different shapes.
+ *
+ * `fatal: not a git repository` is one short line — a toast is right for it.
+ * A merge conflict or a rejected pre-push hook is twenty lines the user needs
+ * to READ, COPY and act on; throwing that into a six-second toast that
+ * dismisses itself, cannot be selected and is never translated is the current
+ * behaviour at twenty-four call sites in GitPanel.vue.
+ */
+
+export const GIT_OUTPUT_INLINE_MAX_LINES = 2
+export const GIT_OUTPUT_INLINE_MAX_CHARS = 200
+
+export function needsScrollableOutput(message: string): boolean {
+  const trimmed = message.trim()
+  if (trimmed.length === 0) return false
+  if (trimmed.length > GIT_OUTPUT_INLINE_MAX_CHARS) return true
+  return trimmed.split('\n').length > GIT_OUTPUT_INLINE_MAX_LINES
+}

--- a/src/client/src/utils/notifications.ts
+++ b/src/client/src/utils/notifications.ts
@@ -1,3 +1,4 @@
+import { Notify } from 'quasar'
 import { useSettingsStore } from 'src/stores/settings'
 import { DEFAULT_NOTIFICATION_SOUND, resolveSoundId, soundUrl } from 'src/utils/notification-sounds'
 
@@ -137,4 +138,46 @@ export function notify(
         : (settings.global.audioNotificationSound ?? DEFAULT_NOTIFICATION_SOUND)
     queueNotificationSound(sound, volumeOverride ?? settings.global.audioNotificationVolume)
   }
+}
+
+export interface RetryableErrorOptions {
+  /** Already translated by the caller — this module has no i18n context. */
+  retryLabel: string
+  onRetry: () => void
+  detailsLabel?: string
+  onDetails?: () => void
+  /** Required for the same reason `retryLabel` is: an internal English default
+   *  would be a user-visible string no locale file can reach. */
+  dismissLabel: string
+  /** Milliseconds. Defaults to 0 (stays until dismissed). */
+  timeout?: number
+}
+
+/**
+ * A failure notification the user can actually act on.
+ *
+ * Every error toast in the client used to be a dead end: read it, watch it
+ * vanish after six seconds, redo the gesture by hand. The default timeout is
+ * 0 on purpose — a toast carrying a button the user must click cannot also
+ * dismiss itself while they read it. Retry is never invented by this helper:
+ * the caller decides whether an action is safe to offer, exactly like the
+ * network helper leaves retry to the caller.
+ */
+export function notifyRetryableError(message: string, options: RetryableErrorOptions): void {
+  const actions: Array<{ label: string; color: string; handler?: () => void }> = [
+    { label: options.retryLabel, color: 'white', handler: options.onRetry },
+  ]
+  if (options.detailsLabel && options.onDetails) {
+    actions.push({ label: options.detailsLabel, color: 'white', handler: options.onDetails })
+  }
+  actions.push({ label: options.dismissLabel, color: 'grey-5' })
+
+  Notify.create({
+    type: 'negative',
+    position: 'top',
+    multiLine: true,
+    message,
+    timeout: options.timeout ?? 0,
+    actions,
+  })
 }

--- a/src/client/src/utils/terminal-reconnect.ts
+++ b/src/client/src/utils/terminal-reconnect.ts
@@ -1,0 +1,42 @@
+/**
+ * Reconnection schedule for the workspace terminal.
+ *
+ * A closed socket used to leave the panel looking OPEN: `isOpen` only checks
+ * `!exited`, so after a backend restart or a laptop waking from sleep the user
+ * kept typing into a dead connection, every keystroke dropped by the
+ * `readyState === OPEN` guard in the onData listener.
+ *
+ * Doubling from 500 ms picks a returning backend up almost immediately while
+ * never hammering one that is genuinely down. Bounded (unlike the main
+ * WebSocket store's unlimited backoff in `src/stores/websocket.ts`, which
+ * must keep retrying forever because losing it breaks the whole app): past
+ * `TERMINAL_RECONNECT_MAX_ATTEMPTS` the terminal gives up and the user takes
+ * over via the manual "Reconnect" button, since a single dead terminal tab
+ * does not warrant retrying indefinitely.
+ */
+
+export const TERMINAL_RECONNECT_MAX_ATTEMPTS = 6
+const BASE_DELAY_MS = 500
+const MAX_DELAY_MS = 10_000
+
+/** Delay before attempt number `attempt` (1-based). `null` means give up. */
+export function terminalReconnectDelayMs(attempt: number): number | null {
+  if (attempt < 1 || attempt > TERMINAL_RECONNECT_MAX_ATTEMPTS) return null
+  return Math.min(BASE_DELAY_MS * 2 ** (attempt - 1), MAX_DELAY_MS)
+}
+
+/**
+ * Whether refocusing a workspace tab should open a new socket for its
+ * terminal. Pulled out as pure logic so the double-connect regression can be
+ * asserted without mounting `TerminalPanel.vue`: switching away from a
+ * workspace while a reconnect backoff is armed, then switching back, used to
+ * fire an immediate `connectWs` from the `workspaceId` watcher on top of the
+ * timer that was still pending — two sockets racing to replace the same
+ * entry. Callers MUST also cancel any pending reconnect timer before acting
+ * on this decision (see `TerminalPanel.vue`'s `clearReconnectTimer`); this
+ * function only answers "is a fresh connection needed", not "is one already
+ * scheduled".
+ */
+export function shouldConnectOnFocus(state: { wsOpen: boolean; exited: boolean }): boolean {
+  return !state.exited && !state.wsOpen
+}

--- a/src/client/src/utils/unsaved-guard.ts
+++ b/src/client/src/utils/unsaved-guard.ts
@@ -1,0 +1,45 @@
+/**
+ * Registry of "scopes with unsaved work".
+ *
+ * The client had no navigation guard at all: modified settings, a filled-in
+ * creation form and a file edited in the diff viewer all vanished silently on
+ * route change or tab close. Components register a predicate here; one router
+ * guard and one beforeunload listener consult it.
+ *
+ * Keeping every scope (rather than one "is the page dirty" flag) is what fixes
+ * the settings page's nastiest case: its banner was computed per tab, so
+ * switching tabs made the warning DISAPPEAR and the user believed they had
+ * saved.
+ */
+
+const scopes = new Map<string, () => boolean>()
+
+export function registerUnsavedScope(id: string, isDirty: () => boolean): void {
+  scopes.set(id, isDirty)
+}
+
+export function unregisterUnsavedScope(id: string): void {
+  scopes.delete(id)
+}
+
+export function listDirtyScopes(): string[] {
+  const dirty: string[] = []
+  for (const [id, isDirty] of scopes) {
+    try {
+      if (isDirty()) dirty.push(id)
+    } catch {
+      // A predicate reading a torn-down component must never trap the user on
+      // the page. Treat it as clean.
+    }
+  }
+  return dirty
+}
+
+export function hasUnsavedWork(): boolean {
+  return listDirtyScopes().length > 0
+}
+
+/** @internal — tests only. */
+export function _clearUnsavedScopesForTest(): void {
+  scopes.clear()
+}

--- a/src/server/routes/health.ts
+++ b/src/server/routes/health.ts
@@ -6,6 +6,7 @@ import { getDb } from '../db/index.js'
 import { SCHEMA_VERSION } from '../db/migrations.js'
 import { resolveCodexBinary } from '../services/agent/engines/codex/spawn.js'
 import { getGlobalSettings, getProjectSettings, SETTINGS_SCHEMA_VERSION } from '../services/settings-service.js'
+import { type LogLevel, readRecentLogs } from '../utils/logger.js'
 import { getDbPath, getKoboHome, getPackageVersion } from '../utils/paths.js'
 import { slugifyProjectName } from '../utils/project-slug.js'
 import { resolveWorkspaceWorktreePath } from '../utils/worktree-paths.js'
@@ -133,6 +134,22 @@ function safeFileSize(p: string): number | null {
     return null
   }
 }
+
+const VALID_LOG_LEVELS: LogLevel[] = ['debug', 'info', 'warn', 'error']
+
+// GET /api/health/logs?limit=200&level=error — most recent entries, newest first.
+// Declared BEFORE any dynamic segment, per the route-ordering invariant.
+app.get('/logs', (c) => {
+  try {
+    const rawLimit = Number.parseInt(c.req.query('limit') ?? '', 10)
+    const limit = Number.isFinite(rawLimit) ? rawLimit : 200
+    const rawLevel = c.req.query('level')
+    const level = VALID_LOG_LEVELS.includes(rawLevel as LogLevel) ? (rawLevel as LogLevel) : undefined
+    return c.json({ entries: readRecentLogs(level ? { limit, level } : { limit }) })
+  } catch (err) {
+    return c.json({ error: err instanceof Error ? err.message : 'Failed to read logs' }, 500)
+  }
+})
 
 // GET /api/health/report — detailed health diagnostics for the Health panel.
 app.get('/report', async (c) => {

--- a/src/server/routes/workspaces.ts
+++ b/src/server/routes/workspaces.ts
@@ -54,6 +54,7 @@ import * as purgeWorktreeService from '../services/worktree-purge-service.js'
 import * as worktreeService from '../services/worktree-service.js'
 import { resolveUniqueBranchAndPath } from '../utils/branch-resolver.js'
 import * as gitOps from '../utils/git-ops.js'
+import { logError } from '../utils/logger.js'
 import { slugifyProjectName } from '../utils/project-slug.js'
 import * as safePath from '../utils/safe-path.js'
 import { resolveSiblingWorkspaceWorktreePath } from '../utils/worktree-paths.js'
@@ -63,6 +64,130 @@ const app = new Hono()
 
 /** Tracks workspaces currently running a setup script to prevent concurrent executions. */
 const setupScriptRunning = new Set<string>()
+
+/**
+ * Ordered, named steps of `POST /api/workspaces`. The handler already runs
+ * these sequentially; naming them is what lets the create page say WHAT it is
+ * waiting on instead of showing an undifferentiated spinner for what can be
+ * several minutes (a user-supplied setup script runs inside this request).
+ */
+export const CREATE_WORKSPACE_STEPS = [
+  'validate',
+  'fetch-source-branch',
+  'inspect-worktree',
+  'extract-notion',
+  'extract-sentry',
+  'create-record',
+  'create-tasks',
+  'create-worktree',
+  'write-conventions',
+  'write-context-files',
+  'build-prompt',
+  'setup-script',
+  'start-agent',
+  // Never reached on a happy path. Emitted while the handler UNDOES a failed
+  // creation, so the page stops showing the last step it managed to reach.
+  'rollback',
+  'done',
+] as const
+
+export type CreateWorkspaceStep = (typeof CREATE_WORKSPACE_STEPS)[number]
+
+/**
+ * Emit one creation-progress beat.
+ *
+ * The channel is the client-supplied `creationId`, NOT a workspace id: while
+ * this handler runs, the workspace row may not exist yet and the client has
+ * no id to subscribe to (the POST response is still in flight). A WebSocket
+ * subscription is just a string in a Set, and `emitEphemeral` never persists,
+ * so there is no foreign key to satisfy — the existing machinery works as-is.
+ *
+ * No `creationId` (API consumers, tests) → no-op.
+ */
+function emitCreateProgress(creationId: string | undefined, step: CreateWorkspaceStep): void {
+  if (!creationId) return
+  try {
+    wsService.emitEphemeral(creationId, 'workspace:create-progress', {
+      creationId,
+      step,
+      index: CREATE_WORKSPACE_STEPS.indexOf(step),
+      total: CREATE_WORKSPACE_STEPS.length,
+    })
+  } catch (err) {
+    // Best-effort: a broken progress beat must never fail workspace creation.
+    console.error(`[workspaces] emitCreateProgress failed for step '${step}':`, err)
+  }
+}
+
+/**
+ * What a rollback provably cannot reach. The setup script may have installed
+ * dependencies in a global cache, started containers or written files outside
+ * the worktree — say so rather than implying a total undo.
+ */
+const SETUP_SCRIPT_ROLLBACK_CAVEAT =
+  ' The setup script had already run: anything it created outside the worktree (containers, global caches, files elsewhere) was NOT undone.'
+
+/** Terminal failure beat — names the step that broke, so the user never has to guess. */
+function emitCreateFailed(creationId: string | undefined, step: CreateWorkspaceStep, message: string): void {
+  if (!creationId) return
+  try {
+    wsService.emitEphemeral(creationId, 'workspace:create-failed', { creationId, step, message })
+  } catch (err) {
+    // Best-effort: a broken failure beat must never mask or replace the real error.
+    console.error(`[workspaces] emitCreateFailed failed for step '${step}':`, err)
+  }
+}
+
+/**
+ * Undo a creation that failed after the workspace row existed.
+ *
+ * Delegates to `deleteWorkspaceWithSideEffects` — the module's ONE demolition
+ * path — rather than growing a second cleanup that would drift from it. That
+ * function already stops the agent, stops the dev server, destroys the
+ * terminal, skips a worktree the user brought (`worktreeOwned === false`), and
+ * collects side-effect failures as warnings without ever throwing.
+ *
+ * It is declared with `async function` further down the file, so it is hoisted
+ * and callable from here.
+ *
+ * IMPORTANT: this is best-effort cleanup. It must NEVER throw, and it must
+ * NEVER become the error the caller reports — the original cause always wins.
+ */
+async function rollbackFailedCreation(
+  workspace: WorkspaceRow,
+  opts: { deleteLocalBranch: boolean },
+): Promise<string[]> {
+  try {
+    return await deleteWorkspaceWithSideEffects(workspace, {
+      deleteLocalBranch: opts.deleteLocalBranch,
+      // Nothing was ever pushed at this point in the creation flow.
+      deleteRemoteBranch: false,
+    })
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    console.error(`[workspaces] rollback of '${workspace.id}' failed:`, message)
+    return [`Rollback of workspace '${workspace.name}' failed: ${message}`]
+  }
+}
+
+/**
+ * Move a freshly created workspace to `brainstorming`, never throwing.
+ *
+ * This transition is cosmetic — the agent starts either way — but it sits
+ * inside the creation try block, so letting it throw would hand a live
+ * workspace to the rollback path and demolish it. The realistic trigger is a
+ * race: a long setup script leaves the row visible in the sidebar, the user
+ * clicks Start, the agent moves the workspace to `executing`, and
+ * `executing -> brainstorming` is then a rejected transition. Losing the
+ * status beat is a cosmetic bug; losing the worktree is data loss.
+ */
+function markBrainstormingBestEffort(workspaceId: string): void {
+  try {
+    workspaceService.updateWorkspaceStatus(workspaceId, 'brainstorming')
+  } catch (err) {
+    console.error(`[workspaces] could not mark '${workspaceId}' as brainstorming:`, err)
+  }
+}
 
 const VALID_AGENT_PERMISSION_MODES: AgentPermissionMode[] = ['plan', 'bypass', 'strict', 'interactive']
 const VALID_WORKSPACE_STATUSES: WorkspaceStatus[] = [
@@ -221,6 +346,25 @@ app.post('/:id/switch-engine', migrationGuard, async (c) => {
 
 // POST /api/workspaces — create workspace
 app.post('/', migrationGuard, async (c) => {
+  // Declared outside the try so the outermost catch (any unforeseen throw,
+  // including a malformed request body) can still name a step instead of
+  // leaving the create-progress channel silent. Updated in lockstep with
+  // every `emitCreateProgress` call below via the assignment-expression
+  // argument, so it always reflects the last beat actually emitted.
+  let creationId: string | undefined
+  let currentStep: CreateWorkspaceStep = 'validate'
+  // The workspace row, as soon as it exists, so the outermost catch can undo a
+  // creation that broke on a step with no handler of its own. Only `name` ever
+  // changes afterwards (Notion / Sentry title), and the rollback uses it for
+  // log text alone — every field it acts on is fixed at creation time.
+  let createdWorkspace: WorkspaceRow | null = null
+  // Set only once WE created the worktree, which is also what created the
+  // branch. A failure before that point must not delete a branch we never made.
+  let createdBranch = false
+  // Hoisted out of the `build-prompt` block (declared with `const` there) so
+  // both rollback paths — the `start-agent` branch and the outermost catch —
+  // can read it to decide whether the setup-script caveat applies.
+  let setupScriptConfigured = false
   try {
     const body = await c.req.json<{
       name: string
@@ -243,6 +387,7 @@ app.post('/', migrationGuard, async (c) => {
       autoLoop?: boolean
       autoLoopSessionMode?: 'per_task' | 'continuous'
       worktreePath?: string
+      creationId?: string
     }>()
 
     // workingBranch is derived from git when worktreePath is provided, so
@@ -254,6 +399,10 @@ app.post('/', migrationGuard, async (c) => {
       return c.json({ error: 'Missing required field: workingBranch' }, 400)
     }
 
+    creationId = typeof body.creationId === 'string' && body.creationId.length > 0 ? body.creationId : undefined
+    currentStep = 'validate'
+    emitCreateProgress(creationId, currentStep)
+
     // Validate the engine id (if provided) against the registry. An unknown
     // engine is rejected up-front so we don't create orphan workspaces that
     // can't spawn an agent.
@@ -261,7 +410,9 @@ app.post('/', migrationGuard, async (c) => {
       const engines = listEngines()
       const validEngineIds = engines.map((e) => e.id as string)
       if (!validEngineIds.includes(body.engine)) {
-        return c.json({ error: `Unknown engine '${body.engine}'. Valid engines: ${validEngineIds.join(', ')}` }, 400)
+        const message = `Unknown engine '${body.engine}'. Valid engines: ${validEngineIds.join(', ')}`
+        emitCreateFailed(creationId, 'validate', message)
+        return c.json({ error: message, step: 'validate' }, 400)
       }
       // Cross-validate engine × permission mode: each engine declares which
       // modes it supports via `capabilities.permissionModes`. The UI already
@@ -272,12 +423,9 @@ app.post('/', migrationGuard, async (c) => {
         const engine = engines.find((e) => (e.id as string) === body.engine)
         const supported = engine?.capabilities.permissionModes ?? []
         if (!supported.includes(body.agentPermissionMode)) {
-          return c.json(
-            {
-              error: `Engine '${body.engine}' does not support agentPermissionMode '${body.agentPermissionMode}'. Supported: ${supported.join(', ')}`,
-            },
-            400,
-          )
+          const message = `Engine '${body.engine}' does not support agentPermissionMode '${body.agentPermissionMode}'. Supported: ${supported.join(', ')}`
+          emitCreateFailed(creationId, 'validate', message)
+          return c.json({ error: message, step: 'validate' }, 400)
         }
       }
     }
@@ -287,6 +435,8 @@ app.post('/', migrationGuard, async (c) => {
     // and only hard-block (422) when neither origin nor a local branch is usable.
     // The reuse path (body.worktreePath) needs no base ref, so a failed fetch is
     // simply logged there.
+    currentStep = 'fetch-source-branch'
+    emitCreateProgress(creationId, currentStep)
     const isReuseRequest = !!body.worktreePath
     let baseRef = `origin/${body.sourceBranch}`
     let usedLocalFallback = false
@@ -305,7 +455,9 @@ app.post('/', migrationGuard, async (c) => {
           `[workspaces] fetch of '${body.sourceBranch}' from origin failed; falling back to local branch: ${message}`,
         )
       } else {
-        return c.json({ error: `${message} — and no local branch '${body.sourceBranch}' exists to fall back on` }, 422)
+        const failure = `${message} — and no local branch '${body.sourceBranch}' exists to fall back on`
+        emitCreateFailed(creationId, 'fetch-source-branch', failure)
+        return c.json({ error: failure, step: 'fetch-source-branch' }, 422)
       }
     }
 
@@ -317,8 +469,14 @@ app.post('/', migrationGuard, async (c) => {
     let useReusedWorktree = false
     let reusedDerivedBranch: string | null = null
     if (body.worktreePath) {
+      currentStep = 'inspect-worktree'
+      emitCreateProgress(creationId, currentStep)
+    }
+    if (body.worktreePath) {
       if (!fs.existsSync(body.worktreePath)) {
-        return c.json({ error: `Worktree path does not exist: ${body.worktreePath}` }, 422)
+        const failure = `Worktree path does not exist: ${body.worktreePath}`
+        emitCreateFailed(creationId, 'inspect-worktree', failure)
+        return c.json({ error: failure, step: 'inspect-worktree' }, 422)
       }
       try {
         const commonDir = execFileSync('git', ['-C', body.worktreePath, 'rev-parse', '--git-common-dir'], {
@@ -326,24 +484,32 @@ app.post('/', migrationGuard, async (c) => {
         }).trim()
         const expectedCommonDir = path.join(body.projectPath, '.git')
         if (path.resolve(commonDir) !== path.resolve(expectedCommonDir)) {
-          return c.json({ error: `Worktree '${body.worktreePath}' belongs to a different repository` }, 422)
+          const failure = `Worktree '${body.worktreePath}' belongs to a different repository`
+          emitCreateFailed(creationId, 'inspect-worktree', failure)
+          return c.json({ error: failure, step: 'inspect-worktree' }, 422)
         }
         const branch = execFileSync('git', ['-C', body.worktreePath, 'rev-parse', '--abbrev-ref', 'HEAD'], {
           encoding: 'utf-8',
         }).trim()
         if (!branch || branch === 'HEAD') {
-          return c.json({ error: 'Worktree is in detached HEAD state and cannot be attached' }, 422)
+          const failure = 'Worktree is in detached HEAD state and cannot be attached'
+          emitCreateFailed(creationId, 'inspect-worktree', failure)
+          return c.json({ error: failure, step: 'inspect-worktree' }, 422)
         }
         reusedDerivedBranch = branch
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err)
-        return c.json({ error: `Failed to inspect worktree: ${message}` }, 422)
+        const failure = `Failed to inspect worktree: ${message}`
+        emitCreateFailed(creationId, 'inspect-worktree', failure)
+        return c.json({ error: failure, step: 'inspect-worktree' }, 422)
       }
       // Validate the worktree isn't already attached to another workspace.
       const dbForCheck = getDb()
       const existing = dbForCheck.prepare('SELECT id FROM workspaces WHERE worktree_path = ?').get(body.worktreePath)
       if (existing) {
-        return c.json({ error: 'This worktree is already attached to another Kōbō workspace' }, 422)
+        const failure = 'This worktree is already attached to another Kōbō workspace'
+        emitCreateFailed(creationId, 'inspect-worktree', failure)
+        return c.json({ error: failure, step: 'inspect-worktree' }, 422)
       }
       useReusedWorktree = true
     }
@@ -353,14 +519,20 @@ app.post('/', migrationGuard, async (c) => {
     // before createWorkspace and surface failures as 422.
     let notionContent: notionService.NotionPageContent | null = null
     if (body.notionUrl) {
+      currentStep = 'extract-notion'
+      emitCreateProgress(creationId, currentStep)
       if (!settingsService.getGlobalSettings().notionEnabled) {
-        return c.json({ error: 'Notion integration is disabled in Settings' }, 403)
+        const failure = 'Notion integration is disabled in Settings'
+        emitCreateFailed(creationId, 'extract-notion', failure)
+        return c.json({ error: failure, step: 'extract-notion' }, 403)
       }
       try {
         notionContent = await notionService.extractNotionPage(body.notionUrl)
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err)
-        return c.json({ error: `Failed to extract Notion page: ${message}` }, 422)
+        const failure = `Failed to extract Notion page: ${message}`
+        emitCreateFailed(creationId, 'extract-notion', failure)
+        return c.json({ error: failure, step: 'extract-notion' }, 422)
       }
       const assigneeProperty = settingsService.getGlobalSettings().notionAssigneeProperty
       if (assigneeProperty && body.notionUrl) {
@@ -378,14 +550,20 @@ app.post('/', migrationGuard, async (c) => {
 
     let sentryContent: sentryService.SentryIssueContent | null = null
     if (body.sentryUrl) {
+      currentStep = 'extract-sentry'
+      emitCreateProgress(creationId, currentStep)
       if (!settingsService.getGlobalSettings().sentryEnabled) {
-        return c.json({ error: 'Sentry integration is disabled in Settings' }, 403)
+        const failure = 'Sentry integration is disabled in Settings'
+        emitCreateFailed(creationId, 'extract-sentry', failure)
+        return c.json({ error: failure, step: 'extract-sentry' }, 403)
       }
       try {
         sentryContent = await sentryService.extractSentryIssue(body.sentryUrl)
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err)
-        return c.json({ error: `Failed to extract Sentry issue: ${message}` }, 422)
+        const failure = `Failed to extract Sentry issue: ${message}`
+        emitCreateFailed(creationId, 'extract-sentry', failure)
+        return c.json({ error: failure, step: 'extract-sentry' }, 422)
       }
       if (sentryContent && sentryContent.assignee.length === 0) {
         const sentryUrl = body.sentryUrl
@@ -453,6 +631,8 @@ app.post('/', migrationGuard, async (c) => {
     //      request — keeps the user's flow smooth at the cost of a longer
     //      branch name. The same hash is applied to BOTH the branch and the
     //      worktree path so they stay aligned.
+    currentStep = 'create-record'
+    emitCreateProgress(creationId, currentStep)
     let prospectiveWorktreePath: string
     let workingBranchAdjusted = false
     if (useReusedWorktree) {
@@ -470,7 +650,8 @@ app.post('/', migrationGuard, async (c) => {
         workingBranchAdjusted = resolved.adjusted
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err)
-        return c.json({ error: message }, 409)
+        emitCreateFailed(creationId, 'create-record', message)
+        return c.json({ error: message, step: 'create-record' }, 409)
       }
     }
 
@@ -496,6 +677,7 @@ app.post('/', migrationGuard, async (c) => {
       engine: body.engine,
       ...(useReusedWorktree ? {} : { worktreesPath: globalSettings.worktreesPath }),
     })
+    createdWorkspace = workspace
 
     // Enable auto-loop before starting the initial brainstorming session so
     // its model override is available when selecting that session's model.
@@ -545,6 +727,8 @@ app.post('/', migrationGuard, async (c) => {
       workspace = workspaceService.updateWorkspaceName(workspace.id, `${prefix}${sentryContent.title}`)
     }
 
+    currentStep = 'create-tasks'
+    emitCreateProgress(creationId, currentStep)
     // Create tasks from extracted Notion data
     if (notionContent) {
       let sortOrder = 0
@@ -600,6 +784,8 @@ app.post('/', migrationGuard, async (c) => {
       }
     }
 
+    currentStep = 'create-worktree'
+    emitCreateProgress(creationId, currentStep)
     // Create git worktree for the working branch — unless we're reusing an
     // existing one, in which case the path is taken straight from the body.
     let worktreePath: string
@@ -615,25 +801,27 @@ app.post('/', migrationGuard, async (c) => {
           projectSlug,
         )
         worktreePath = created.worktreePath
+        // Not an assumption: `createWorktree` reports which git command it ran.
+        // It falls back to attaching an existing branch, and deleting that one
+        // on rollback would destroy commits the user made before Kobo existed.
+        createdBranch = created.branchCreated
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err)
-        // Roll back the half-created workspace: a failed worktree creation must NOT
-        // leave an orphan record behind. Best-effort cleanup of any partial worktree
-        // dir git may have produced, then delete the just-inserted workspace row.
-        try {
-          worktreeService.removeWorktree(body.projectPath, prospectiveWorktreePath)
-        } catch {
-          // worktree may never have been registered — ignore
-        }
-        try {
-          workspaceService.deleteWorkspace(workspace.id)
-        } catch (delErr) {
-          console.error('[workspaces] rollback deleteWorkspace failed:', delErr)
-        }
-        return c.json({ error: `Failed to create worktree: ${message}` }, 500)
+        // Roll back the half-created workspace through the SHARED demolition
+        // path — a second inline cleanup here would drift from it. The branch
+        // is not deleted: `createWorktree` failed, so we never created one.
+        const rollbackWarnings = await rollbackFailedCreation(workspace, { deleteLocalBranch: false })
+        const failure = `Failed to create worktree: ${message}`
+        emitCreateFailed(creationId, 'create-worktree', failure)
+        return c.json(
+          { error: failure, step: 'create-worktree', rollback: { done: true, warnings: rollbackWarnings } },
+          500,
+        )
       }
     }
 
+    currentStep = 'write-conventions'
+    emitCreateProgress(creationId, currentStep)
     // Ensure Kobo-generated files are gitignored. Check both the root
     // .gitignore and .ai/.gitignore to avoid duplicate entries.
     try {
@@ -666,7 +854,10 @@ app.post('/', migrationGuard, async (c) => {
         fs.appendFileSync(rootGitignorePath, `${separator}${toAdd.join('\n')}\n`, 'utf-8')
       }
     } catch (err) {
-      console.error('[workspaces] Failed to update .gitignore:', err)
+      logError('workspaces', 'Failed to update .gitignore', {
+        workspaceId: workspace.id,
+        error: err instanceof Error ? err.message : String(err),
+      })
     }
 
     // Write git conventions to the worktree if configured
@@ -678,7 +869,10 @@ app.post('/', migrationGuard, async (c) => {
         const conventionsPath = path.join(aiDir, '.git-conventions.md')
         fs.writeFileSync(conventionsPath, effectiveSettings.gitConventions, 'utf-8')
       } catch (err) {
-        console.error('[workspaces] Failed to write .git-conventions.md:', err)
+        logError('workspaces', 'Failed to write .git-conventions.md', {
+          workspaceId: workspace.id,
+          error: err instanceof Error ? err.message : String(err),
+        })
       }
     }
 
@@ -686,7 +880,14 @@ app.post('/', migrationGuard, async (c) => {
     // persisted via setInitialPrompt). This guarantees the prompt survives a
     // setup-script crash and can be replayed by /:id/start.
     let setupScriptFailed = false
+    // Captured, not swallowed: a failed engine start used to reach only the
+    // server console while the route still answered 201 "created". A
+    // half-created workspace lies to the user, so this now drives a full
+    // rollback below instead of merely flipping the status to 'error'.
+    let agentStartError: string | null = null
 
+    currentStep = 'write-context-files'
+    emitCreateProgress(creationId, currentStep)
     // Save Notion content as markdown in worktree
     let notionFilePath: string | null = null
     if (notionContent && body.notionUrl) {
@@ -738,7 +939,10 @@ app.post('/', migrationGuard, async (c) => {
 
         fs.writeFileSync(notionFilePath, md, 'utf-8')
       } catch (err) {
-        console.error('[workspaces] Failed to save Notion content:', err)
+        logError('workspaces', 'Failed to save Notion content', {
+          workspaceId: workspace.id,
+          error: err instanceof Error ? err.message : String(err),
+        })
       }
     }
 
@@ -795,7 +999,10 @@ app.post('/', migrationGuard, async (c) => {
           sortOrder: 9999,
         })
       } catch (err) {
-        console.error('[workspaces] Failed to save Sentry content:', err)
+        logError('workspaces', 'Failed to save Sentry content', {
+          workspaceId: workspace.id,
+          error: err instanceof Error ? err.message : String(err),
+        })
         sentryFilePath = null
       }
     }
@@ -825,6 +1032,8 @@ app.post('/', migrationGuard, async (c) => {
     // VALID_TRANSITIONS contract intact (`created → extracting → brainstorming`
     // vs `created → brainstorming` when setup is skipped).
     {
+      currentStep = 'build-prompt'
+      emitCreateProgress(creationId, currentStep)
       // Resolve the per-feature initial-prompt templates with single-fallback
       // semantics: project || global is already handled inside getEffectiveSettings,
       // and a whitespace-only string acts as a user escape hatch (skip injection).
@@ -992,8 +1201,10 @@ Once the brainstorming + planning steps above are complete and you have a saved 
       // leaves the workspace in `error` state with `initial_prompt` ready for
       // a retry via POST /:id/start. Skipped when reusing an existing worktree
       // (rerunning could be destructive — drop a curated node_modules, etc.).
-      const setupScriptConfigured = effectiveSettings.setupScript && !body.skipSetupScript && !useReusedWorktree
+      setupScriptConfigured = Boolean(effectiveSettings.setupScript) && !body.skipSetupScript && !useReusedWorktree
       if (setupScriptConfigured) {
+        currentStep = 'setup-script'
+        emitCreateProgress(creationId, currentStep)
         workspaceService.updateWorkspaceStatus(workspace.id, 'extracting')
         wsService.emit(workspace.id, 'setup:output', { text: '[kobo] Running setup script...' })
         try {
@@ -1006,18 +1217,20 @@ Once the brainstorming + planning steps above are complete and you have a saved 
           if (result.exitCode !== 0) {
             workspaceService.updateWorkspaceStatus(workspace.id, 'error')
             setupScriptFailed = true
+            emitCreateFailed(creationId, 'setup-script', `Setup script exited with code ${result.exitCode}`)
           } else {
-            workspaceService.updateWorkspaceStatus(workspace.id, 'brainstorming')
+            markBrainstormingBestEffort(workspace.id)
           }
         } catch (err) {
           const message = err instanceof Error ? err.message : String(err)
           console.error(`[workspaces] Setup script error: ${message}`)
           workspaceService.updateWorkspaceStatus(workspace.id, 'error')
           setupScriptFailed = true
+          emitCreateFailed(creationId, 'setup-script', message)
         }
       } else {
         // No setup step → go straight from `created` to `brainstorming`.
-        workspaceService.updateWorkspaceStatus(workspace.id, 'brainstorming')
+        markBrainstormingBestEffort(workspace.id)
       }
 
       if (setupScriptFailed) {
@@ -1026,7 +1239,15 @@ Once the brainstorming + planning steps above are complete and you have a saved 
             '[kobo] Setup script failed — the agent was NOT started. Your initial prompt has been saved. ' +
             'Fix the setup script (Settings → Scripts) and click Start to retry with the original prompt.',
         })
+        // This path keeps its deliberate recovery flow (workspace stays in
+        // `error`, prompt persisted, 201 response) — nothing is undone here.
+        // The step is already named on the create-progress channel by the
+        // `emitCreateFailed(creationId, 'setup-script', …)` calls above, at
+        // the point of detection (exit code / thrown error), so the create
+        // page never shows a mute spinner on this path.
       } else {
+        currentStep = 'start-agent'
+        emitCreateProgress(creationId, currentStep)
         try {
           // The brainstorming session (this very first startAgent call) uses
           // brainstormModel when the workspace was created with auto-loop
@@ -1068,14 +1289,39 @@ Once the brainstorming + planning steps above are complete and you have a saved 
         } catch (err) {
           const message = err instanceof Error ? err.message : String(err)
           console.error(`[workspaces] Failed to start agent: ${message}`)
-          try {
-            workspaceService.updateWorkspaceStatus(workspace.id, 'error')
-          } catch {
-            /* already logged */
-          }
+          agentStartError = message
         }
       }
     }
+
+    // A workspace whose agent never started is a half-created object, and a
+    // half-created object is exactly what lies to the user. Undo everything
+    // and report the step that broke.
+    if (agentStartError) {
+      emitCreateProgress(creationId, 'rollback')
+      // A worktree the user brought is not ours to remove, and neither is the
+      // branch it was already sitting on. `deleteWorkspaceWithSideEffects`
+      // already guards the worktree via `worktreeOwned`; the branch flag is
+      // ours to set.
+      const rollbackWarnings = await rollbackFailedCreation(workspace, {
+        deleteLocalBranch: !useReusedWorktree,
+      })
+
+      // The setup script has already run by this point — see the caveat's own
+      // comment for what that rollback cannot reach.
+      const setupCaveat = setupScriptConfigured ? SETUP_SCRIPT_ROLLBACK_CAVEAT : ''
+      const failure = `Failed to start the agent: ${agentStartError}. The workspace, its worktree and its branch were removed.${setupCaveat}`
+
+      emitCreateFailed(creationId, 'start-agent', failure)
+      return c.json({ error: failure, step: 'start-agent', rollback: { done: true, warnings: rollbackWarnings } }, 500)
+    }
+
+    // The agent is running. From here the workspace is a live object, not a
+    // half-created one, so it stops being the rollback's business: dropping the
+    // handle means a later throw (the read below, a header, a status beat)
+    // returns 500 without demolishing a worktree that already has an agent
+    // working in it. Failures before this line still roll back in full.
+    createdWorkspace = null
 
     // Return created workspace with tasks
     const workspaceWithTasks = workspaceService.getWorkspaceWithTasks(workspace.id)
@@ -1088,10 +1334,48 @@ Once the brainstorming + planning steps above are complete and you have a saved 
     if (usedLocalFallback) {
       c.header('X-Kobo-Source-Fallback', 'local')
     }
+    // The `done` beat means "the sequence completed the way the user expects" —
+    // NOT merely "the HTTP response is about to return 201". A workspace whose
+    // setup script failed still gets a 201 (its record exists, in `error`
+    // status, ready for retry via POST /:id/start) because that path has a
+    // deliberate recovery flow — but the create-progress channel must not
+    // claim success on it: the corresponding emitCreateFailed above already
+    // named the real failure. A failed agent start never reaches this line at
+    // all (see the rollback branch above).
+    if (!setupScriptFailed) {
+      currentStep = 'done'
+      emitCreateProgress(creationId, currentStep)
+    }
     return c.json(workspaceWithTasks, 201)
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err)
-    return c.json({ error: message }, 500)
+    // Anything past `create-record` left a row behind. Leaving it there is a
+    // half-created workspace whose existence lies to the user — and the client
+    // already tells them "the server undoes everything it created". Make that
+    // sentence true for every step, not only the two that had their own
+    // handler. Best-effort: the rollback never throws and never becomes the
+    // reported error.
+    if (createdWorkspace) {
+      emitCreateProgress(creationId, 'rollback')
+      const rollbackWarnings = await rollbackFailedCreation(createdWorkspace, { deleteLocalBranch: createdBranch })
+      logError('workspaces', 'Rolled back a creation that failed outside any per-step handler', {
+        workspaceId: createdWorkspace.id,
+        step: currentStep,
+        error: message,
+        ...(rollbackWarnings.length > 0 ? { rollbackWarnings } : {}),
+      })
+      // Say exactly what was undone — a claim of "everything" would be the
+      // very kind of comfortable lie this route is being fixed for.
+      const removed = createdBranch
+        ? ' The workspace, its worktree and its branch were removed.'
+        : ' The half-created workspace was removed.'
+      const cause = message.endsWith('.') ? message : `${message}.`
+      const failure = `${cause}${removed}${setupScriptConfigured ? SETUP_SCRIPT_ROLLBACK_CAVEAT : ''}`
+      emitCreateFailed(creationId, currentStep, failure)
+      return c.json({ error: failure, step: currentStep, rollback: { done: true, warnings: rollbackWarnings } }, 500)
+    }
+    emitCreateFailed(creationId, currentStep, message)
+    return c.json({ error: message, step: currentStep }, 500)
   }
 })
 

--- a/src/server/services/worktree-purge-service.ts
+++ b/src/server/services/worktree-purge-service.ts
@@ -1,4 +1,5 @@
 import fs from 'node:fs'
+import { logError, logWarn } from '../utils/logger.js'
 import * as agentManager from './agent/orchestrator.js'
 import * as devServerService from './dev-server-service.js'
 import { getForgeProvider } from './forge/registry.js'
@@ -34,13 +35,13 @@ export async function purgeWorktree(workspaceId: string): Promise<PurgeResult> {
     await agentManager.stopAgentAndWait(workspaceId)
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err)
-    console.error(`[purge] stopAgentAndWait failed for '${workspace.name}':`, msg)
+    logError('purge', `stopAgent failed for '${workspace.name}'`, { workspaceId: workspace.id, error: msg })
   }
   try {
     await devServerService.stopDevServer(workspaceId)
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err)
-    console.error(`[purge] stopDevServer failed for '${workspace.name}':`, msg)
+    logError('purge', `stopDevServer failed for '${workspace.name}'`, { workspaceId: workspace.id, error: msg })
   }
   try {
     destroyTerminal(workspaceId)
@@ -122,7 +123,10 @@ async function captureRestoreData(
         prUrl = fresh.url ?? null
       }
     } catch (err) {
-      console.warn(`[purge] PR lookup for restore data failed:`, err instanceof Error ? err.message : err)
+      logWarn('purge', 'PR lookup for restore data failed', {
+        workspaceId: workspace.id,
+        error: err instanceof Error ? err.message : String(err),
+      })
     }
   }
 

--- a/src/server/services/worktree-service.ts
+++ b/src/server/services/worktree-service.ts
@@ -122,7 +122,7 @@ export function createWorktree(
   baseRef: string,
   worktreesPath?: string | null,
   projectSlug?: string,
-): { worktreePath: string; base: 'origin' | 'local' } {
+): { worktreePath: string; base: 'origin' | 'local'; branchCreated: boolean } {
   const worktreesDir = resolveWorktreesRoot(projectPath, worktreesPath)
   if (!fs.existsSync(worktreesDir)) {
     fs.mkdirSync(worktreesDir, { recursive: true })
@@ -130,6 +130,11 @@ export function createWorktree(
 
   const worktreePath = resolveWorkspaceWorktreePath(projectPath, branchName, worktreesPath, projectSlug)
   const base: 'origin' | 'local' = baseRef.startsWith('origin/') ? 'origin' : 'local'
+
+  // Tracks which of the two git commands below actually ran. Callers use it to
+  // decide whether a rollback may delete the branch: deleting one we merely
+  // attached to would destroy commits Kobo never created.
+  let branchCreated = true
 
   try {
     git(projectPath, ['worktree', 'add', '-b', branchName, worktreePath, baseRef])
@@ -139,6 +144,7 @@ export function createWorktree(
     // If branch already exists, add worktree without creating the branch
     if (isGitBranchExistsError(message)) {
       git(projectPath, ['worktree', 'add', worktreePath, branchName])
+      branchCreated = false
     } else {
       throw new Error(`Failed to create worktree for branch '${branchName}': ${message}`)
     }
@@ -146,7 +152,7 @@ export function createWorktree(
 
   addToExclude(projectPath, worktreePath)
 
-  return { worktreePath, base }
+  return { worktreePath, base, branchCreated }
 }
 
 /** Remove a git worktree and clean up the .git/info/exclude entry.

--- a/src/server/utils/logger.ts
+++ b/src/server/utils/logger.ts
@@ -1,0 +1,133 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { getKoboHome } from './paths.js'
+
+/**
+ * Minimal structured logger — deliberately dependency-free.
+ *
+ * Kōbō ships twelve production dependencies, all structural. A logging library
+ * would be the thirteenth for a single-user local tool whose entire need is
+ * "one JSON line per event, in a file that does not grow forever, readable
+ * from the Health page". That fits in this module, so it lives here.
+ *
+ * In production every console line goes to the stdout of a process started in
+ * a terminal: close the terminal, lose the diagnosis. This writes to disk AND
+ * mirrors to the console, so nothing regresses while call sites migrate.
+ */
+
+export type LogLevel = 'debug' | 'info' | 'warn' | 'error'
+
+export interface LogEntry {
+  ts: string
+  level: LogLevel
+  scope: string
+  message: string
+  meta?: unknown
+}
+
+const MAX_FILE_BYTES = 5 * 1024 * 1024
+const KEPT_ROTATIONS = 3
+const LEVEL_ORDER: Record<LogLevel, number> = { debug: 0, info: 1, warn: 2, error: 3 }
+
+let cachedDir: string | null = null
+
+/** Test hook: drop the cached directory so a new KOBO_HOME takes effect. */
+export function _resetLoggerForTest(): void {
+  cachedDir = null
+}
+
+function logDir(): string {
+  if (cachedDir === null) cachedDir = path.join(getKoboHome(), 'logs')
+  return cachedDir
+}
+
+export function getLogFilePath(): string {
+  return path.join(logDir(), 'kobo.log')
+}
+
+function rotateIfNeeded(file: string): void {
+  let size = 0
+  try {
+    size = fs.statSync(file).size
+  } catch {
+    return // no file yet — nothing to rotate
+  }
+  if (size < MAX_FILE_BYTES) return
+
+  try {
+    fs.rmSync(`${file}.${KEPT_ROTATIONS}`, { force: true })
+    for (let i = KEPT_ROTATIONS - 1; i >= 1; i--) {
+      if (fs.existsSync(`${file}.${i}`)) fs.renameSync(`${file}.${i}`, `${file}.${i + 1}`)
+    }
+    fs.renameSync(file, `${file}.1`)
+  } catch (err) {
+    console.error('[logger] rotation failed:', err)
+  }
+}
+
+function mirrorToConsole(entry: LogEntry): void {
+  const line = `[${entry.scope}] ${entry.message}`
+  if (entry.level === 'error') console.error(line, entry.meta ?? '')
+  else if (entry.level === 'warn') console.warn(line, entry.meta ?? '')
+  else console.log(line, entry.meta ?? '')
+}
+
+export function log(level: LogLevel, scope: string, message: string, meta?: unknown): void {
+  const entry: LogEntry = { ts: new Date().toISOString(), level, scope, message }
+  if (meta !== undefined) entry.meta = meta
+  mirrorToConsole(entry)
+
+  // A logging failure must NEVER take down the operation it was logging.
+  try {
+    const dir = logDir()
+    fs.mkdirSync(dir, { recursive: true })
+    const file = getLogFilePath()
+    rotateIfNeeded(file)
+    fs.appendFileSync(file, `${JSON.stringify(entry)}\n`, 'utf-8')
+  } catch {
+    // Console already has the line; nothing more to do.
+  }
+}
+
+export function logInfo(scope: string, message: string, meta?: unknown): void {
+  log('info', scope, message, meta)
+}
+
+export function logWarn(scope: string, message: string, meta?: unknown): void {
+  log('warn', scope, message, meta)
+}
+
+export function logError(scope: string, message: string, meta?: unknown): void {
+  log('error', scope, message, meta)
+}
+
+/**
+ * Most recent entries first, bounded. Reads only the current file — the
+ * rotated ones stay on disk for a human with `grep`, which is the right tool
+ * for anything this route cannot answer.
+ */
+export function readRecentLogs(options: { limit?: number; level?: LogLevel } = {}): LogEntry[] {
+  const limit = Math.min(Math.max(options.limit ?? 200, 1), 2000)
+  const minLevel = options.level ? LEVEL_ORDER[options.level] : 0
+
+  let raw: string
+  try {
+    raw = fs.readFileSync(getLogFilePath(), 'utf-8')
+  } catch {
+    return []
+  }
+
+  const out: LogEntry[] = []
+  const lines = raw.split('\n')
+  for (let i = lines.length - 1; i >= 0 && out.length < limit; i--) {
+    const line = lines[i].trim()
+    if (line.length === 0) continue
+    try {
+      const entry = JSON.parse(line) as LogEntry
+      if (LEVEL_ORDER[entry.level] >= minLevel) out.push(entry)
+    } catch {
+      // A truncated last line (process killed mid-append) is skipped, not fatal.
+    }
+  }
+  return out
+}


### PR DESCRIPTION
## Summary
- Workspace creation now names each of its 13 steps as it runs and rolls back everything on any failure, instead of going silent or leaving a half-built workspace behind.
- Settings, the workspace list, git actions and the diff viewer stop swallowing failures and repainting the same screen as if nothing happened; a dead backend is now told apart from an empty account.
- Adds a single `apiFetch` network entry point (one timeout, one error shape), a readable server-side JSONL log that survives process exit, and navigation guards that warn before losing unsaved settings, an in-progress creation form, or an edited diff file.

## Test plan
- [x] `make ci` passes locally (install, audit, lint, tsc, backend + client test suites)
- [x] Backend 2291 -> 2314 tests, client 640 -> 710 tests, all green