### PR TITLE
fix(git,db): serialize git writes, bound event history, verify irreversible ops

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -380,6 +380,41 @@ alternatives).
   on named Docker volumes, NTFS / exFAT / tmpfs, strict SELinux with `:Z`, or
   `userns-remap`.
 
+## Conversation history retention (opt-in)
+
+Every agent message, tool call and diff Kōbō displays is persisted in the
+`ws_events` table so the activity feed survives a reload. At roughly 25 rows per
+second per running session, that table is the one that grows without bound —
+and SQLite never gives the space back on its own.
+
+Kōbō can prune it, but **the feature is off by default and always has to be
+turned on deliberately**: it permanently deletes conversation history, and a
+silent loss of history is worse than a large file. Leave it off and nothing is
+ever deleted, exactly as before.
+
+**Settings → Worktrees → Conversation history retention** exposes two values,
+both global (the database is single):
+
+| Setting | Default | Meaning |
+|---|---|---|
+| Delete events older than (days) | `0` | Age above which an agent event is deleted. **`0` means retention is disabled — nothing is ever deleted.** |
+| Events always kept per workspace | `0` | The most recent events of each workspace survive whatever their age. Set it (5000 is a good starting point) at the same time you enable retention, so an old but still-open workspace keeps a readable history. |
+
+The prune runs **once, at server start-up**, before the daily backup, in batches
+of 5 000 rows so the SQLite write lock is never held for more than a few
+milliseconds. When enough pages have been freed, a `VACUUM` returns the space to
+the filesystem.
+
+**What it deletes:** rows of `ws_events` — the recorded agent output.
+**What it never touches:** workspaces, tasks, sessions, branches, worktrees, or
+any file in your repositories.
+
+Enabling retention — or shortening an existing window — asks for confirmation
+first, and the dialog states how many of your recorded events the new window
+would delete. Note that the first run is the largest one: switching a year-old
+database to a 30-day window deletes eleven months in one go. Deleted events
+cannot be recovered, and the server logs how many each prune removed.
+
 ## Network access
 
 By default, Kōbō binds its HTTP and WebSocket server to `127.0.0.1` (localhost

--- a/src/__tests__/change-source-branch-service.test.ts
+++ b/src/__tests__/change-source-branch-service.test.ts
@@ -85,6 +85,7 @@ const SCRIPT_TIMEOUT_MS = 5 * 60 * 1000
 
 import { execFileSync } from 'node:child_process'
 import { changeSourceBranch } from '../server/services/change-source-branch-service.js'
+import { withGitRepoLock } from '../server/utils/git-repo-lock.js'
 
 function g(repo: string, args: string[]): string {
   return execFileSync('git', args, { cwd: repo, encoding: 'utf-8' }).trimEnd()
@@ -356,6 +357,41 @@ describe('changeSourceBranch', () => {
     const res = await changeSourceBranch('w1', 'develop')
     expect(res.status).toBe('conflict')
     expect(updateSourceMock).toHaveBeenCalledWith('w1', 'develop')
+  })
+
+  it('rotates the backup branches even when the attempt ends in a conflict', async () => {
+    // Same divergence as above — the cherry-pick is guaranteed to conflict.
+    g(repo, ['checkout', '-q', 'develop'])
+    writeFileSync(join(repo, 'base.txt'), 'develop-change\n')
+    g(repo, ['commit', '-q', '-am', 'D2'])
+    g(repo, ['push', '-q', 'origin', 'develop'])
+    g(repo, ['checkout', '-q', 'main'])
+    g(repo, ['checkout', '-q', '-b', 'feature'])
+    writeFileSync(join(repo, 'base.txt'), 'feature-change\n')
+    g(repo, ['commit', '-q', '-am', 'F1'])
+    // Four backups from previous failed attempts, above the retention of 3.
+    for (const stamp of ['1000', '2000', '3000', '4000']) {
+      g(repo, ['branch', `kobo-backup/feature-${stamp}`, 'feature'])
+    }
+
+    getWorkspaceMock.mockReturnValue({
+      id: 'w1',
+      sourceBranch: 'main',
+      workingBranch: 'feature',
+      worktreePath: repo,
+      projectPath: repo,
+    })
+
+    const res = await changeSourceBranch('w1', 'develop')
+    expect(res.status).toBe('conflict')
+
+    // 4 old + 1 created by this attempt, rotated down to the 3 newest.
+    const remaining = g(repo, ['branch', '--list', 'kobo-backup/feature-*', '--format=%(refname:short)'])
+      .split('\n')
+      .filter(Boolean)
+    expect(remaining).toHaveLength(3)
+    expect(remaining).not.toContain('kobo-backup/feature-1000')
+    expect(remaining).not.toContain('kobo-backup/feature-2000')
   })
 
   it('runs the custom script when changeSourceBranchScript is set and updates metadata on exit 0', async () => {
@@ -630,5 +666,58 @@ describe('changeSourceBranch', () => {
     expect(res.status).toBe('done')
     expect(spawnMock).not.toHaveBeenCalled()
     expect(g(repo, ['log', '--format=%s', 'feature'])).toContain('D1')
+  })
+
+  it('refuses to change the source branch while a stale git index lock is held', async () => {
+    g(repo, ['checkout', '-q', '-b', 'feature'])
+    writeFileSync(join(repo, 'feat.txt'), 'feat\n')
+    g(repo, ['add', '.'])
+    g(repo, ['commit', '-q', '-m', 'F1'])
+    writeFileSync(join(repo, '.git', 'index.lock'), '')
+
+    getWorkspaceMock.mockReturnValue({
+      id: 'w1',
+      name: 'w1',
+      sourceBranch: 'main',
+      workingBranch: 'feature',
+      worktreePath: repo,
+      projectPath: repo,
+    })
+
+    await expect(changeSourceBranch('w1', 'develop')).rejects.toThrow(/index of this worktree is locked/)
+    expect(spawnMock).not.toHaveBeenCalled()
+  })
+
+  it('checks the index lock after acquiring the repository lock, not when queueing', async () => {
+    g(repo, ['checkout', '-q', '-b', 'feature'])
+    writeFileSync(join(repo, 'feat.txt'), 'feat\n')
+    g(repo, ['add', '.'])
+    g(repo, ['commit', '-q', '-m', 'F1'])
+
+    getWorkspaceMock.mockReturnValue({
+      id: 'w1',
+      name: 'w1',
+      sourceBranch: 'main',
+      workingBranch: 'feature',
+      worktreePath: repo,
+      projectPath: repo,
+    })
+
+    // Occupy the repository lock so the change is queued behind it, exactly
+    // like a concurrent PR-watcher fetch would.
+    let release: () => void = () => {}
+    const holder = withGitRepoLock(repo, () => new Promise<void>((resolve) => (release = resolve)))
+    await flushMicrotasks()
+
+    const pending = changeSourceBranch('w1', 'develop')
+    await flushMicrotasks()
+
+    // The lock only appears WHILE we are queued: a guard evaluated at request
+    // time cannot see it, one evaluated after acquisition must.
+    writeFileSync(join(repo, '.git', 'index.lock'), '')
+    release()
+    await holder
+
+    await expect(pending).rejects.toThrow(/index of this worktree is locked/)
   })
 })

--- a/src/__tests__/db-backup-service.test.ts
+++ b/src/__tests__/db-backup-service.test.ts
@@ -141,4 +141,25 @@ describe('createPreMigrationBackup', () => {
 
     rmSync(tmpDir, { recursive: true, force: true })
   })
+
+  it('rotates its own backups instead of growing one full DB copy per migration', async () => {
+    const { createPreMigrationBackup } = await import('../server/services/db-backup-service.js')
+    for (const tag of ['v10', 'v11', 'v12', 'v13', 'v14', 'v15']) {
+      await createPreMigrationBackup(db, dbPath, tag, 3)
+    }
+
+    const remaining = fs.readdirSync(path.dirname(dbPath)).filter((f) => f.startsWith('kobo.db.premigration-'))
+    expect(remaining).toHaveLength(3)
+  })
+
+  it('never rotates the daily backups away', async () => {
+    const { createDailyDbBackupIfNeeded, createPreMigrationBackup } = await import(
+      '../server/services/db-backup-service.js'
+    )
+    await createDailyDbBackupIfNeeded(db, dbPath)
+    const result = await createPreMigrationBackup(db, dbPath, 'v10', 1)
+
+    expect(result.deleted).toEqual([])
+    expect(fs.readdirSync(path.dirname(dbPath)).filter((f) => f.startsWith('kobo.db.backup-'))).toHaveLength(1)
+  })
 })

--- a/src/__tests__/git-ops-cherry-pick.test.ts
+++ b/src/__tests__/git-ops-cherry-pick.test.ts
@@ -11,6 +11,7 @@ import {
   getOngoingGitOperation,
   listBackupBranches,
   listProperCommits,
+  pruneBackupBranches,
   reconstructBranchOnto,
   restoreBranchFromBackup,
 } from '../server/utils/git-ops.js'
@@ -140,6 +141,48 @@ describe('backup branch restore', () => {
 
     restoreBranchFromBackup(repo, 'feature', backups[0])
     expect(g(repo, ['rev-parse', 'HEAD'])).toBe(originalTip)
+  })
+})
+
+describe('pruneBackupBranches', () => {
+  it('keeps only the newest backups and reports what it deleted', () => {
+    g(repo, ['checkout', '-q', '-b', 'feature'])
+    for (const stamp of ['1000', '2000', '3000', '4000', '5000']) {
+      g(repo, ['branch', `kobo-backup/feature-${stamp}`, 'feature'])
+    }
+    expect(listBackupBranches(repo, 'feature')).toHaveLength(5)
+
+    const { removed, warnings } = pruneBackupBranches(repo, 'feature', 3)
+
+    expect(warnings).toEqual([])
+    expect(removed.sort()).toEqual(['kobo-backup/feature-1000', 'kobo-backup/feature-2000'])
+    expect(listBackupBranches(repo, 'feature')).toEqual([
+      'kobo-backup/feature-5000',
+      'kobo-backup/feature-4000',
+      'kobo-backup/feature-3000',
+    ])
+  })
+
+  it('leaves everything alone when there are fewer backups than the retention count', () => {
+    g(repo, ['checkout', '-q', '-b', 'feature'])
+    g(repo, ['branch', 'kobo-backup/feature-1000', 'feature'])
+    expect(pruneBackupBranches(repo, 'feature', 3).removed).toEqual([])
+    expect(listBackupBranches(repo, 'feature')).toEqual(['kobo-backup/feature-1000'])
+  })
+
+  it('reports a warning instead of silently disabling itself when the listing fails', () => {
+    const result = pruneBackupBranches('/definitely/not/a/repository', 'feature', 3)
+    expect(result.removed).toEqual([])
+    expect(result.warnings).toHaveLength(1)
+    expect(result.warnings[0]).toMatch(/backup/i)
+  })
+})
+
+describe('listBackupBranches error handling', () => {
+  it('throws instead of pretending there is no backup when git fails', () => {
+    expect(() => listBackupBranches('/definitely/not/a/repository', 'feature')).toThrow(
+      /Failed to list backup branches/,
+    )
   })
 })
 

--- a/src/__tests__/git-ops.test.ts
+++ b/src/__tests__/git-ops.test.ts
@@ -4,6 +4,7 @@ import os, { tmpdir } from 'node:os'
 import path, { join } from 'node:path'
 import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
 import {
+  assertNoIndexLock,
   BranchAlreadyExistsError,
   buildNonInteractiveGitEnv,
   commitAllChanges,
@@ -16,6 +17,8 @@ import {
   EMPTY_TREE_SHA,
   fetchSourceBranch,
   fetchSourceBranchAsync,
+  findStashIndexByLabel,
+  GitIndexLockError,
   getChangedFiles,
   getChangedFilesBetween,
   getCommitCount,
@@ -25,11 +28,13 @@ import {
   getDiffStats,
   getDiffStatsBetween,
   getFileAtRef,
+  getIndexLockPath,
   getStructuredDiffStatsBetween,
   getWorkingTreeDiffStats,
   getWorkingTreeFiles,
   getWorkingTreeStatus,
   isGitWorktree,
+  isValidBranchName,
   listBranchCommits,
   listBranches,
   listCommitsBehind,
@@ -41,6 +46,8 @@ import {
   rebaseBranch,
   rollbackFile,
   slugifyBranchSegment,
+  stashPop,
+  stashPush,
   worktreeHasChangesStrict,
 } from '../server/utils/git-ops.js'
 
@@ -1442,6 +1449,26 @@ describe('slugifyBranchSegment', () => {
   })
 })
 
+describe('isValidBranchName(name)', () => {
+  it('accepts the shapes Kōbō actually produces', () => {
+    for (const name of ['feature/my-thing', 'fix/bug_42', 'release-1.2.3', 'main']) {
+      expect(isValidBranchName(name)).toBe(true)
+    }
+  })
+
+  it('rejects anything git would read as an option', () => {
+    for (const name of ['--force', '-x', '--exec=rm -rf /']) {
+      expect(isValidBranchName(name)).toBe(false)
+    }
+  })
+
+  it('rejects the shapes git check-ref-format refuses', () => {
+    for (const name of ['', 'feature/..//x', 'feature/x.lock', 'feature/', 'feature/x.', 'a b']) {
+      expect(isValidBranchName(name)).toBe(false)
+    }
+  })
+})
+
 describe('getFileAtRef', () => {
   it('reads a file larger than the default 1 MB buffer instead of returning null', () => {
     const repo = mkdtempSync(join(tmpdir(), 'kobo-bigfile-'))
@@ -1489,5 +1516,70 @@ describe('buildNonInteractiveGitEnv — SSH prompt suppression', () => {
     const built = buildNonInteractiveGitEnv().GIT_SSH_COMMAND
     expect(built).toContain('-i /tmp/k')
     expect(built).toContain('-o BatchMode=yes')
+  })
+})
+
+describe('index lock detection', () => {
+  it('returns null when no lock is held', () => {
+    expect(getIndexLockPath(repoDir)).toBeNull()
+    expect(() => assertNoIndexLock(repoDir)).not.toThrow()
+  })
+
+  it('reports the absolute lock path and a removal command when a lock was left behind', () => {
+    const lockPath = path.join(repoDir, '.git', 'index.lock')
+    fs.writeFileSync(lockPath, '')
+    try {
+      expect(getIndexLockPath(repoDir)).toBe(lockPath)
+      expect(() => assertNoIndexLock(repoDir)).toThrow(GitIndexLockError)
+      expect(() => assertNoIndexLock(repoDir)).toThrow(`rm -f '${lockPath}'`)
+    } finally {
+      fs.rmSync(lockPath, { force: true })
+    }
+  })
+
+  it('never throws outside a git repository', () => {
+    const plain = fs.mkdtempSync(path.join(os.tmpdir(), 'kobo-nolock-'))
+    expect(getIndexLockPath(plain)).toBeNull()
+    fs.rmSync(plain, { recursive: true, force: true })
+  })
+})
+
+describe('stashPop(repoPath, label)', () => {
+  it('restores the Kōbō entry even when another stash was pushed on top of it', () => {
+    const repo = fs.mkdtempSync(path.join(os.tmpdir(), 'kobo-stash-'))
+    execFileSync('git', ['init', '-q', '-b', 'main'], { cwd: repo })
+    execFileSync('git', ['config', 'user.email', 't@t.t'], { cwd: repo })
+    execFileSync('git', ['config', 'user.name', 'T'], { cwd: repo })
+    fs.writeFileSync(path.join(repo, 'f.txt'), 'base\n')
+    execFileSync('git', ['add', '.'], { cwd: repo })
+    execFileSync('git', ['commit', '-q', '-m', 'base'], { cwd: repo })
+
+    // Kōbō stashes the user's work, under its own label.
+    fs.writeFileSync(path.join(repo, 'f.txt'), 'USER WORK\n')
+    stashPush(repo, 'kobo-change-source-branch')
+
+    // The agent (or the integrated terminal) stashes something else meanwhile.
+    fs.writeFileSync(path.join(repo, 'f.txt'), 'AGENT WORK\n')
+    execFileSync('git', ['stash', 'push', '-m', 'agent-wip'], { cwd: repo })
+
+    expect(findStashIndexByLabel(repo, 'kobo-change-source-branch')).toBe(1)
+
+    stashPop(repo, 'kobo-change-source-branch')
+
+    expect(fs.readFileSync(path.join(repo, 'f.txt'), 'utf-8')).toBe('USER WORK\n')
+    fs.rmSync(repo, { recursive: true, force: true })
+  })
+
+  it('throws instead of popping a random entry when the label is gone', () => {
+    const repo = fs.mkdtempSync(path.join(os.tmpdir(), 'kobo-stash-missing-'))
+    execFileSync('git', ['init', '-q', '-b', 'main'], { cwd: repo })
+    execFileSync('git', ['config', 'user.email', 't@t.t'], { cwd: repo })
+    execFileSync('git', ['config', 'user.name', 'T'], { cwd: repo })
+    fs.writeFileSync(path.join(repo, 'f.txt'), 'base\n')
+    execFileSync('git', ['add', '.'], { cwd: repo })
+    execFileSync('git', ['commit', '-q', '-m', 'base'], { cwd: repo })
+
+    expect(() => stashPop(repo, 'kobo-change-source-branch')).toThrow(/kobo-change-source-branch/)
+    fs.rmSync(repo, { recursive: true, force: true })
   })
 })

--- a/src/__tests__/git-repo-lock.test.ts
+++ b/src/__tests__/git-repo-lock.test.ts
@@ -1,0 +1,86 @@
+import { execFileSync } from 'node:child_process'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { _resetGitRepoLocksForTest, resolveGitCommonDir, withGitRepoLock } from '../server/utils/git-repo-lock.js'
+
+function g(repo: string, args: string[]): string {
+  return execFileSync('git', args, { cwd: repo, encoding: 'utf-8' }).trimEnd()
+}
+
+let repo: string
+let worktreeA: string
+let otherRepo: string
+
+beforeEach(() => {
+  _resetGitRepoLocksForTest()
+  repo = mkdtempSync(join(tmpdir(), 'kobo-lock-'))
+  g(repo, ['init', '-q', '-b', 'main'])
+  g(repo, ['config', 'user.email', 't@t.t'])
+  g(repo, ['config', 'user.name', 'T'])
+  writeFileSync(join(repo, 'f.txt'), 'base\n')
+  g(repo, ['add', '.'])
+  g(repo, ['commit', '-q', '-m', 'base'])
+  worktreeA = join(mkdtempSync(join(tmpdir(), 'kobo-lock-wt-')), 'a')
+  g(repo, ['worktree', 'add', '-q', '-b', 'feature/a', worktreeA])
+
+  otherRepo = mkdtempSync(join(tmpdir(), 'kobo-lock-other-'))
+  g(otherRepo, ['init', '-q', '-b', 'main'])
+})
+
+afterEach(() => {
+  rmSync(repo, { recursive: true, force: true })
+  rmSync(worktreeA, { recursive: true, force: true })
+  rmSync(otherRepo, { recursive: true, force: true })
+})
+
+describe('resolveGitCommonDir()', () => {
+  it('maps a worktree and its main repository to the same directory', () => {
+    expect(resolveGitCommonDir(worktreeA)).toBe(resolveGitCommonDir(repo))
+  })
+
+  it('maps two unrelated repositories to different directories', () => {
+    expect(resolveGitCommonDir(otherRepo)).not.toBe(resolveGitCommonDir(repo))
+  })
+
+  it('never throws outside a git repository', () => {
+    const plain = mkdtempSync(join(tmpdir(), 'kobo-lock-plain-'))
+    expect(() => resolveGitCommonDir(plain)).not.toThrow()
+    rmSync(plain, { recursive: true, force: true })
+  })
+})
+
+describe('withGitRepoLock()', () => {
+  it('never interleaves two operations on worktrees of the same repository', async () => {
+    const trace: string[] = []
+    const slow = async (tag: string) => {
+      trace.push(`${tag}:start`)
+      await new Promise((resolve) => setTimeout(resolve, 20))
+      trace.push(`${tag}:end`)
+    }
+
+    await Promise.all([withGitRepoLock(repo, () => slow('main')), withGitRepoLock(worktreeA, () => slow('worktree'))])
+
+    expect(trace).toEqual(['main:start', 'main:end', 'worktree:start', 'worktree:end'])
+  })
+
+  it('lets unrelated repositories run concurrently', async () => {
+    const trace: string[] = []
+    const slow = async (tag: string) => {
+      trace.push(`${tag}:start`)
+      await new Promise((resolve) => setTimeout(resolve, 20))
+      trace.push(`${tag}:end`)
+    }
+
+    await Promise.all([withGitRepoLock(repo, () => slow('one')), withGitRepoLock(otherRepo, () => slow('two'))])
+
+    expect(trace).toEqual(['one:start', 'two:start', 'one:end', 'two:end'])
+  })
+
+  it('does not let a failed operation block the queue', async () => {
+    const failing = withGitRepoLock(repo, () => Promise.reject(new Error('boom')))
+    await expect(failing).rejects.toThrow('boom')
+    await expect(withGitRepoLock(repo, () => 'ok')).resolves.toBe('ok')
+  })
+})

--- a/src/__tests__/migrations.test.ts
+++ b/src/__tests__/migrations.test.ts
@@ -42,8 +42,8 @@ describe('runMigrations(db)', () => {
     db.close()
   })
 
-  it('exporte SCHEMA_VERSION = 35', () => {
-    expect(SCHEMA_VERSION).toBe(35)
+  it('exporte SCHEMA_VERSION = 36', () => {
+    expect(SCHEMA_VERSION).toBe(36)
   })
 
   it('migration v33 records and backfills the engine on agent sessions', () => {
@@ -122,8 +122,17 @@ describe('runMigrations(db)', () => {
     )
     expect((db.prepare('SELECT errors FROM session_event_metrics').get() as { errors: number }).errors).toBe(1)
 
+    // v36 drops the AFTER DELETE trigger: metrics are recomputed once,
+    // application-side, at the end of the deleting transaction (see
+    // recomputeSessionMetrics in workspace-service.ts). The stored value is
+    // therefore intentionally stale until that call runs.
     db.prepare("DELETE FROM ws_events WHERE id = 'e3'").run()
-    expect((db.prepare('SELECT errors FROM session_event_metrics').get() as { errors: number }).errors).toBe(0)
+    expect((db.prepare('SELECT errors FROM session_event_metrics').get() as { errors: number }).errors).toBe(1)
+    expect(
+      (db
+        .prepare("SELECT name FROM sqlite_master WHERE type = 'trigger' AND name = ?")
+        .get('trg_ws_events_metrics_delete') as { name: string } | undefined) ?? null,
+    ).toBeNull()
     db.close()
   })
 
@@ -156,7 +165,7 @@ describe('runMigrations(db)', () => {
       status: 'completed',
       task_progress_baseline: null,
     })
-    expect(getMigrationHistory(upgraded).at(-1)).toMatchObject({
+    expect(getMigrationHistory(upgraded).find((record) => record.version === 35)).toMatchObject({
       version: 35,
       name: 'add-agent-session-task-progress-baseline',
     })
@@ -169,6 +178,65 @@ describe('runMigrations(db)', () => {
         (column) => column.name,
       ),
     ).toContain('task_progress_baseline')
+    fresh.close()
+  })
+
+  it('migration v36 drops the delete trigger and adds the hot indexes, converging with a fresh install', () => {
+    const upgraded = new Database(':memory:')
+    initSchema(upgraded)
+    // Re-create the v34 shape on purpose: an installation migrated through v34
+    // carries the trigger, a fresh install created after v36 never does.
+    upgraded.exec(`
+      CREATE TRIGGER IF NOT EXISTS trg_ws_events_metrics_delete
+      AFTER DELETE ON ws_events
+      WHEN OLD.type = 'agent:event' AND OLD.session_id IS NOT NULL
+      BEGIN
+        DELETE FROM session_event_metrics
+        WHERE workspace_id = OLD.workspace_id AND session_id = OLD.session_id;
+      END;
+      CREATE TABLE schema_migrations (version INTEGER PRIMARY KEY, name TEXT NOT NULL, applied_at TEXT NOT NULL);
+    `)
+    for (let version = 1; version <= 35; version++) {
+      upgraded.prepare('INSERT INTO schema_migrations VALUES (?, ?, ?)').run(version, `v${version}`, 'now')
+    }
+
+    runMigrations(upgraded)
+
+    const upgradedObjects = (
+      upgraded
+        .prepare("SELECT name FROM sqlite_master WHERE type IN ('trigger', 'index') AND name NOT LIKE 'sqlite_%'")
+        .all() as Array<{ name: string }>
+    )
+      .map((row) => row.name)
+      .sort()
+    expect(upgradedObjects).not.toContain('trg_ws_events_metrics_delete')
+    expect(upgradedObjects).toContain('trg_ws_events_metrics_insert')
+    for (const name of [
+      'idx_tasks_workspace_sort',
+      'idx_agent_sessions_workspace_started',
+      'idx_agent_sessions_engine_session',
+      'idx_workspaces_archived_updated',
+      'idx_session_event_metrics_session',
+    ]) {
+      expect(upgradedObjects).toContain(name)
+    }
+    expect(getMigrationHistory(upgraded).at(-1)).toMatchObject({
+      version: 36,
+      name: 'drop-metrics-delete-trigger-add-hot-indexes',
+    })
+
+    const fresh = new Database(':memory:')
+    runMigrations(fresh)
+    const freshObjects = (
+      fresh
+        .prepare("SELECT name FROM sqlite_master WHERE type IN ('trigger', 'index') AND name NOT LIKE 'sqlite_%'")
+        .all() as Array<{ name: string }>
+    )
+      .map((row) => row.name)
+      .sort()
+    expect(freshObjects).toEqual(upgradedObjects)
+
+    upgraded.close()
     fresh.close()
   })
 

--- a/src/__tests__/pr-watcher-service.test.ts
+++ b/src/__tests__/pr-watcher-service.test.ts
@@ -19,8 +19,13 @@ vi.mock('../server/services/workspace-service.js', () => ({
   updateWorkspaceSourceBranch: vi.fn(),
 }))
 vi.mock('../server/services/git-stats-service.js', () => ({ computeGitStats: vi.fn() }))
+const gitTrace: string[] = []
 vi.mock('../server/utils/git-ops.js', () => ({
-  fetchSourceBranchAsync: vi.fn(() => Promise.resolve()),
+  fetchSourceBranchAsync: vi.fn(async () => {
+    gitTrace.push('fetch:start')
+    await new Promise((resolve) => setTimeout(resolve, 10))
+    gitTrace.push('fetch:end')
+  }),
   isGitWorktree: vi.fn(() => false),
 }))
 vi.mock('node:fs', async () => {
@@ -194,6 +199,27 @@ describe('checkPrStatuses — base change detection', () => {
 
     expect(wsService.updateWorkspaceSourceBranch).not.toHaveBeenCalled()
     expect(wsSvc.emitEphemeral).not.toHaveBeenCalled()
+  })
+})
+
+describe('checkPrStatuses — git stats fetch ordering', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    _resetForTest()
+  })
+
+  it('waits for the fetch before computing git stats, so counters are not one tick late', async () => {
+    gitTrace.length = 0
+    vi.mocked(wsService.listWorkspaces).mockReturnValue([makeWorkspace()] as never)
+    vi.mocked(computeGitStats).mockImplementation(async () => {
+      gitTrace.push('stats')
+      return {} as never
+    })
+    getPrStatusMock.mockResolvedValue(null)
+
+    await checkPrStatuses()
+
+    expect(gitTrace).toEqual(['fetch:start', 'fetch:end', 'stats'])
   })
 })
 

--- a/src/__tests__/routes-settings.test.ts
+++ b/src/__tests__/routes-settings.test.ts
@@ -24,6 +24,16 @@ vi.mock('../server/services/agent/orchestrator.js', () => ({
   getBackendPort: vi.fn(() => 3300),
 }))
 
+vi.mock('../server/db/index.js', () => ({
+  getDb: vi.fn(() => ({
+    prepare: vi.fn(() => ({ get: vi.fn(() => ({ c: 0 })) })),
+  })),
+}))
+
+vi.mock('../server/services/ws-events-retention-service.js', () => ({
+  countPrunableWsEvents: vi.fn(() => 0),
+}))
+
 // ── Imports (after mocks) ────────────────────────────────────────────────────
 
 import router from '../server/routes/settings.js'
@@ -377,5 +387,18 @@ describe('network routes', () => {
     const res = await app.request('/api/settings/network/ping')
     expect(res.status).toBe(200)
     expect(await res.json()).toEqual({ ok: true })
+  })
+})
+
+describe('GET /ws-events-retention-preview', () => {
+  it('refuses a negative window instead of counting something absurd', async () => {
+    const res = await app.request('/api/settings/ws-events-retention-preview?days=-1&keep=0')
+    expect(res.status).toBe(400)
+  })
+
+  it('counts zero when the window is 0 — retention disabled deletes nothing', async () => {
+    const res = await app.request('/api/settings/ws-events-retention-preview?days=0&keep=0')
+    expect(res.status).toBe(200)
+    expect((await res.json()) as { deletable: number }).toMatchObject({ deletable: 0 })
   })
 })

--- a/src/__tests__/routes-workspaces.test.ts
+++ b/src/__tests__/routes-workspaces.test.ts
@@ -55,6 +55,7 @@ vi.mock('../server/services/workspace-service.js', () => ({
   updateWorkspaceSourceBranch: vi.fn(),
   setInitialPrompt: vi.fn(),
   clearInitialPrompt: vi.fn(),
+  recomputeSessionMetrics: vi.fn(),
 }))
 
 vi.mock('../server/services/worktree-service.js', () => ({
@@ -154,6 +155,13 @@ vi.mock('../server/utils/git-ops.js', () => ({
       .replace(/^-+|-+$/g, '')
       .slice(0, maxLen)
       .replace(/-+$/g, ''),
+  // Mirror the real validator so rename-branch tests exercise real behavior.
+  isValidBranchName: (name: string) => {
+    if (!/^[A-Za-z0-9][A-Za-z0-9/_.-]*$/.test(name)) return false
+    if (name.includes('..') || name.includes('//')) return false
+    if (name.endsWith('/') || name.endsWith('.') || name.endsWith('.lock')) return false
+    return true
+  },
   deleteLocalBranch: vi.fn(),
   deleteRemoteBranch: vi.fn(),
   pushBranch: vi.fn(),
@@ -217,6 +225,7 @@ vi.mock('../server/utils/git-ops.js', () => ({
   renameBranch: vi.fn(),
   branchExists: vi.fn().mockReturnValue(false),
   listBackupBranches: vi.fn().mockReturnValue([]),
+  pruneBackupBranches: vi.fn().mockReturnValue([]),
   restoreBranchFromBackup: vi.fn(),
   getWorkingTreeFiles: vi.fn().mockReturnValue([]),
 }))
@@ -5116,6 +5125,19 @@ describe('POST /api/workspaces/:id/rename-branch', () => {
     expect(vi.mocked(workspaceService.updateWorktreePath)).not.toHaveBeenCalled()
     expect(vi.mocked(workspaceService.updateWorkingBranch)).toHaveBeenCalledWith('ws-1', 'feature/new')
   })
+
+  it('rejects a branch name git would read as an option', async () => {
+    const res = await app.request('/api/workspaces/ws-1/rename-branch', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ newName: '--force' }),
+    })
+    expect(res.status).toBe(400)
+    expect((await res.json()) as { error: string }).toMatchObject({
+      error: expect.stringContaining('Invalid branch name'),
+    })
+    expect(vi.mocked(gitOps.renameBranch)).not.toHaveBeenCalled()
+  })
 })
 
 describe('POST /api/workspaces — pre-flight URL validation', () => {
@@ -6189,6 +6211,20 @@ describe('POST /api/workspaces/:id/cancel-source-change', () => {
     expect(res.status).toBe(409)
     const body = await res.json()
     expect((body as { code: string }).code).toBe('no_backup')
+    expect(gitOps.restoreBranchFromBackup).not.toHaveBeenCalled()
+  })
+
+  it('answers 500 with backup_list_failed when the backup list cannot be read', async () => {
+    vi.mocked(gitOps.listBackupBranches).mockImplementation(() => {
+      throw new Error("Failed to list backup branches for 'feature': index.lock exists")
+    })
+    const res = await app.request('/api/workspaces/ws-1/cancel-source-change', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ previousBase: 'main' }),
+    })
+    expect(res.status).toBe(500)
+    expect((await res.json()) as { code: string }).toMatchObject({ code: 'backup_list_failed' })
     expect(gitOps.restoreBranchFromBackup).not.toHaveBeenCalled()
   })
 

--- a/src/__tests__/script-runner.test.ts
+++ b/src/__tests__/script-runner.test.ts
@@ -4,6 +4,13 @@ import { runScript } from '../server/utils/script-runner.js'
 
 vi.mock('node:child_process', () => ({
   spawn: vi.fn(),
+  // `script-runner.ts` now imports `git-ops.js`, which wires `execFileSync`/
+  // `execFile` at module load time (`promisify(execFile)` throws immediately
+  // if the arg isn't a function). These stubs just need to exist; the timeout
+  // path calls `getIndexLockPath`, which swallows any error from them and
+  // returns `null`, so an empty worktree path here is harmless.
+  execFile: vi.fn(),
+  execFileSync: vi.fn(),
 }))
 vi.mock('../server/services/websocket-service.js', () => ({
   emit: vi.fn(),
@@ -14,7 +21,9 @@ vi.mock('node:fs', () => ({
     mkdirSync: vi.fn(),
     writeFileSync: vi.fn(),
     unlinkSync: vi.fn(),
+    existsSync: vi.fn(),
   },
+  existsSync: vi.fn(),
 }))
 
 describe('runScript — process group on timeout', () => {

--- a/src/__tests__/settings-service.test.ts
+++ b/src/__tests__/settings-service.test.ts
@@ -217,6 +217,23 @@ describe('updateGlobalSettings()', () => {
     expect(() => updateGlobalSettings({ worktreesPath: '../outside' })).toThrow(/parent directory traversal/)
     expect(getGlobalSettings().worktreesPath).toBe('$HOME/kobo/worktrees')
   })
+
+  it('accepts an explicit retention window and refuses an out-of-range one', () => {
+    expect(getGlobalSettings().wsEventsRetentionDays).toBe(0)
+
+    updateGlobalSettings({ wsEventsRetentionDays: 30, wsEventsKeepPerWorkspace: 5000 } as Partial<GlobalSettings>)
+    expect(getGlobalSettings().wsEventsRetentionDays).toBe(30)
+
+    updateGlobalSettings({ wsEventsRetentionDays: -5 } as Partial<GlobalSettings>)
+    expect(getGlobalSettings().wsEventsRetentionDays).toBe(30)
+
+    updateGlobalSettings({ wsEventsRetentionDays: 4_000 } as Partial<GlobalSettings>)
+    expect(getGlobalSettings().wsEventsRetentionDays).toBe(30)
+
+    // 0 is a first-class value — "never delete anything" — not an error.
+    updateGlobalSettings({ wsEventsRetentionDays: 0 } as Partial<GlobalSettings>)
+    expect(getGlobalSettings().wsEventsRetentionDays).toBe(0)
+  })
 })
 
 describe('upsertProject()', () => {
@@ -856,6 +873,53 @@ describe('runSettingsMigrations()', () => {
 
     const migrated = runSettingsMigrations(legacy as unknown as Record<string, unknown>)
     expect(migrated.global.cleanupScriptOnlyOnChanges).toBe(true)
+  })
+
+  it('migration v54 seeds retention DISABLED — the feature is opt-in', () => {
+    const legacy = {
+      schemaVersion: 53,
+      global: {},
+      projects: [],
+    }
+
+    const migrated = runSettingsMigrations(legacy as unknown as Record<string, unknown>)
+    expect(migrated.schemaVersion).toBe(SETTINGS_SCHEMA_VERSION)
+    expect(migrated.global.wsEventsRetentionDays).toBe(0)
+    expect(migrated.global.wsEventsKeepPerWorkspace).toBe(0)
+  })
+
+  it('migration v54 preserves a window the user had already chosen', () => {
+    const legacy = {
+      schemaVersion: 53,
+      global: { wsEventsRetentionDays: 45, wsEventsKeepPerWorkspace: 2000 },
+      projects: [],
+    }
+
+    const migrated = runSettingsMigrations(legacy as unknown as Record<string, unknown>)
+    expect(migrated.global.wsEventsRetentionDays).toBe(45)
+    expect(migrated.global.wsEventsKeepPerWorkspace).toBe(2000)
+  })
+
+  it('migration v54 falls back to disabled on a garbage value', () => {
+    const legacy = {
+      schemaVersion: 53,
+      global: { wsEventsRetentionDays: -1, wsEventsKeepPerWorkspace: 'lots' },
+      projects: [],
+    }
+
+    const migrated = runSettingsMigrations(legacy as unknown as Record<string, unknown>)
+    expect(migrated.global.wsEventsRetentionDays).toBe(0)
+    expect(migrated.global.wsEventsKeepPerWorkspace).toBe(0)
+  })
+
+  it('a fresh settings file is born with retention disabled, like a migrated one', () => {
+    const fresh = getSettings()
+    expect(fresh.global.wsEventsRetentionDays).toBe(0)
+    expect(fresh.global.wsEventsKeepPerWorkspace).toBe(0)
+
+    const migrated = runSettingsMigrations({ schemaVersion: 53, global: {}, projects: [] })
+    expect(migrated.global.wsEventsRetentionDays).toBe(fresh.global.wsEventsRetentionDays)
+    expect(migrated.global.wsEventsKeepPerWorkspace).toBe(fresh.global.wsEventsKeepPerWorkspace)
   })
 })
 
@@ -2131,7 +2195,7 @@ describe('PR notification sounds (v45)', () => {
       audioQuestionSound: 'hey.mp3',
       networkAccessToken: 'keep-me',
     })
-    expect(SETTINGS_SCHEMA_VERSION).toBe(53)
+    expect(SETTINGS_SCHEMA_VERSION).toBe(54)
   })
 
   it('adds the auto-loop retry limit while preserving existing settings', () => {
@@ -2249,7 +2313,7 @@ describe('whip feature toggle (v51)', () => {
       projects: [],
     })
 
-    expect(migrated.schemaVersion).toBe(53)
+    expect(migrated.schemaVersion).toBe(54)
     expect(migrated.global.whipEnabled).toBe(false)
     expect(migrated.global.audioNotifications).toBe(true)
   })
@@ -2297,7 +2361,7 @@ describe('whip feature toggle (v51)', () => {
       projects: [],
     })
 
-    expect(migrated.schemaVersion).toBe(53)
+    expect(migrated.schemaVersion).toBe(54)
     expect(migrated.global.whipShortcut).toBe('mod+shift+x')
     expect(migrated.global.editorCommand).toBe('zed')
   })
@@ -2359,7 +2423,7 @@ describe('whip feature toggle (v51)', () => {
       projects: [],
     })
 
-    expect(migrated.schemaVersion).toBe(53)
+    expect(migrated.schemaVersion).toBe(54)
     expect(migrated.global.whipVolume).toBe(1)
     expect(migrated.global.whipShortcut).toBe('alt+k')
     expect(migrated.global.editorCommand).toBe('zed')

--- a/src/__tests__/websocket-service.test.ts
+++ b/src/__tests__/websocket-service.test.ts
@@ -3,7 +3,7 @@ import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
 import Database from 'better-sqlite3'
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { initSchema } from '../server/db/schema.js'
 
 // ── DB setup (same pattern as workspace-service tests) ──
@@ -29,9 +29,25 @@ async function resetDb() {
 class MockWebSocket extends EventEmitter {
   readyState = 1 // OPEN
   sentMessages: string[] = []
+  bufferedAmount = 0
+  pings = 0
+  terminated = false
+  /** When false, the socket stops answering pings — a half-open connection. */
+  answersPing = true
 
   send(data: string): void {
     this.sentMessages.push(data)
+  }
+
+  ping(): void {
+    this.pings += 1
+    if (this.answersPing) this.emit('pong')
+  }
+
+  terminate(): void {
+    this.terminated = true
+    this.readyState = 3 // CLOSED
+    this.emit('close')
   }
 
   close(): void {
@@ -552,6 +568,117 @@ describe('emitEphemeral()', () => {
 
     expect(wsSub.sentMessages.length).toBe(1)
     expect(wsNotSub.sentMessages.length).toBe(0)
+  })
+})
+
+describe('handleSyncRequest() bounds', () => {
+  it('caps the delta replay instead of streaming a whole night in one message', async () => {
+    const { emit, handleConnection, handleSyncRequest } = await import('../server/services/websocket-service.js')
+    const { getDb } = await import('../server/db/index.js')
+    const db = getDb()
+    const now = new Date().toISOString()
+    db.prepare(
+      `INSERT INTO workspaces (id, name, project_path, source_branch, working_branch, model, created_at, updated_at)
+       VALUES ('ws-1', 'w', '/tmp/w', 'main', 'feature/w', 'claude-opus-4-8', ?, ?)`,
+    ).run(now, now)
+
+    const cursor = emit('ws-1', 'agent:output', { text: 'cursor' })
+    for (let i = 0; i < 2_500; i++) emit('ws-1', 'agent:output', { text: `line ${i}` })
+
+    const ws = new MockWebSocket()
+    handleConnection(ws as unknown as import('ws').WebSocket)
+    ws.sentMessages.length = 0
+    handleSyncRequest(ws as unknown as import('ws').WebSocket, cursor, ['ws-1'])
+
+    const payload = JSON.parse(ws.sentMessages.at(-1) as string) as {
+      type: string
+      payload: { events: unknown[]; mode: string; truncated: boolean }
+    }
+    expect(payload.type).toBe('sync:response')
+    expect(payload.payload.mode).toBe('delta')
+    expect(payload.payload.events.length).toBeLessThanOrEqual(2_000)
+    expect(payload.payload.truncated).toBe(true)
+  })
+
+  it('keeps the most recent events when the snapshot replay overflows the cap', async () => {
+    const { emit, handleConnection, handleSyncRequest } = await import('../server/services/websocket-service.js')
+    const { getDb } = await import('../server/db/index.js')
+    const db = getDb()
+    const now = new Date().toISOString()
+    const insertWorkspace = db.prepare(
+      `INSERT INTO workspaces (id, name, project_path, source_branch, working_branch, model, created_at, updated_at)
+       VALUES (?, ?, '/tmp/w', 'main', 'feature/w', 'claude-opus-4-8', ?, ?)`,
+    )
+
+    // 7 workspaces × the 300-event initial window = 2 100 rows, above the
+    // 2 000-event cap. Emitting workspace by workspace makes rowid order match
+    // emission order, so "oldest" and "newest" are unambiguous.
+    const workspaceIds: string[] = []
+    let oldestId = ''
+    let newestId = ''
+    for (let w = 0; w < 7; w++) {
+      const workspaceId = `ws-snap-${w}`
+      workspaceIds.push(workspaceId)
+      insertWorkspace.run(workspaceId, `w${w}`, now, now)
+      for (let i = 0; i < 300; i++) {
+        const id = emit(workspaceId, 'agent:output', { text: `${workspaceId}-${i}` })
+        if (w === 0 && i === 0) oldestId = id
+        newestId = id
+      }
+    }
+
+    const ws = new MockWebSocket()
+    handleConnection(ws as unknown as import('ws').WebSocket)
+    ws.sentMessages.length = 0
+    // No cursor at all → snapshot mode.
+    handleSyncRequest(ws as unknown as import('ws').WebSocket, '', workspaceIds)
+
+    const payload = JSON.parse(ws.sentMessages.at(-1) as string) as {
+      type: string
+      payload: { events: { id: string }[]; mode: string; truncated: boolean }
+    }
+    expect(payload.payload.mode).toBe('snapshot')
+    expect(payload.payload.events.length).toBe(2_000)
+    expect(payload.payload.truncated).toBe(true)
+    const ids = payload.payload.events.map((e) => e.id)
+    expect(ids).toContain(newestId)
+    expect(ids).not.toContain(oldestId)
+  })
+
+  it('answers sync:error instead of throwing when the query fails', async () => {
+    const { handleConnection, handleSyncRequest } = await import('../server/services/websocket-service.js')
+    const { closeDb } = await import('../server/db/index.js')
+    const ws = new MockWebSocket()
+    handleConnection(ws as unknown as import('ws').WebSocket)
+    ws.sentMessages.length = 0
+    closeDb() // every statement now throws "The database connection is not open"
+
+    expect(() => handleSyncRequest(ws as unknown as import('ws').WebSocket, '', ['ws-1'])).not.toThrow()
+    expect(JSON.parse(ws.sentMessages.at(-1) as string)).toMatchObject({ type: 'sync:error' })
+  })
+})
+
+describe('heartbeat', () => {
+  it('terminates a client that stops answering, and drops it from the map', async () => {
+    vi.useFakeTimers()
+    try {
+      const { handleConnection, getClientCount } = await import('../server/services/websocket-service.js')
+      const ws = new MockWebSocket()
+      handleConnection(ws as unknown as import('ws').WebSocket)
+
+      vi.advanceTimersByTime(30_000)
+      expect(ws.pings).toBe(1)
+      expect(ws.terminated).toBe(false)
+
+      ws.answersPing = false
+      vi.advanceTimersByTime(30_000) // ping #2, still answered? no — pong never comes
+      vi.advanceTimersByTime(30_000) // this tick sees the missing pong
+
+      expect(ws.terminated).toBe(true)
+      expect(getClientCount()).toBe(0)
+    } finally {
+      vi.useRealTimers()
+    }
   })
 })
 

--- a/src/__tests__/workspace-permission-policy-service.test.ts
+++ b/src/__tests__/workspace-permission-policy-service.test.ts
@@ -1,0 +1,182 @@
+// Permission rules are the second irreversible operation of the product: an
+// "always allow" grants a tool a standing right for the life of the workspace.
+// A fingerprint bug here is invisible in use — it silently widens the grant.
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import Database from 'better-sqlite3'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { initSchema } from '../server/db/schema.js'
+
+let tmpDir: string
+let dbPath: string
+
+async function resetDb() {
+  const { closeDb } = await import('../server/db/index.js')
+  closeDb()
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'at-perm-svc-test-'))
+  dbPath = path.join(tmpDir, 'test.db')
+  const db = new Database(dbPath)
+  db.pragma('journal_mode=WAL')
+  db.pragma('foreign_keys=ON')
+  initSchema(db)
+  db.close()
+}
+
+beforeEach(async () => {
+  await resetDb()
+  const { getDb } = await import('../server/db/index.js')
+  const db = getDb(dbPath)
+  const now = new Date().toISOString()
+  db.prepare(
+    `INSERT INTO workspaces (id, name, project_path, source_branch, working_branch, model, created_at, updated_at)
+     VALUES ('ws-1', 'w', '/tmp/w', 'main', 'feature/w', 'claude-opus-4-8', ?, ?)`,
+  ).run(now, now)
+})
+
+afterEach(async () => {
+  const { clearTurnPermissions } = await import('../server/services/workspace-permission-policy-service.js')
+  clearTurnPermissions('ws-1')
+  const { closeDb } = await import('../server/db/index.js')
+  closeDb()
+  if (tmpDir && fs.existsSync(tmpDir)) fs.rmSync(tmpDir, { recursive: true, force: true })
+})
+
+const bashLs = { engine: 'claude-code', toolName: 'Bash', payload: { command: 'ls -la' } }
+const bashRm = { engine: 'claude-code', toolName: 'Bash', payload: { command: 'rm -rf /' } }
+
+describe('permissionFingerprint()', () => {
+  it('is stable under key reordering — same operation, same fingerprint', async () => {
+    const { permissionFingerprint } = await import('../server/services/workspace-permission-policy-service.js')
+    expect(permissionFingerprint({ a: 1, b: { c: 2, d: 3 } })).toBe(permissionFingerprint({ b: { d: 3, c: 2 }, a: 1 }))
+  })
+
+  it('separates two different operations', async () => {
+    const { permissionFingerprint } = await import('../server/services/workspace-permission-policy-service.js')
+    expect(permissionFingerprint({ command: 'ls -la' })).not.toBe(permissionFingerprint({ command: 'rm -rf /' }))
+  })
+
+  it('does not collapse an array into the object with the same values', async () => {
+    const { permissionFingerprint } = await import('../server/services/workspace-permission-policy-service.js')
+    expect(permissionFingerprint([1, 2])).not.toBe(permissionFingerprint({ 0: 1, 1: 2 }))
+  })
+})
+
+describe('turn-scoped permissions', () => {
+  it('allows for the current turn only, and forgets on clear', async () => {
+    const { allowPermissionForTurn, clearTurnPermissions, isWorkspacePermissionAllowed } = await import(
+      '../server/services/workspace-permission-policy-service.js'
+    )
+    expect(isWorkspacePermissionAllowed('ws-1', bashLs)).toBe(false)
+
+    allowPermissionForTurn('ws-1', bashLs)
+    expect(isWorkspacePermissionAllowed('ws-1', bashLs)).toBe(true)
+    // Turn scope is per tool, not per payload — the allowance covers the turn.
+    expect(isWorkspacePermissionAllowed('ws-1', bashRm)).toBe(true)
+
+    clearTurnPermissions('ws-1')
+    expect(isWorkspacePermissionAllowed('ws-1', bashLs)).toBe(false)
+  })
+
+  it('never leaks a turn allowance to another workspace', async () => {
+    const { allowPermissionForTurn, isWorkspacePermissionAllowed } = await import(
+      '../server/services/workspace-permission-policy-service.js'
+    )
+    allowPermissionForTurn('ws-1', bashLs)
+    expect(isWorkspacePermissionAllowed('ws-2', bashLs)).toBe(false)
+  })
+})
+
+describe('persisted permission rules', () => {
+  it("an 'operation' rule covers that exact payload and nothing else", async () => {
+    const { createWorkspacePermissionRule, isWorkspacePermissionAllowed } = await import(
+      '../server/services/workspace-permission-policy-service.js'
+    )
+    createWorkspacePermissionRule('ws-1', bashLs, 'operation')
+
+    expect(isWorkspacePermissionAllowed('ws-1', bashLs)).toBe(true)
+    expect(
+      isWorkspacePermissionAllowed('ws-1', { engine: 'claude-code', toolName: 'Bash', payload: { command: 'ls -la' } }),
+    ).toBe(true)
+    expect(isWorkspacePermissionAllowed('ws-1', bashRm)).toBe(false)
+  })
+
+  it("a 'tool' rule covers every invocation of that tool", async () => {
+    const { createWorkspacePermissionRule, isWorkspacePermissionAllowed } = await import(
+      '../server/services/workspace-permission-policy-service.js'
+    )
+    createWorkspacePermissionRule('ws-1', bashLs, 'tool')
+    expect(isWorkspacePermissionAllowed('ws-1', bashRm)).toBe(true)
+    expect(isWorkspacePermissionAllowed('ws-1', { engine: 'claude-code', toolName: 'Write', payload: {} })).toBe(false)
+  })
+
+  it('records the scope, the fingerprint and a label, and lists newest first', async () => {
+    const { createWorkspacePermissionRule, listWorkspacePermissionRules, permissionFingerprint } = await import(
+      '../server/services/workspace-permission-policy-service.js'
+    )
+    const operation = createWorkspacePermissionRule('ws-1', bashLs, 'operation')
+    expect(operation).toMatchObject({
+      workspaceId: 'ws-1',
+      engine: 'claude-code',
+      toolName: 'Bash',
+      scope: 'operation',
+      fingerprint: permissionFingerprint(bashLs.payload),
+    })
+    expect(operation.displayLabel).toContain('Bash')
+
+    const tool = createWorkspacePermissionRule('ws-1', bashLs, 'tool')
+    expect(tool.fingerprint).toBeNull()
+    expect(tool.displayLabel).toBe('Bash')
+
+    expect(listWorkspacePermissionRules('ws-1')).toHaveLength(2)
+  })
+
+  it('revokes a rule, and reports whether anything was revoked', async () => {
+    const { createWorkspacePermissionRule, isWorkspacePermissionAllowed, removeWorkspacePermissionRule } = await import(
+      '../server/services/workspace-permission-policy-service.js'
+    )
+    const rule = createWorkspacePermissionRule('ws-1', bashLs, 'tool')
+    expect(isWorkspacePermissionAllowed('ws-1', bashRm)).toBe(true)
+
+    expect(removeWorkspacePermissionRule('ws-1', rule.id)).toBe(true)
+    expect(isWorkspacePermissionAllowed('ws-1', bashRm)).toBe(false)
+    expect(removeWorkspacePermissionRule('ws-1', rule.id)).toBe(false)
+  })
+
+  it('refuses to revoke a rule belonging to another workspace', async () => {
+    const { createWorkspacePermissionRule, removeWorkspacePermissionRule, isWorkspacePermissionAllowed } = await import(
+      '../server/services/workspace-permission-policy-service.js'
+    )
+    const rule = createWorkspacePermissionRule('ws-1', bashLs, 'tool')
+    expect(removeWorkspacePermissionRule('ws-2', rule.id)).toBe(false)
+    expect(isWorkspacePermissionAllowed('ws-1', bashRm)).toBe(true)
+  })
+
+  it('scopes rules to their workspace', async () => {
+    const { createWorkspacePermissionRule, isWorkspacePermissionAllowed, listWorkspacePermissionRules } = await import(
+      '../server/services/workspace-permission-policy-service.js'
+    )
+    createWorkspacePermissionRule('ws-1', bashLs, 'tool')
+    expect(isWorkspacePermissionAllowed('ws-2', bashLs)).toBe(false)
+    expect(listWorkspacePermissionRules('ws-2')).toEqual([])
+  })
+
+  it('does not match a rule created for another engine', async () => {
+    const { createWorkspacePermissionRule, isWorkspacePermissionAllowed } = await import(
+      '../server/services/workspace-permission-policy-service.js'
+    )
+    createWorkspacePermissionRule('ws-1', { ...bashLs, engine: 'codex' }, 'tool')
+    expect(isWorkspacePermissionAllowed('ws-1', bashLs)).toBe(false)
+    expect(isWorkspacePermissionAllowed('ws-1', { ...bashLs, engine: 'codex' })).toBe(true)
+  })
+
+  it('disappears with its workspace, without leaving an orphan grant', async () => {
+    const { getDb } = await import('../server/db/index.js')
+    const { createWorkspacePermissionRule, listWorkspacePermissionRules } = await import(
+      '../server/services/workspace-permission-policy-service.js'
+    )
+    createWorkspacePermissionRule('ws-1', bashLs, 'tool')
+    getDb().prepare("DELETE FROM workspaces WHERE id = 'ws-1'").run()
+    expect(listWorkspacePermissionRules('ws-1')).toEqual([])
+  })
+})

--- a/src/__tests__/workspace-service.test.ts
+++ b/src/__tests__/workspace-service.test.ts
@@ -1677,3 +1677,43 @@ describe('dismissPrAttention() / restorePrAttention()', () => {
     expect(() => restorePrAttention('nope', 'ci-failed')).toThrow("Workspace 'nope' not found")
   })
 })
+
+describe('recomputeSessionMetrics()', () => {
+  it('rebuilds a session metric row after events were deleted without the session', async () => {
+    const { getDb } = await import('../server/db/index.js')
+    const { recomputeSessionMetrics } = await import('../server/services/workspace-service.js')
+    const db = getDb()
+    const now = new Date().toISOString()
+    db.prepare(
+      `INSERT INTO workspaces (id, name, project_path, source_branch, working_branch, model, created_at, updated_at)
+       VALUES ('ws-1', 'w', '/tmp/w', 'main', 'feature/w', 'claude-opus-4-8', ?, ?)`,
+    ).run(now, now)
+    db.prepare(
+      "INSERT INTO agent_sessions (id, workspace_id, status, started_at) VALUES ('s-1', 'ws-1', 'completed', ?)",
+    ).run(now)
+    const insert = db.prepare(
+      'INSERT INTO ws_events (id, workspace_id, type, payload, session_id, created_at) VALUES (?, ?, ?, ?, ?, ?)',
+    )
+    insert.run('e1', 'ws-1', 'agent:event', '{"kind":"tool:call"}', 's-1', now)
+    insert.run('e2', 'ws-1', 'agent:event', '{"kind":"tool:call"}', 's-1', now)
+    insert.run('e3', 'ws-1', 'agent:event', '{"kind":"error"}', 's-1', now)
+
+    expect(db.prepare('SELECT tool_calls, errors FROM session_event_metrics').get()).toEqual({
+      tool_calls: 2,
+      errors: 1,
+    })
+
+    // No AFTER DELETE trigger any more: the stored row goes stale on purpose.
+    db.prepare("DELETE FROM ws_events WHERE id = 'e3'").run()
+    expect(db.prepare('SELECT tool_calls, errors FROM session_event_metrics').get()).toEqual({
+      tool_calls: 2,
+      errors: 1,
+    })
+
+    recomputeSessionMetrics('ws-1', 's-1')
+    expect(db.prepare('SELECT tool_calls, errors FROM session_event_metrics').get()).toEqual({
+      tool_calls: 2,
+      errors: 0,
+    })
+  })
+})

--- a/src/__tests__/worktree-purge-service.test.ts
+++ b/src/__tests__/worktree-purge-service.test.ts
@@ -1,0 +1,179 @@
+// The two irreversible operations of the product had no test at all. This one
+// covers worktree purge: an operation that deletes a directory from disk and
+// flips a flag driving the "restore" UX and the PR watcher's auto-restore probe.
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const existsSyncMock = vi.fn(() => true)
+vi.mock('node:fs', async () => {
+  const actual = await vi.importActual<typeof import('node:fs')>('node:fs')
+  return {
+    ...actual,
+    existsSync: (p: string) => existsSyncMock(p),
+    default: { ...actual, existsSync: (p: string) => existsSyncMock(p) },
+  }
+})
+
+// The real service calls `agentManager.stopAgentAndWait` (not `stopAgent`) so
+// that `removeWorktree`, which runs later in the same function, never races a
+// still-dying agent process.
+const stopAgentAndWaitMock = vi.fn(async () => {})
+vi.mock('../server/services/agent/orchestrator.js', () => ({
+  stopAgentAndWait: (id: string) => stopAgentAndWaitMock(id),
+}))
+const stopDevServerMock = vi.fn(async () => {})
+vi.mock('../server/services/dev-server-service.js', () => ({ stopDevServer: (id: string) => stopDevServerMock(id) }))
+const destroyTerminalMock = vi.fn()
+vi.mock('../server/services/terminal-service.js', () => ({ destroyTerminal: (id: string) => destroyTerminalMock(id) }))
+
+const getPrStatusMock = vi.fn(async () => ({ number: 42, url: 'https://example.test/pr/42' }))
+vi.mock('../server/services/forge/resolve.js', () => ({ resolveForge: vi.fn(() => 'github') }))
+vi.mock('../server/services/forge/registry.js', () => ({
+  getForgeProvider: vi.fn(() => ({ id: 'github', getPrStatus: getPrStatusMock })),
+}))
+
+const emitEphemeralMock = vi.fn()
+vi.mock('../server/services/websocket-service.js', () => ({
+  emitEphemeral: (id: string, type: string, payload: unknown) => emitEphemeralMock(id, type, payload),
+}))
+
+const getWorkspaceMock = vi.fn()
+const archiveWorkspaceMock = vi.fn((id: string) => ({ id, archivedAt: '2026-08-29T00:00:00.000Z' }))
+const markWorktreePurgedMock = vi.fn()
+vi.mock('../server/services/workspace-service.js', () => ({
+  getWorkspace: (id: string) => getWorkspaceMock(id),
+  archiveWorkspace: (id: string) => archiveWorkspaceMock(id),
+  markWorktreePurged: (id: string, data: unknown) => markWorktreePurgedMock(id, data),
+}))
+
+const removeWorktreeMock = vi.fn()
+vi.mock('../server/services/worktree-service.js', () => ({
+  removeWorktree: (projectPath: string, worktreePath: string) => removeWorktreeMock(projectPath, worktreePath),
+  isPermissionError: (message: string) => /EACCES|EPERM|permission denied/i.test(message),
+}))
+
+import { purgeWorktree } from '../server/services/worktree-purge-service.js'
+
+function makeWorkspace(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'ws-1',
+    name: 'my workspace',
+    projectPath: '/tmp/project',
+    worktreePath: '/tmp/project/.worktrees/ws-1',
+    workingBranch: 'feature/x',
+    sourceBranch: 'develop',
+    worktreeOwned: true,
+    worktreePurgedAt: null,
+    archivedAt: null,
+    ...overrides,
+  }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  existsSyncMock.mockReturnValue(true)
+  getPrStatusMock.mockResolvedValue({ number: 42, url: 'https://example.test/pr/42' })
+})
+
+describe('purgeWorktree()', () => {
+  it('reports not-found for an unknown workspace, touching nothing', async () => {
+    getWorkspaceMock.mockReturnValue(undefined)
+    await expect(purgeWorktree('nope')).resolves.toEqual({ outcome: 'not-found', warnings: [] })
+    expect(removeWorktreeMock).not.toHaveBeenCalled()
+    expect(markWorktreePurgedMock).not.toHaveBeenCalled()
+  })
+
+  it('is idempotent on an already purged workspace', async () => {
+    getWorkspaceMock.mockReturnValue(makeWorkspace({ worktreePurgedAt: '2026-08-01T00:00:00.000Z' }))
+    await expect(purgeWorktree('ws-1')).resolves.toEqual({ outcome: 'already-purged', warnings: [] })
+    expect(removeWorktreeMock).not.toHaveBeenCalled()
+  })
+
+  it('refuses to delete a worktree Kōbō did not create', async () => {
+    getWorkspaceMock.mockReturnValue(makeWorkspace({ worktreeOwned: false }))
+    await expect(purgeWorktree('ws-1')).resolves.toEqual({ outcome: 'worktree-not-owned', warnings: [] })
+    expect(removeWorktreeMock).not.toHaveBeenCalled()
+  })
+
+  it('stops the agent, the dev server and the terminal before removing anything', async () => {
+    getWorkspaceMock.mockReturnValue(makeWorkspace())
+    existsSyncMock.mockImplementation(() => removeWorktreeMock.mock.calls.length === 0)
+
+    const result = await purgeWorktree('ws-1')
+
+    expect(result.outcome).toBe('purged')
+    expect(stopAgentAndWaitMock).toHaveBeenCalledWith('ws-1')
+    expect(stopDevServerMock).toHaveBeenCalledWith('ws-1')
+    expect(destroyTerminalMock).toHaveBeenCalledWith('ws-1')
+    expect(removeWorktreeMock).toHaveBeenCalledWith('/tmp/project', '/tmp/project/.worktrees/ws-1')
+  })
+
+  it('archives, marks purged and captures the PR snapshot on the happy path', async () => {
+    getWorkspaceMock.mockReturnValue(makeWorkspace())
+    existsSyncMock.mockImplementation(() => removeWorktreeMock.mock.calls.length === 0)
+
+    const result = await purgeWorktree('ws-1')
+
+    expect(result).toEqual({ outcome: 'purged', warnings: [] })
+    expect(archiveWorkspaceMock).toHaveBeenCalledWith('ws-1')
+    expect(markWorktreePurgedMock).toHaveBeenCalledWith('ws-1', {
+      prNumber: 42,
+      prUrl: 'https://example.test/pr/42',
+      forge: 'github',
+      mergeCommitSha: null,
+      originalWorktreePath: '/tmp/project/.worktrees/ws-1',
+      originalSourceBranch: 'develop',
+      originalWorkingBranch: 'feature/x',
+    })
+    expect(emitEphemeralMock).toHaveBeenCalledWith('ws-1', 'workspace:worktree-purged', expect.anything())
+  })
+
+  it('never marks purged when the directory survived the removal', async () => {
+    getWorkspaceMock.mockReturnValue(makeWorkspace())
+    removeWorktreeMock.mockImplementation(() => {
+      throw new Error("Failed to remove worktree '/tmp/project/.worktrees/ws-1': EACCES: permission denied")
+    })
+
+    const result = await purgeWorktree('ws-1')
+
+    expect(result.outcome).toBe('removal-failed')
+    expect(markWorktreePurgedMock).not.toHaveBeenCalled()
+    expect(emitEphemeralMock).not.toHaveBeenCalledWith('ws-1', 'workspace:worktree-purged', expect.anything())
+    expect(emitEphemeralMock).toHaveBeenCalledWith('ws-1', 'workspace:worktree-purge-failed', expect.anything())
+  })
+
+  it('hands the user a copy-pasteable recovery command on a permission failure', async () => {
+    getWorkspaceMock.mockReturnValue(makeWorkspace())
+    removeWorktreeMock.mockImplementation(() => {
+      throw new Error('EACCES: permission denied')
+    })
+
+    const result = await purgeWorktree('ws-1')
+
+    expect(result.warnings.join('\n')).toContain("sudo rm -rf '/tmp/project/.worktrees/ws-1'")
+    expect(result.warnings.join('\n')).toContain('git worktree prune')
+    expect(result.warnings.join('\n')).toContain('Permission denied')
+  })
+
+  it('still purges when the PR lookup fails — the snapshot is best-effort', async () => {
+    getWorkspaceMock.mockReturnValue(makeWorkspace())
+    existsSyncMock.mockImplementation(() => removeWorktreeMock.mock.calls.length === 0)
+    getPrStatusMock.mockRejectedValue(new Error('gh: not authenticated'))
+
+    const result = await purgeWorktree('ws-1')
+
+    expect(result.outcome).toBe('purged')
+    expect(markWorktreePurgedMock).toHaveBeenCalledWith(
+      'ws-1',
+      expect.objectContaining({ prNumber: null, prUrl: null }),
+    )
+  })
+
+  it('does not re-archive a workspace that is already archived', async () => {
+    getWorkspaceMock.mockReturnValue(makeWorkspace({ archivedAt: '2026-08-01T00:00:00.000Z' }))
+    existsSyncMock.mockImplementation(() => removeWorktreeMock.mock.calls.length === 0)
+
+    await purgeWorktree('ws-1')
+
+    expect(archiveWorkspaceMock).not.toHaveBeenCalled()
+  })
+})

--- a/src/__tests__/worktree-service-docker-cleanup.test.ts
+++ b/src/__tests__/worktree-service-docker-cleanup.test.ts
@@ -16,13 +16,13 @@ beforeEach(() => {
 })
 
 describe('removeWorktree Docker cleanup', () => {
-  it('happy path: git remove succeeds, Docker is never invoked', () => {
+  it('happy path: git remove succeeds, Docker is never invoked', async () => {
     mockExec.mockReturnValue('' as never)
-    removeWorktree(PROJECT, WORKTREE)
+    await removeWorktree(PROJECT, WORKTREE)
     expect(mockExec.mock.calls.filter((c) => c[0] === 'docker')).toHaveLength(0)
   })
 
-  it('recovers from a permission error (French locale message) via Docker chown then prune', () => {
+  it('recovers from a permission error (French locale message) via Docker chown then prune', async () => {
     mockExec.mockImplementation(((file: string, args?: readonly string[]) => {
       if (file === 'docker') return ''
       // The first `git worktree remove` already de-registered the worktree, so the
@@ -34,9 +34,10 @@ describe('removeWorktree Docker cleanup', () => {
       return ''
     }) as unknown as typeof execFileSync)
 
-    expect(() => removeWorktree(PROJECT, WORKTREE)).not.toThrow()
+    await expect(removeWorktree(PROJECT, WORKTREE)).resolves.toBeUndefined()
     // git is invoked under the C locale so its errors are deterministic English.
-    const gitCall = mockExec.mock.calls.find((c) => c[0] === 'git')
+    // (the very first git call is the repository-lock's `rev-parse --git-common-dir`)
+    const gitCall = mockExec.mock.calls.find((c) => c[0] === 'git' && (c[1] as string[])?.includes('remove'))
     expect((gitCall?.[2] as { env?: Record<string, string> })?.env?.LC_ALL).toBe('C')
     // Docker chown reclaimed ownership…
     const dockerRun = mockExec.mock.calls.find((c) => c[0] === 'docker' && (c[1] as string[])?.includes('run'))
@@ -49,32 +50,32 @@ describe('removeWorktree Docker cleanup', () => {
     expect(mockExec.mock.calls.some((c) => c[0] === 'git' && (c[1] as string[])?.includes('prune'))).toBe(true)
   })
 
-  it('rethrows a non-permission error without invoking Docker', () => {
+  it('rethrows a non-permission error without invoking Docker', async () => {
     mockExec.mockImplementation(((file: string, args?: readonly string[]) => {
       if (file === 'git' && args?.includes('remove')) throw new Error('fatal: not a git repository')
       return ''
     }) as unknown as typeof execFileSync)
-    expect(() => removeWorktree(PROJECT, WORKTREE)).toThrow(/not a git repository/)
+    await expect(removeWorktree(PROJECT, WORKTREE)).rejects.toThrow(/not a git repository/)
     expect(mockExec.mock.calls.filter((c) => c[0] === 'docker')).toHaveLength(0)
   })
 
-  it('rethrows the original error when Docker is unavailable', () => {
+  it('rethrows the original error when Docker is unavailable', async () => {
     mockExec.mockImplementation(((file: string, args?: readonly string[]) => {
       if (file === 'docker' && args?.includes('version')) throw new Error('docker: command not found')
       if (file === 'git' && args?.includes('remove')) throw new Error('Permission denied')
       return ''
     }) as unknown as typeof execFileSync)
-    expect(() => removeWorktree(PROJECT, WORKTREE)).toThrow(/Permission denied/)
+    await expect(removeWorktree(PROJECT, WORKTREE)).rejects.toThrow(/Permission denied/)
     expect(mockExec.mock.calls.filter((c) => c[0] === 'docker' && (c[1] as string[])?.includes('run'))).toHaveLength(0)
   })
 
-  it('rethrows when the recovery (prune) still fails', () => {
+  it('rethrows when the recovery (prune) still fails', async () => {
     mockExec.mockImplementation(((file: string, args?: readonly string[]) => {
       if (file === 'docker') return ''
       if (file === 'git' && args?.includes('remove')) throw new Error('Permission denied')
       if (file === 'git' && args?.includes('prune')) throw new Error('prune failed')
       return ''
     }) as unknown as typeof execFileSync)
-    expect(() => removeWorktree(PROJECT, WORKTREE)).toThrow(/prune failed/)
+    await expect(removeWorktree(PROJECT, WORKTREE)).rejects.toThrow(/prune failed/)
   })
 })

--- a/src/__tests__/worktree-service.test.ts
+++ b/src/__tests__/worktree-service.test.ts
@@ -83,7 +83,7 @@ describe('createWorktree(projectPath, branchName, baseRef)', () => {
     expect(content).toContain(`/${relativePath}`)
   })
 
-  it("n'ajoute pas les worktrees absolus hors projet à .git/info/exclude", () => {
+  it("n'ajoute pas les worktrees absolus hors projet à .git/info/exclude", async () => {
     const branchName = 'feature/external-root'
     const externalRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'at-wt-external-'))
     let worktreePath = ''
@@ -99,7 +99,7 @@ describe('createWorktree(projectPath, branchName, baseRef)', () => {
       expect(content).not.toContain(`/${relativePath}`)
     } finally {
       if (worktreePath && fs.existsSync(worktreePath)) {
-        removeWorktree(repoDir, worktreePath)
+        await removeWorktree(repoDir, worktreePath)
       }
       fs.rmSync(externalRoot, { recursive: true, force: true })
     }
@@ -179,19 +179,19 @@ describe('worktreeExists(projectPath, branchName)', () => {
 })
 
 describe('removeWorktree(projectPath, worktreePath)', () => {
-  it('supprime le worktree et son dossier', () => {
+  it('supprime le worktree et son dossier', async () => {
     const branchName = 'feature/remove-test'
     const { worktreePath } = createWorktree(repoDir, branchName, 'origin/main')
     expect(fs.existsSync(worktreePath)).toBe(true)
 
-    removeWorktree(repoDir, worktreePath)
+    await removeWorktree(repoDir, worktreePath)
     expect(fs.existsSync(worktreePath)).toBe(false)
   })
 
-  it("retire l'entrée de .git/info/exclude après suppression", () => {
+  it("retire l'entrée de .git/info/exclude après suppression", async () => {
     const branchName = 'feature/remove-exclude'
     const { worktreePath } = createWorktree(repoDir, branchName, 'origin/main')
-    removeWorktree(repoDir, worktreePath)
+    await removeWorktree(repoDir, worktreePath)
 
     const excludeFile = path.join(repoDir, '.git', 'info', 'exclude')
     if (fs.existsSync(excludeFile)) {
@@ -201,14 +201,52 @@ describe('removeWorktree(projectPath, worktreePath)', () => {
     }
   })
 
-  it("le worktree n'apparaît plus dans listWorktrees après suppression", () => {
+  it("le worktree n'apparaît plus dans listWorktrees après suppression", async () => {
     const branchName = 'feature/remove-list-check'
     const { worktreePath } = createWorktree(repoDir, branchName, 'origin/main')
-    removeWorktree(repoDir, worktreePath)
+    await removeWorktree(repoDir, worktreePath)
 
     const worktrees = listWorktrees(repoDir)
     const found = worktrees.some((wt) => wt.branch === branchName)
     expect(found).toBe(false)
+  })
+
+  it('waits for the shared repository lock before touching the common git dir', async () => {
+    const { withGitRepoLock, _resetGitRepoLocksForTest } = await import('../server/utils/git-repo-lock.js')
+    _resetGitRepoLocksForTest()
+    const { worktreePath } = createWorktree(repoDir, 'feature/remove-under-lock', 'origin/main')
+
+    let release: () => void = () => {}
+    const holder = withGitRepoLock(repoDir, () => new Promise<void>((resolve) => (release = resolve)))
+    await Promise.resolve()
+
+    const pending = removeWorktree(repoDir, worktreePath)
+    for (let i = 0; i < 5; i++) await Promise.resolve()
+    // `git worktree remove` mutates the common git dir, so it must not run
+    // while another repository operation holds the lock.
+    expect(fs.existsSync(worktreePath)).toBe(true)
+
+    release()
+    await holder
+    await pending
+    expect(fs.existsSync(worktreePath)).toBe(false)
+  })
+
+  it('refuses to report success while the directory is still on disk', async () => {
+    const wtPath = path.join(fs.mkdtempSync(path.join(os.tmpdir(), 'at-wt-verify-')), 'wt')
+    createWorktree(repoDir, 'feature/verify-removal', 'origin/main')
+    // Simulate the failure mode: git drops the administrative entry but the
+    // directory survives (root-owned files, a busy mount, an open handle).
+    const realPath = listWorktrees(repoDir).find((w) => w.branch === 'feature/verify-removal')?.path as string
+    gitSetup(repoDir, ['worktree', 'remove', realPath, '--force'])
+    fs.mkdirSync(realPath, { recursive: true })
+    fs.writeFileSync(path.join(realPath, 'leftover.txt'), 'still here\n')
+
+    await expect(removeWorktree(repoDir, realPath)).rejects.toThrow(/still on disk|Failed to remove worktree/)
+    expect(fs.existsSync(realPath)).toBe(true)
+
+    fs.rmSync(realPath, { recursive: true, force: true })
+    fs.rmSync(wtPath, { recursive: true, force: true })
   })
 })
 

--- a/src/__tests__/ws-events-metrics-perf.test.ts
+++ b/src/__tests__/ws-events-metrics-perf.test.ts
@@ -1,0 +1,94 @@
+// The AFTER DELETE trigger on ws_events re-aggregated the whole session for
+// EVERY deleted row: 79.7 s for 20 000 events, 106.6 s through a cascade, with
+// the SQLite write lock held throughout. This test pins the budget.
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import Database from 'better-sqlite3'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { initSchema } from '../server/db/schema.js'
+
+let tmpDir: string
+let db: Database.Database
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'kobo-metrics-perf-'))
+  db = new Database(path.join(tmpDir, 'test.db'))
+  db.pragma('journal_mode=WAL')
+  db.pragma('foreign_keys=ON')
+  initSchema(db)
+})
+
+afterEach(() => {
+  db.close()
+  fs.rmSync(tmpDir, { recursive: true, force: true })
+})
+
+/** Seed one workspace + one session + `count` agent events. */
+function seed(count: number): void {
+  const now = new Date().toISOString()
+  db.prepare(
+    `INSERT INTO workspaces (id, name, project_path, source_branch, working_branch, model, created_at, updated_at)
+     VALUES ('ws-1', 'perf', '/tmp/p', 'main', 'feature/p', 'claude-opus-4-8', ?, ?)`,
+  ).run(now, now)
+  db.prepare(
+    `INSERT INTO agent_sessions (id, workspace_id, status, started_at)
+     VALUES ('session-1', 'ws-1', 'completed', ?)`,
+  ).run(now)
+
+  const insert = db.prepare(
+    'INSERT INTO ws_events (id, workspace_id, type, payload, session_id, created_at) VALUES (?, ?, ?, ?, ?, ?)',
+  )
+  const insertMany = db.transaction((n: number) => {
+    for (let i = 0; i < n; i++) {
+      insert.run(`e${i}`, 'ws-1', 'agent:event', '{"kind":"tool:call"}', 'session-1', now)
+    }
+  })
+  insertMany(count)
+}
+
+describe('ws_events deletion performance', () => {
+  it('deletes a workspace carrying 20 000 events in under a second', () => {
+    seed(20_000)
+    expect(db.prepare('SELECT COUNT(*) AS c FROM ws_events').get()).toEqual({ c: 20_000 })
+
+    const started = performance.now()
+    db.prepare("DELETE FROM workspaces WHERE id = 'ws-1'").run()
+    const elapsedMs = performance.now() - started
+
+    expect(db.prepare('SELECT COUNT(*) AS c FROM ws_events').get()).toEqual({ c: 0 })
+    expect(db.prepare('SELECT COUNT(*) AS c FROM session_event_metrics').get()).toEqual({ c: 0 })
+    expect(elapsedMs).toBeLessThan(1_000)
+  }, 180_000)
+
+  it('leaves no AFTER DELETE trigger on ws_events in a fresh install', () => {
+    const triggers = (
+      db.prepare("SELECT name FROM sqlite_master WHERE type = 'trigger'").all() as Array<{ name: string }>
+    ).map((row) => row.name)
+    expect(triggers).toContain('trg_ws_events_metrics_insert')
+    expect(triggers).not.toContain('trg_ws_events_metrics_delete')
+  })
+
+  it('serves the five hot queries from an index instead of a full scan', () => {
+    const plan = (sql: string, ...params: string[]): string =>
+      (db.prepare(`EXPLAIN QUERY PLAN ${sql}`).all(...params) as Array<{ detail: string }>)
+        .map((row) => row.detail)
+        .join(' | ')
+
+    expect(plan('SELECT * FROM tasks WHERE workspace_id = ? ORDER BY sort_order ASC', 'x')).toContain(
+      'idx_tasks_workspace_sort',
+    )
+    expect(plan('SELECT * FROM agent_sessions WHERE workspace_id = ? ORDER BY started_at DESC LIMIT 1', 'x')).toContain(
+      'idx_agent_sessions_workspace_started',
+    )
+    expect(
+      plan('SELECT id FROM agent_sessions WHERE engine_session_id = ? ORDER BY started_at DESC LIMIT 1', 'x'),
+    ).toContain('idx_agent_sessions_engine_session')
+    expect(plan('SELECT * FROM workspaces WHERE archived_at IS NULL ORDER BY updated_at DESC')).toContain(
+      'idx_workspaces_archived_updated',
+    )
+    expect(plan('SELECT tool_calls FROM session_event_metrics WHERE session_id = ?', 'x')).toContain(
+      'idx_session_event_metrics_session',
+    )
+  })
+})

--- a/src/__tests__/ws-events-retention-service.test.ts
+++ b/src/__tests__/ws-events-retention-service.test.ts
@@ -1,0 +1,140 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import Database from 'better-sqlite3'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { initSchema } from '../server/db/schema.js'
+import {
+  countPrunableWsEvents,
+  pruneWsEvents,
+  resolveRetentionConfig,
+} from '../server/services/ws-events-retention-service.js'
+
+let tmpDir: string
+let db: Database.Database
+
+const NOW_MS = Date.parse('2026-08-29T12:00:00.000Z')
+const daysAgo = (days: number): string => new Date(NOW_MS - days * 24 * 60 * 60 * 1000).toISOString()
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'kobo-retention-'))
+  db = new Database(path.join(tmpDir, 'test.db'))
+  db.pragma('journal_mode=WAL')
+  db.pragma('foreign_keys=ON')
+  initSchema(db)
+  const now = daysAgo(0)
+  db.prepare(
+    `INSERT INTO workspaces (id, name, project_path, source_branch, working_branch, model, created_at, updated_at)
+     VALUES ('ws-1', 'w', '/tmp/w', 'main', 'feature/w', 'claude-opus-4-8', ?, ?)`,
+  ).run(now, now)
+  db.prepare(
+    "INSERT INTO agent_sessions (id, workspace_id, status, started_at) VALUES ('s-1', 'ws-1', 'completed', ?)",
+  ).run(now)
+})
+
+afterEach(() => {
+  db.close()
+  fs.rmSync(tmpDir, { recursive: true, force: true })
+})
+
+/** Insert `count` agent events dated `ageDays` ago, ids prefixed by `prefix`. */
+function seedEvents(prefix: string, count: number, ageDays: number, kind = 'message:text'): void {
+  const insert = db.prepare(
+    'INSERT INTO ws_events (id, workspace_id, type, payload, session_id, created_at) VALUES (?, ?, ?, ?, ?, ?)',
+  )
+  const at = daysAgo(ageDays)
+  const many = db.transaction(() => {
+    for (let i = 0; i < count; i++) {
+      insert.run(`${prefix}-${i}`, 'ws-1', 'agent:event', JSON.stringify({ kind }), 's-1', at)
+    }
+  })
+  many()
+}
+
+describe('resolveRetentionConfig()', () => {
+  it('defaults to DISABLED when the settings say nothing — the feature is opt-in', () => {
+    expect(resolveRetentionConfig({})).toEqual({ retentionDays: 0, keepPerWorkspace: 0 })
+  })
+
+  it('reads an explicitly chosen window as it is', () => {
+    expect(resolveRetentionConfig({ wsEventsRetentionDays: 7, wsEventsKeepPerWorkspace: 10 })).toEqual({
+      retentionDays: 7,
+      keepPerWorkspace: 10,
+    })
+  })
+
+  it('falls back to disabled on an invalid value rather than guessing a window', () => {
+    expect(resolveRetentionConfig({ wsEventsRetentionDays: -5 }).retentionDays).toBe(0)
+    expect(resolveRetentionConfig({ wsEventsRetentionDays: 1.5 }).retentionDays).toBe(0)
+  })
+})
+
+describe('countPrunableWsEvents()', () => {
+  it('counts what a given window would delete, without deleting anything', () => {
+    seedEvents('old', 40, 90)
+    seedEvents('recent', 5, 1)
+
+    expect(countPrunableWsEvents(db, { retentionDays: 30, keepPerWorkspace: 10 }, NOW_MS)).toBe(35)
+    expect((db.prepare('SELECT COUNT(*) AS c FROM ws_events').get() as { c: number }).c).toBe(45)
+  })
+
+  it('counts zero when retention is disabled', () => {
+    seedEvents('old', 40, 900)
+    expect(countPrunableWsEvents(db, { retentionDays: 0, keepPerWorkspace: 0 }, NOW_MS)).toBe(0)
+  })
+})
+
+describe('pruneWsEvents()', () => {
+  it('deletes events older than the window while keeping the recent tail', () => {
+    seedEvents('old', 40, 90)
+    seedEvents('recent', 5, 1)
+
+    const result = pruneWsEvents(db, { retentionDays: 30, keepPerWorkspace: 10 }, NOW_MS)
+
+    // 45 rows, the 10 newest are protected by the tail, so 35 of the 40 old ones go.
+    expect(result.deleted).toBe(35)
+    expect((db.prepare('SELECT COUNT(*) AS c FROM ws_events').get() as { c: number }).c).toBe(10)
+    expect((db.prepare("SELECT COUNT(*) AS c FROM ws_events WHERE id LIKE 'recent-%'").get() as { c: number }).c).toBe(
+      5,
+    )
+  })
+
+  it('does nothing at all with the default, disabled configuration', () => {
+    seedEvents('old', 40, 900)
+    const result = pruneWsEvents(db, resolveRetentionConfig({}), NOW_MS)
+    expect(result).toMatchObject({ deleted: 0, sessionsRecomputed: 0, vacuumed: false })
+    expect((db.prepare('SELECT COUNT(*) AS c FROM ws_events').get() as { c: number }).c).toBe(40)
+  })
+
+  it('never touches workspaces, sessions or tasks', () => {
+    seedEvents('old', 40, 90)
+    pruneWsEvents(db, { retentionDays: 30, keepPerWorkspace: 0 }, NOW_MS)
+    expect((db.prepare('SELECT COUNT(*) AS c FROM workspaces').get() as { c: number }).c).toBe(1)
+    expect((db.prepare('SELECT COUNT(*) AS c FROM agent_sessions').get() as { c: number }).c).toBe(1)
+  })
+
+  it('recomputes the metrics of every session it touched, once', () => {
+    seedEvents('old', 6, 90, 'tool:call')
+    seedEvents('recent', 2, 1, 'tool:call')
+    expect(
+      (db.prepare('SELECT tool_calls FROM session_event_metrics').get() as { tool_calls: number }).tool_calls,
+    ).toBe(8)
+
+    const result = pruneWsEvents(db, { retentionDays: 30, keepPerWorkspace: 2 }, NOW_MS)
+
+    expect(result.deleted).toBe(6)
+    expect(result.sessionsRecomputed).toBe(1)
+    expect(
+      (db.prepare('SELECT tool_calls FROM session_event_metrics').get() as { tool_calls: number }).tool_calls,
+    ).toBe(2)
+  })
+
+  it('reclaims free pages instead of leaving a 95 %-empty file behind', () => {
+    seedEvents('old', 6_000, 90)
+    pruneWsEvents(db, { retentionDays: 30, keepPerWorkspace: 0 }, NOW_MS)
+
+    const freelist = db.pragma('freelist_count', { simple: true }) as number
+    const pageCount = db.pragma('page_count', { simple: true }) as number
+    expect(freelist / pageCount).toBeLessThan(0.25)
+  })
+})

--- a/src/client/src/i18n/de.ts
+++ b/src/client/src/i18n/de.ts
@@ -1278,6 +1278,23 @@ export default {
   'settings.autoLoopMaxRetries': 'Maximale automatische Wiederholungen',
   'settings.autoLoopMaxRetriesHint':
     'Stoppt die Auto-Loop nach dieser Anzahl von Quota- oder vorübergehenden Serverfehlern.',
+  'settings.retentionTitle': 'Aufbewahrung des Konversationsverlaufs (standardmäßig aus)',
+  'settings.retentionWarning':
+    'Wird diese Option aktiviert, löscht sie den Konversationsverlauf der Agenten endgültig aus der Datenbank — zuerst alles, was bereits älter als das Zeitfenster ist. Gelöschte Ereignisse lassen sich nicht wiederherstellen.',
+  'settings.retentionHint':
+    'Läuft einmal beim Start des Servers. Workspaces, Aufgaben, Sessions, Branches und Worktrees bleiben unberührt — betroffen ist nur die aufgezeichnete Agentenausgabe.',
+  'settings.retentionDaysLabel': 'Ereignisse löschen, die älter sind als (Tage)',
+  'settings.retentionDaysHint':
+    '0 — der Standard — behält alle Ereignisse dauerhaft. Tragen Sie einen Wert ein, um die Aufbewahrung zu aktivieren.',
+  'settings.retentionKeepLabel': 'Immer behaltene Ereignisse pro Workspace',
+  'settings.retentionKeepHint':
+    'Die neuesten Ereignisse jedes Workspace bleiben unabhängig von ihrem Alter erhalten, damit ein alter, aber noch offener Workspace einen lesbaren Verlauf behält. Empfohlen: 5000.',
+  'settings.retentionDisabledHint': 'Aufbewahrung deaktiviert: Es wird nie etwas gelöscht.',
+  'settings.retentionConfirmTitle': 'Konversationsverlauf endgültig löschen?',
+  'settings.retentionConfirmMessage':
+    'Nur {days} Tag(e) Verlauf zu behalten löscht beim nächsten Serverstart endgültig {count} der {total} aufgezeichneten Agentenereignisse — einschließlich allem, was bereits älter ist. Das lässt sich nicht rückgängig machen. Fortfahren?',
+  'settings.retentionConfirmMessageUnknown':
+    'Nur {days} Tag(e) Verlauf zu behalten löscht beim nächsten Serverstart endgültig alle älteren Agentenereignisse — einschließlich allem, was bereits angesammelt wurde. Die genaue Menge konnte nicht ermittelt werden. Das lässt sich nicht rückgängig machen. Fortfahren?',
   'settings.purgeDocsTitle': 'Wie Purge funktioniert — Wiederherstellung & Berechtigungen',
   'settings.purgeDocsRestoreTitle': 'Einen bereinigten Worktree wiederherstellen (automatisch erkannt)',
   'settings.purgeDocsRestoreIntro':

--- a/src/client/src/i18n/en.ts
+++ b/src/client/src/i18n/en.ts
@@ -1261,6 +1261,22 @@ export default {
     'When ON, the worktree is deleted from disk as soon as the PR is merged (in addition to the auto-archive). Chat history is kept.',
   'settings.autoLoopMaxRetries': 'Maximum automatic retries',
   'settings.autoLoopMaxRetriesHint': 'Stops the auto-loop after this many quota or temporary server failures.',
+  'settings.retentionTitle': 'Conversation history retention (off by default)',
+  'settings.retentionWarning':
+    'Turning this on permanently deletes agent conversation history from the database, starting with everything already older than the window. Deleted events cannot be recovered.',
+  'settings.retentionHint':
+    'Runs once at server start-up. Workspaces, tasks, sessions, branches and worktrees are never touched — only the recorded agent output.',
+  'settings.retentionDaysLabel': 'Delete events older than (days)',
+  'settings.retentionDaysHint': '0 — the default — keeps every event for ever. Set a value to enable retention.',
+  'settings.retentionKeepLabel': 'Events always kept per workspace',
+  'settings.retentionKeepHint':
+    'The most recent events of each workspace survive whatever their age, so an old but still-open workspace keeps a readable history. Suggested: 5000.',
+  'settings.retentionDisabledHint': 'Retention is disabled: nothing will ever be deleted.',
+  'settings.retentionConfirmTitle': 'Permanently delete conversation history?',
+  'settings.retentionConfirmMessage':
+    'Keeping only {days} day(s) of history will permanently delete {count} of the {total} recorded agent events at the next server start-up, including everything already older than that. This cannot be undone. Continue?',
+  'settings.retentionConfirmMessageUnknown':
+    'Keeping only {days} day(s) of history will permanently delete every older agent event at the next server start-up, including everything already accumulated. The exact volume could not be counted. This cannot be undone. Continue?',
   'settings.purgeDocsTitle': 'How purge works — restore & permissions',
   'settings.purgeDocsRestoreTitle': 'Restoring a purged worktree (auto-detected)',
   'settings.purgeDocsRestoreIntro':

--- a/src/client/src/i18n/es.ts
+++ b/src/client/src/i18n/es.ts
@@ -1275,6 +1275,23 @@ export default {
   'settings.autoLoopMaxRetries': 'Máximo de reintentos automáticos',
   'settings.autoLoopMaxRetriesHint':
     'Detiene el bucle automático tras este número de errores de cuota o de servidor temporales.',
+  'settings.retentionTitle': 'Retención del historial de conversación (desactivada por defecto)',
+  'settings.retentionWarning':
+    'Activar esta opción elimina definitivamente de la base de datos el historial de conversación de los agentes, empezando por todo lo que ya sea más antiguo que la ventana. Los eventos eliminados no se pueden recuperar.',
+  'settings.retentionHint':
+    'Se ejecuta una vez al arrancar el servidor. Los workspaces, tareas, sesiones, branches y worktrees nunca se tocan — solo la salida registrada de los agentes.',
+  'settings.retentionDaysLabel': 'Eliminar eventos más antiguos de (días)',
+  'settings.retentionDaysHint':
+    '0 — el valor por defecto — conserva todos los eventos indefinidamente. Indica un valor para activar la retención.',
+  'settings.retentionKeepLabel': 'Eventos siempre conservados por workspace',
+  'settings.retentionKeepHint':
+    'Los eventos más recientes de cada workspace sobreviven sea cual sea su antigüedad, para que un workspace antiguo pero aún abierto conserve un historial legible. Sugerido: 5000.',
+  'settings.retentionDisabledHint': 'Retención desactivada: nunca se eliminará nada.',
+  'settings.retentionConfirmTitle': '¿Eliminar definitivamente el historial de conversación?',
+  'settings.retentionConfirmMessage':
+    'Conservar solo {days} día(s) de historial eliminará definitivamente, en el próximo arranque del servidor, {count} de los {total} eventos de agente registrados — incluido todo lo que ya sea más antiguo. Es irreversible. ¿Continuar?',
+  'settings.retentionConfirmMessageUnknown':
+    'Conservar solo {days} día(s) de historial eliminará definitivamente, en el próximo arranque del servidor, todos los eventos de agente más antiguos — incluido todo lo ya acumulado. No se ha podido calcular el volumen exacto. Es irreversible. ¿Continuar?',
   'settings.purgeDocsTitle': 'Cómo funciona el borrado — restauración y permisos',
   'settings.purgeDocsRestoreTitle': 'Restaurar un worktree borrado (detección automática)',
   'settings.purgeDocsRestoreIntro':

--- a/src/client/src/i18n/fr.ts
+++ b/src/client/src/i18n/fr.ts
@@ -1277,6 +1277,23 @@ export default {
   'settings.autoLoopMaxRetries': 'Nombre maximal de nouvelles tentatives',
   'settings.autoLoopMaxRetriesHint':
     "Arrête l'auto-loop après ce nombre d'erreurs de quota ou d'erreurs serveur temporaires.",
+  'settings.retentionTitle': "Rétention de l'historique de conversation (désactivée par défaut)",
+  'settings.retentionWarning':
+    "Activer cette option supprime définitivement de la base l'historique de conversation des agents, à commencer par tout ce qui est déjà plus vieux que la fenêtre. Les événements supprimés sont irrécupérables.",
+  'settings.retentionHint':
+    "Exécutée une fois au démarrage du serveur. Les workspaces, tâches, sessions, branches et worktrees ne sont jamais touchés — seule la sortie enregistrée des agents l'est.",
+  'settings.retentionDaysLabel': 'Supprimer les événements plus vieux que (jours)',
+  'settings.retentionDaysHint':
+    '0 — la valeur par défaut — conserve tous les événements indéfiniment. Renseignez une valeur pour activer la rétention.',
+  'settings.retentionKeepLabel': 'Événements toujours conservés par workspace',
+  'settings.retentionKeepHint':
+    "Les événements les plus récents de chaque workspace survivent quel que soit leur âge, pour qu'un workspace ancien mais toujours ouvert garde un historique lisible. Suggéré : 5000.",
+  'settings.retentionDisabledHint': 'Rétention désactivée : rien ne sera jamais supprimé.',
+  'settings.retentionConfirmTitle': "Supprimer définitivement de l'historique de conversation ?",
+  'settings.retentionConfirmMessage':
+    "Ne conserver que {days} jour(s) d'historique supprimera définitivement, au prochain démarrage du serveur, {count} des {total} événements d'agent enregistrés — y compris tout ce qui est déjà plus ancien. C'est irréversible. Continuer ?",
+  'settings.retentionConfirmMessageUnknown':
+    "Ne conserver que {days} jour(s) d'historique supprimera définitivement, au prochain démarrage du serveur, tous les événements d'agent plus anciens — y compris tout ce qui est déjà accumulé. Le volume exact n'a pas pu être calculé. C'est irréversible. Continuer ?",
   'settings.purgeDocsTitle': 'Comment ça marche — restauration & permissions',
   'settings.purgeDocsRestoreTitle': 'Restaurer un worktree purgé (détection automatique)',
   'settings.purgeDocsRestoreIntro':

--- a/src/client/src/i18n/it.ts
+++ b/src/client/src/i18n/it.ts
@@ -1274,6 +1274,23 @@ export default {
   'settings.autoLoopMaxRetries': 'Numero massimo di tentativi automatici',
   'settings.autoLoopMaxRetriesHint':
     'Interrompe l’auto-loop dopo questo numero di errori di quota o server temporanei.',
+  'settings.retentionTitle': 'Conservazione della cronologia delle conversazioni (disattivata di default)',
+  'settings.retentionWarning':
+    'Attivare questa opzione elimina definitivamente dal database la cronologia delle conversazioni degli agenti, a partire da tutto ciò che è già più vecchio della finestra. Gli eventi eliminati non sono recuperabili.',
+  'settings.retentionHint':
+    "Viene eseguita una volta all'avvio del server. Workspace, attività, sessioni, branch e worktree non vengono mai toccati — solo l'output registrato degli agenti.",
+  'settings.retentionDaysLabel': 'Elimina gli eventi più vecchi di (giorni)',
+  'settings.retentionDaysHint':
+    '0 — il valore predefinito — conserva tutti gli eventi per sempre. Indica un valore per attivare la conservazione.',
+  'settings.retentionKeepLabel': 'Eventi sempre conservati per workspace',
+  'settings.retentionKeepHint':
+    'Gli eventi più recenti di ogni workspace sopravvivono a prescindere dalla loro età, così un workspace vecchio ma ancora aperto mantiene una cronologia leggibile. Consigliato: 5000.',
+  'settings.retentionDisabledHint': 'Conservazione disattivata: non verrà mai eliminato nulla.',
+  'settings.retentionConfirmTitle': 'Eliminare definitivamente la cronologia delle conversazioni?',
+  'settings.retentionConfirmMessage':
+    "Conservare solo {days} giorno/i di cronologia eliminerà definitivamente, al prossimo avvio del server, {count} dei {total} eventi degli agenti registrati — compreso tutto ciò che è già più vecchio. L'operazione è irreversibile. Continuare?",
+  'settings.retentionConfirmMessageUnknown':
+    "Conservare solo {days} giorno/i di cronologia eliminerà definitivamente, al prossimo avvio del server, tutti gli eventi degli agenti più vecchi — compreso tutto ciò che è già accumulato. Non è stato possibile calcolare il volume esatto. L'operazione è irreversibile. Continuare?",
   'settings.purgeDocsTitle': 'Come funziona la pulizia — ripristino e permessi',
   'settings.purgeDocsRestoreTitle': 'Ripristinare un worktree eliminato (rilevamento automatico)',
   'settings.purgeDocsRestoreIntro':

--- a/src/client/src/pages/SettingsPage.vue
+++ b/src/client/src/pages/SettingsPage.vue
@@ -1589,6 +1589,41 @@ where ffmpeg</pre>
                 class="settings-input q-mt-md"
               />
 
+              <q-separator dark class="q-my-md" />
+
+              <div data-tour="settings-card-worktrees-retention">
+                <div class="text-subtitle2 q-mb-sm">{{ $t('settings.retentionTitle') }}</div>
+                <div class="text-caption text-negative q-mb-sm">{{ $t('settings.retentionWarning') }}</div>
+                <div class="text-caption text-grey-7 q-mb-sm">{{ $t('settings.retentionHint') }}</div>
+                <q-input
+                  v-model.number="globalWsEventsRetentionDays"
+                  :label="$t('settings.retentionDaysLabel')"
+                  :hint="$t('settings.retentionDaysHint')"
+                  type="number"
+                  min="0"
+                  max="3650"
+                  dense
+                  dark
+                  outlined
+                  class="settings-input"
+                />
+                <q-input
+                  v-model.number="globalWsEventsKeepPerWorkspace"
+                  :label="$t('settings.retentionKeepLabel')"
+                  :hint="$t('settings.retentionKeepHint')"
+                  type="number"
+                  min="0"
+                  max="1000000"
+                  dense
+                  dark
+                  outlined
+                  class="settings-input q-mt-md"
+                />
+                <div v-if="globalWsEventsRetentionDays === 0" class="text-caption text-grey-6 q-mt-sm">
+                  {{ $t('settings.retentionDisabledHint') }}
+                </div>
+              </div>
+
               <q-expansion-item
                 dense
                 dark
@@ -2608,6 +2643,8 @@ const globalFileManagerCommand = ref('')
 const globalTerminalCommand = ref('')
 const globalAutoPurgeOnPrMerged = ref(false)
 const globalAutoLoopMaxRetries = ref(5)
+const globalWsEventsRetentionDays = ref(0)
+const globalWsEventsKeepPerWorkspace = ref(0)
 
 // Network access
 interface NetworkState {
@@ -3497,6 +3534,8 @@ function captureGlobalSnapshot(): string {
     terminalCommand: globalTerminalCommand.value,
     autoPurgeOnPrMerged: globalAutoPurgeOnPrMerged.value,
     autoLoopMaxRetries: globalAutoLoopMaxRetries.value,
+    wsEventsRetentionDays: globalWsEventsRetentionDays.value,
+    wsEventsKeepPerWorkspace: globalWsEventsKeepPerWorkspace.value,
     browserNotifications: globalBrowserNotifications.value,
     audioNotifications: globalAudioNotifications.value,
     audioQuestionNotifications: globalAudioQuestionNotifications.value,
@@ -3603,6 +3642,8 @@ function syncGlobalForm() {
   globalTerminalCommand.value = store.global.terminalCommand ?? ''
   globalAutoPurgeOnPrMerged.value = store.global.autoPurgeOnPrMerged ?? false
   globalAutoLoopMaxRetries.value = store.global.autoLoopMaxRetries ?? 5
+  globalWsEventsRetentionDays.value = store.global.wsEventsRetentionDays ?? 0
+  globalWsEventsKeepPerWorkspace.value = store.global.wsEventsKeepPerWorkspace ?? 0
   globalBrowserNotifications.value = store.global.browserNotifications ?? true
   globalAudioNotifications.value = store.global.audioNotifications ?? true
   globalAudioQuestionNotifications.value = store.global.audioQuestionNotifications ?? false
@@ -3895,9 +3936,55 @@ async function resetFieldToDefault(field: ResettableField) {
   }
 }
 
+/**
+ * Ask before NARROWING the retention window — which includes enabling it.
+ *
+ * `0` means "keep everything", so in this comparison it is +∞: going from 0 to
+ * 30 shrinks the window from infinity to a month and is the single most
+ * destructive move of the feature (a year-old database loses eleven months at
+ * the next start-up). Going the other way — 30 → 0, or 7 → 30 — destroys
+ * nothing and needs no confirmation.
+ *
+ * The dialog states the real volume, from a preview that counts without
+ * deleting. If that count fails we still ask, with a wording that carries no
+ * number: a failed preview must never remove the safeguard.
+ */
+async function confirmRetentionReduction(): Promise<boolean> {
+  const asWindow = (days: number): number => (days === 0 ? Number.POSITIVE_INFINITY : days)
+  const previous = store.global.wsEventsRetentionDays ?? 0
+  const next = globalWsEventsRetentionDays.value
+  if (asWindow(next) >= asWindow(previous)) return true
+
+  let message = t('settings.retentionConfirmMessageUnknown', { days: next })
+  try {
+    const preview = await store.previewRetention(next, globalWsEventsKeepPerWorkspace.value)
+    message = t('settings.retentionConfirmMessage', {
+      days: next,
+      count: preview.deletable,
+      total: preview.total,
+    })
+  } catch (err) {
+    console.error('[SettingsPage] retention preview failed:', err)
+  }
+
+  return await new Promise<boolean>((resolve) => {
+    $q.dialog({
+      title: t('settings.retentionConfirmTitle'),
+      message,
+      cancel: true,
+      persistent: true,
+      dark: true,
+    })
+      .onOk(() => resolve(true))
+      .onCancel(() => resolve(false))
+      .onDismiss(() => resolve(false))
+  })
+}
+
 async function saveGlobal() {
   const worktreesPathValid = await globalWorktreesPathInput.value?.validate()
   if (worktreesPathValid === false) return
+  if (!(await confirmRetentionReduction())) return
 
   savingGlobal.value = true
   try {
@@ -3916,6 +4003,8 @@ async function saveGlobal() {
       terminalCommand: globalTerminalCommand.value,
       autoPurgeOnPrMerged: globalAutoPurgeOnPrMerged.value,
       autoLoopMaxRetries: globalAutoLoopMaxRetries.value,
+      wsEventsRetentionDays: globalWsEventsRetentionDays.value,
+      wsEventsKeepPerWorkspace: globalWsEventsKeepPerWorkspace.value,
       browserNotifications: globalBrowserNotifications.value,
       audioNotifications: globalAudioNotifications.value,
       audioQuestionNotifications: globalAudioQuestionNotifications.value,

--- a/src/client/src/stores/settings.ts
+++ b/src/client/src/stores/settings.ts
@@ -98,6 +98,8 @@ interface GlobalSettings {
   /** Opt-in: pr-watcher auto-purges the worktree on PR-merged transition. */
   autoPurgeOnPrMerged: boolean
   autoLoopMaxRetries: number
+  wsEventsRetentionDays: number
+  wsEventsKeepPerWorkspace: number
   browserNotifications: boolean
   audioNotifications: boolean
   audioQuestionNotifications: boolean
@@ -233,6 +235,8 @@ export const useSettingsStore = defineStore('settings', {
       terminalCommand: '',
       autoPurgeOnPrMerged: false,
       autoLoopMaxRetries: 5,
+      wsEventsRetentionDays: 0,
+      wsEventsKeepPerWorkspace: 0,
       browserNotifications: true,
       audioNotifications: true,
       audioQuestionNotifications: false,
@@ -360,6 +364,10 @@ export const useSettingsStore = defineStore('settings', {
       changeSourceBranchScript: string
     }> {
       return apiFetch('/api/settings/defaults')
+    },
+
+    async previewRetention(days: number, keep: number): Promise<{ deletable: number; total: number }> {
+      return apiFetch(`/api/settings/ws-events-retention-preview?days=${days}&keep=${keep}`)
     },
 
     async updateGlobal(data: Partial<GlobalSettings>) {

--- a/src/server/db/migrations.ts
+++ b/src/server/db/migrations.ts
@@ -621,6 +621,69 @@ export const migrations: Migration[] = [
       }
     },
   },
+  {
+    version: 36,
+    name: 'drop-metrics-delete-trigger-add-hot-indexes',
+    migrate: (db) => {
+      // The AFTER DELETE trigger installed by v34 re-aggregated the entire
+      // session for EVERY deleted row. Measured on an identical schema: 79.7 s
+      // for 20 000 events, 106.6 s through a cascade, with the SQLite write
+      // lock held for the whole duration — during which every WebSocket emit
+      // gives up after busy_timeout and loses the event for good.
+      // Metrics are now recomputed once, application-side, at the end of the
+      // transactions that delete events while keeping the session
+      // (recomputeSessionMetrics in workspace-service.ts).
+      db.exec('DROP TRIGGER IF EXISTS trg_ws_events_metrics_delete')
+
+      const tables = new Set(
+        (db.prepare("SELECT name FROM sqlite_master WHERE type = 'table'").all() as Array<{ name: string }>).map(
+          (row) => row.name,
+        ),
+      )
+      const hasColumns = (table: string, needed: readonly string[]): boolean => {
+        if (!tables.has(table)) return false
+        const columns = new Set(
+          (db.prepare(`PRAGMA table_info(${table})`).all() as Array<{ name: string }>).map((column) => column.name),
+        )
+        return needed.every((column) => columns.has(column))
+      }
+
+      // Five hot paths measured as full table scans before this migration.
+      const indexes: ReadonlyArray<{ table: string; columns: readonly string[]; sql: string }> = [
+        {
+          table: 'tasks',
+          columns: ['workspace_id', 'sort_order'],
+          sql: 'CREATE INDEX IF NOT EXISTS idx_tasks_workspace_sort ON tasks(workspace_id, sort_order)',
+        },
+        {
+          table: 'agent_sessions',
+          columns: ['workspace_id', 'started_at'],
+          sql: 'CREATE INDEX IF NOT EXISTS idx_agent_sessions_workspace_started ON agent_sessions(workspace_id, started_at DESC)',
+        },
+        {
+          table: 'agent_sessions',
+          columns: ['engine_session_id'],
+          sql: 'CREATE INDEX IF NOT EXISTS idx_agent_sessions_engine_session ON agent_sessions(engine_session_id)',
+        },
+        {
+          table: 'workspaces',
+          columns: ['archived_at', 'updated_at'],
+          sql: 'CREATE INDEX IF NOT EXISTS idx_workspaces_archived_updated ON workspaces(archived_at, updated_at DESC)',
+        },
+        {
+          table: 'session_event_metrics',
+          columns: ['session_id'],
+          sql: 'CREATE INDEX IF NOT EXISTS idx_session_event_metrics_session ON session_event_metrics(session_id)',
+        },
+      ]
+      // Column guards, not just table guards: several shipped migration tests
+      // build a stripped-down table (e.g. `workspaces(id, engine)`) and replay
+      // every later migration on top of it.
+      for (const index of indexes) {
+        if (hasColumns(index.table, index.columns)) db.exec(index.sql)
+      }
+    },
+  },
 ]
 
 /** Current schema version — always equals the highest migration version. */

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -127,45 +127,6 @@ export function initSchema(db: Database.Database): void {
         output_tokens = MAX(output_tokens, excluded.output_tokens);
     END;
 
-    CREATE TRIGGER IF NOT EXISTS trg_ws_events_metrics_delete
-    AFTER DELETE ON ws_events
-    WHEN OLD.type = 'agent:event' AND OLD.session_id IS NOT NULL
-    BEGIN
-      DELETE FROM session_event_metrics
-      WHERE workspace_id = OLD.workspace_id AND session_id = OLD.session_id;
-
-      INSERT INTO session_event_metrics (
-        workspace_id, session_id, tool_calls, errors, input_tokens, output_tokens
-      )
-      SELECT
-        e.workspace_id,
-        e.session_id,
-        SUM(CASE WHEN json_extract(e.payload, '$.kind') = 'tool:call' THEN 1 ELSE 0 END),
-        SUM(CASE
-          WHEN json_extract(e.payload, '$.kind') = 'error'
-            OR (json_extract(e.payload, '$.kind') = 'tool:result'
-              AND json_extract(e.payload, '$.isError') = 1)
-          THEN 1 ELSE 0
-        END),
-        MAX(CASE
-          WHEN json_extract(e.payload, '$.kind') = 'usage'
-            AND json_type(e.payload, '$.inputTokens') IN ('integer', 'real')
-          THEN CAST(json_extract(e.payload, '$.inputTokens') AS INTEGER) ELSE 0
-        END),
-        MAX(CASE
-          WHEN json_extract(e.payload, '$.kind') = 'usage'
-            AND json_type(e.payload, '$.outputTokens') IN ('integer', 'real')
-          THEN CAST(json_extract(e.payload, '$.outputTokens') AS INTEGER) ELSE 0
-        END)
-      FROM ws_events e
-      JOIN agent_sessions s ON s.id = e.session_id AND s.workspace_id = e.workspace_id
-      WHERE e.workspace_id = OLD.workspace_id
-        AND e.session_id = OLD.session_id
-        AND e.type = 'agent:event'
-        AND json_valid(e.payload)
-      GROUP BY e.workspace_id, e.session_id;
-    END;
-
     CREATE TABLE IF NOT EXISTS workspace_permission_rules (
       id TEXT PRIMARY KEY,
       workspace_id TEXT NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
@@ -238,5 +199,15 @@ export function initSchema(db: Database.Database): void {
       ON ws_events(type, created_at DESC, id DESC);
     CREATE INDEX IF NOT EXISTS idx_workspace_chat_history_workspace_id_id
       ON workspace_chat_history(workspace_id, id DESC);
+    CREATE INDEX IF NOT EXISTS idx_tasks_workspace_sort
+      ON tasks(workspace_id, sort_order);
+    CREATE INDEX IF NOT EXISTS idx_agent_sessions_workspace_started
+      ON agent_sessions(workspace_id, started_at DESC);
+    CREATE INDEX IF NOT EXISTS idx_agent_sessions_engine_session
+      ON agent_sessions(engine_session_id);
+    CREATE INDEX IF NOT EXISTS idx_workspaces_archived_updated
+      ON workspaces(archived_at, updated_at DESC);
+    CREATE INDEX IF NOT EXISTS idx_session_event_metrics_session
+      ON session_event_metrics(session_id);
   `)
 }

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -59,6 +59,7 @@ import { startUsagePoller, stopUsagePoller } from './services/usage/index.js'
 import * as wakeupService from './services/wakeup-service.js'
 import { emit, emitEphemeral, handleConnection, setMessageHandler } from './services/websocket-service.js'
 import { getActiveSession, getWorkspace, updateWorkspaceStatus } from './services/workspace-service.js'
+import { pruneWsEvents, resolveRetentionConfig } from './services/ws-events-retention-service.js'
 import { getClientSpaPath, getDbPath, getKoboHome, getPackageVersion } from './utils/paths.js'
 
 console.log(`[kobo] Kōbō home: ${getKoboHome()}`)
@@ -74,12 +75,39 @@ try {
   if (pending.length > 0) {
     const result = await createPreMigrationBackup(db, getDbPath(), `v${pending[pending.length - 1]}`)
     console.log(`[kobo] Pre-migration backup before applying ${pending.length} migration(s): ${result.created}`)
+    if (result.deleted.length > 0) {
+      console.log(`[kobo] Rotated ${result.deleted.length} old pre-migration backup(s)`)
+    }
   }
 } catch (err) {
   console.error('[kobo] Pre-migration backup failed (continuing — daily backup remains as fallback):', err)
 }
 
 runMigrations(db)
+
+// Event retention. OPT-IN: disabled by default, so this is a no-op until the
+// user sets a window in Settings → Worktrees. When enabled it runs at boot
+// only: no session is alive yet, so the batched write lock disturbs nobody, and
+// the daily backup that follows snapshots an already-compacted file.
+// Best-effort — a failure must never block boot.
+try {
+  const retentionConfig = resolveRetentionConfig(getGlobalSettings())
+  if (retentionConfig.retentionDays > 0) {
+    const retentionStartedAt = Date.now()
+    const retention = pruneWsEvents(db, retentionConfig)
+    if (retention.deleted > 0 || retention.vacuumed) {
+      console.log(
+        `[kobo] Event retention (${retentionConfig.retentionDays} d, keeping ${retentionConfig.keepPerWorkspace}/workspace): ` +
+          `${retention.deleted} agent event(s) permanently deleted, ` +
+          `${retention.sessionsRecomputed} session metric(s) recomputed, ` +
+          `${retention.vacuumed ? `VACUUM reclaimed ${retention.freePagesBefore - retention.freePagesAfter} page(s), ` : ''}` +
+          `${Date.now() - retentionStartedAt} ms`,
+      )
+    }
+  }
+} catch (err) {
+  console.error('[kobo] Event retention failed (continuing):', err)
+}
 
 // Daily DB backup (best-effort, fire-and-forget — never blocks boot).
 // Creates a WAL-safe snapshot alongside kobo.db if no backup exists in the

--- a/src/server/routes/settings.ts
+++ b/src/server/routes/settings.ts
@@ -1,4 +1,5 @@
 import { Hono } from 'hono'
+import { getDb } from '../db/index.js'
 import { getBackendPort } from '../services/agent/orchestrator.js'
 import {
   DEFAULT_NOTION_INITIAL_PROMPT,
@@ -18,6 +19,7 @@ import {
   type ProjectSettings,
 } from '../services/settings-service.js'
 import { listTemplates, replaceAllTemplates } from '../services/templates-service.js'
+import { countPrunableWsEvents } from '../services/ws-events-retention-service.js'
 
 /** Hono sub-router for global and per-project settings CRUD. */
 const app = new Hono()
@@ -59,6 +61,28 @@ app.get('/defaults', (c) => {
     sentryInitialPromptTemplate: DEFAULT_SENTRY_INITIAL_PROMPT,
     changeSourceBranchScript: DEFAULT_CHANGE_SOURCE_BRANCH_SCRIPT,
   })
+})
+
+// GET /api/settings/ws-events-retention-preview?days=<n>&keep=<n>
+// Count what a retention window WOULD delete, without deleting anything. Backs
+// the confirmation dialog: enabling retention on a year-old database destroys
+// months of conversation in one go, and the user is entitled to the number
+// before agreeing to it.
+app.get('/ws-events-retention-preview', (c) => {
+  try {
+    const days = Number.parseInt(c.req.query('days') ?? '', 10)
+    const keep = Number.parseInt(c.req.query('keep') ?? '', 10)
+    if (!Number.isInteger(days) || days < 0 || !Number.isInteger(keep) || keep < 0) {
+      return c.json({ error: 'days and keep must be non-negative integers' }, 400)
+    }
+    const db = getDb()
+    const total = (db.prepare('SELECT COUNT(*) AS c FROM ws_events').get() as { c: number }).c
+    const deletable = countPrunableWsEvents(db, { retentionDays: days, keepPerWorkspace: keep })
+    return c.json({ deletable, total })
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    return c.json({ error: message }, 500)
+  }
 })
 
 // GET /api/settings/network — network access state + LAN URLs

--- a/src/server/routes/workspaces.ts
+++ b/src/server/routes/workspaces.ts
@@ -1903,7 +1903,15 @@ app.delete('/:id/events/:eventId', (c) => {
       return c.json({ error: `Workspace '${workspaceId}' not found` }, 404)
     }
     const db = getDb()
+    // Capture the session BEFORE deleting: since v36 there is no AFTER DELETE
+    // trigger, so the metrics of that session must be recomputed once, here.
+    const row = db
+      .prepare('SELECT session_id FROM ws_events WHERE id = ? AND workspace_id = ?')
+      .get(eventId, workspaceId) as { session_id: string | null } | undefined
     db.prepare('DELETE FROM ws_events WHERE id = ? AND workspace_id = ?').run(eventId, workspaceId)
+    if (row?.session_id) {
+      workspaceService.recomputeSessionMetrics(workspaceId, row.session_id)
+    }
     return c.json({ ok: true })
   } catch (err) {
     const message = err instanceof Error ? err.message : 'unknown'
@@ -3008,7 +3016,7 @@ async function deleteWorkspaceWithSideEffects(
     console.log(`[workspaces] skipping worktree removal on delete (already purged): ${worktreePath}`)
   } else if (workspace.worktreeOwned) {
     try {
-      worktreeService.removeWorktree(workspace.projectPath, worktreePath)
+      await worktreeService.removeWorktree(workspace.projectPath, worktreePath)
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err)
       console.error(`[workspaces] Failed to remove worktree: ${message}`)
@@ -3515,8 +3523,14 @@ app.post('/:id/rename-branch', async (c) => {
     if (!newName) {
       return c.json({ error: 'newName is required' }, 400)
     }
-    if (!/^[A-Za-z0-9/_\-.]+$/.test(newName)) {
-      return c.json({ error: 'Invalid branch name (only letters, digits, /, _, -, . allowed)' }, 400)
+    if (!gitOps.isValidBranchName(newName)) {
+      return c.json(
+        {
+          error:
+            'Invalid branch name. It must start with a letter or a digit and may then contain letters, digits, /, _, - and . — no leading dash, no "..", no trailing "/", "." or ".lock".',
+        },
+        400,
+      )
     }
     const workspace = workspaceService.getWorkspace(id)
     if (!workspace) {
@@ -4133,7 +4147,16 @@ app.post('/:id/cancel-source-change', async (c) => {
     const workspace = workspaceService.getWorkspace(id)
     if (!workspace) return c.json({ error: `Workspace '${id}' not found` }, 404)
 
-    const backups = gitOps.listBackupBranches(workspace.worktreePath, workspace.workingBranch)
+    // "No backup exists" and "I could not find out" are different answers.
+    // Conflating them told the user restoration was impossible while the
+    // backup branch was on disk, closing the only rollback path there is.
+    let backups: string[]
+    try {
+      backups = gitOps.listBackupBranches(workspace.worktreePath, workspace.workingBranch)
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      return c.json({ error: `Cannot list backup branches: ${message}`, code: 'backup_list_failed' }, 500)
+    }
     if (backups.length === 0) {
       return c.json({ error: 'No backup branch found — cannot auto-restore', code: 'no_backup' }, 409)
     }

--- a/src/server/services/change-source-branch-service.ts
+++ b/src/server/services/change-source-branch-service.ts
@@ -3,6 +3,7 @@
 import { spawn } from 'node:child_process'
 import * as path from 'node:path'
 import * as gitOps from '../utils/git-ops.js'
+import { withGitRepoLock } from '../utils/git-repo-lock.js'
 import { getAgentStatus } from './agent/orchestrator.js'
 import { getForgeProvider } from './forge/registry.js'
 import { resolveForge } from './forge/resolve.js'
@@ -11,6 +12,9 @@ import { getWorkspace, updateWorkspaceSourceBranch } from './workspace-service.j
 
 /** Above this many proper commits, refuse and ask for a manual rebase. */
 export const MAX_PROPER_COMMITS = 50
+
+/** Label written by `stashPush` and read back by `stashPop` — see F27. */
+const STASH_LABEL = 'kobo-change-source-branch'
 
 /** Wall-clock limit on the custom change-source-branch script. */
 const SCRIPT_TIMEOUT_MS = 5 * 60 * 1000
@@ -21,7 +25,32 @@ export interface ChangeSourceBranchResult {
   forcePushNeeded: boolean
   /** Number of proper commits replayed (0 for the aligned path). */
   commitCount: number
+  /** Non-fatal problems worth showing the user (e.g. the backup rotation could not run). */
+  warnings?: string[]
 }
+
+/**
+ * Rotate the backup branches, best-effort. Called on EVERY exit path that has
+ * already created one — a conflict is precisely the case that repeats, and
+ * rotating only on full success let the failure scenario grow without bound.
+ * Returns the warnings so a caller can surface them instead of burying them in
+ * the server log; never throws, since the outcome being returned (or the error
+ * being rethrown) always matters more than the housekeeping.
+ */
+function rotateBackupBranches(worktreePath: string, workingBranch: string): string[] {
+  try {
+    const { warnings } = gitOps.pruneBackupBranches(worktreePath, workingBranch, BACKUP_BRANCHES_KEPT)
+    for (const warning of warnings) console.warn(`[change-source-branch] ${warning}`)
+    return warnings
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    console.warn(`[change-source-branch] backup rotation failed: ${message}`)
+    return [`Backup branch rotation failed: ${message}`]
+  }
+}
+
+/** Three kept means two levels of fallback beyond the branch just created. */
+const BACKUP_BRANCHES_KEPT = 3
 
 /**
  * Re-target a workspace onto `newBase`: reconstruct its working branch via
@@ -69,8 +98,37 @@ export async function changeSourceBranch(workspaceId: string, newBase: string): 
     if (dirty) {
       return { status: 'dirty', forcePushNeeded: false, commitCount: 0 }
     }
+    // A stale index.lock makes every git write fail half-way through, and the
+    // raw git message tells the user nothing. Typical origin: a setup/cleanup
+    // script SIGKILLed at its timeout during a commit. The custom-script path
+    // does not go through the repository lock, so the check is immediate here.
+    gitOps.assertNoIndexLock(worktreePath)
     return runCustomScript(workspace, oldBase, trimmedNew, effective.changeSourceBranchScript)
   }
+
+  // The whole built-in strategy runs under the repository lock: it fetches,
+  // resets and cherry-picks, all of which touch the COMMON git dir shared by
+  // every worktree of the project. A concurrent fetch from the PR watcher
+  // during the cherry-pick leaves it aborted mid-way.
+  return withGitRepoLock(worktreePath, () =>
+    runBuiltInStrategy(workspaceId, worktreePath, workingBranch, workspace.projectPath, oldBase, trimmedNew),
+  )
+}
+
+/** The built-in cherry-pick strategy. Always called under the repository lock. */
+async function runBuiltInStrategy(
+  workspaceId: string,
+  worktreePath: string,
+  workingBranch: string,
+  projectPath: string,
+  oldBase: string,
+  trimmedNew: string,
+): Promise<ChangeSourceBranchResult> {
+  // Index-lock guard FIRST, and here rather than at the entry point: the
+  // repository lock above may have queued us for a while, so a check made at
+  // request time describes a state that no longer holds — it would miss a lock
+  // taken since, or report one that has been released in the meantime.
+  gitOps.assertNoIndexLock(worktreePath)
 
   // Fetch every branch so all `origin/*` refs are current: the proper-commit
   // computation and the `reset --hard` target both depend on fresh refs.
@@ -112,7 +170,7 @@ export async function changeSourceBranch(workspaceId: string, newBase: string): 
   }
 
   const stashed = isAligned && dirty
-  if (stashed) gitOps.stashPush(worktreePath, 'kobo-change-source-branch')
+  if (stashed) gitOps.stashPush(worktreePath, STASH_LABEL)
 
   try {
     gitOps.reconstructBranchOnto(worktreePath, workingBranch, trimmedNew, commits)
@@ -123,7 +181,12 @@ export async function changeSourceBranch(workspaceId: string, newBase: string): 
       // or abort. `stashed` is always false here — a conflict needs commits,
       // the stash path is aligned-only — so no stash is stranded.
       updateWorkspaceSourceBranch(workspaceId, trimmedNew)
-      return { status: 'conflict', forcePushNeeded, commitCount: commits.length }
+      return {
+        status: 'conflict',
+        forcePushNeeded,
+        commitCount: commits.length,
+        warnings: emptyToUndefined(rotateBackupBranches(worktreePath, workingBranch)),
+      }
     }
     // Non-conflict failure (e.g. the `reset --hard` itself failed) — best
     // effort restore of the stash before letting the error propagate, same
@@ -131,11 +194,15 @@ export async function changeSourceBranch(workspaceId: string, newBase: string): 
     // work on an unrelated failure.
     if (stashed) {
       try {
-        gitOps.stashPop(worktreePath)
+        gitOps.stashPop(worktreePath, STASH_LABEL)
       } catch {
         /* best-effort — the original error is more relevant than this one */
       }
     }
+    // The backup branch is created first, so it exists even when the reset that
+    // follows blew up. Rotate before rethrowing; its own warnings can only be
+    // logged here, the error is what reaches the caller.
+    rotateBackupBranches(worktreePath, workingBranch)
     throw err
   }
 
@@ -148,14 +215,19 @@ export async function changeSourceBranch(workspaceId: string, newBase: string): 
 
   if (stashed) {
     try {
-      gitOps.stashPop(worktreePath)
+      gitOps.stashPop(worktreePath, STASH_LABEL)
     } catch {
-      return { status: 'conflict', forcePushNeeded, commitCount: commits.length }
+      return {
+        status: 'conflict',
+        forcePushNeeded,
+        commitCount: commits.length,
+        warnings: emptyToUndefined(rotateBackupBranches(worktreePath, workingBranch)),
+      }
     }
   }
 
   try {
-    const provider = getForgeProvider(resolveForge(workspace.projectPath))
+    const provider = getForgeProvider(resolveForge(projectPath))
     if (provider.capabilities.canChangePrBase) {
       const pr = await provider.getPrStatus(worktreePath, workingBranch)
       if (pr) await provider.changePrBase(worktreePath, trimmedNew)
@@ -164,7 +236,20 @@ export async function changeSourceBranch(workspaceId: string, newBase: string): 
     console.error('[change-source-branch] PR base update failed (non-fatal):', err)
   }
 
-  return { status: isAligned ? 'aligned' : 'done', forcePushNeeded, commitCount: commits.length }
+  // Each backup pins a whole previous history and git can never reclaim it.
+  const warnings = rotateBackupBranches(worktreePath, workingBranch)
+
+  return {
+    status: isAligned ? 'aligned' : 'done',
+    forcePushNeeded,
+    commitCount: commits.length,
+    warnings: emptyToUndefined(warnings),
+  }
+}
+
+/** Keep `warnings` out of the JSON response entirely when there is nothing to say. */
+function emptyToUndefined(warnings: string[]): string[] | undefined {
+  return warnings.length > 0 ? warnings : undefined
 }
 
 /** Spawn the script with `bash -c`, return the standard result on exit 0, throw on non-zero. */

--- a/src/server/services/db-backup-service.ts
+++ b/src/server/services/db-backup-service.ts
@@ -26,17 +26,33 @@ interface BackupEntry {
   mtimeMs: number
 }
 
-function listBackups(dir: string): BackupEntry[] {
+function listBackups(dir: string, prefix: string = BACKUP_PREFIX): BackupEntry[] {
   if (!fs.existsSync(dir)) return []
   return fs
     .readdirSync(dir)
-    .filter((f) => f.startsWith(BACKUP_PREFIX))
+    .filter((f) => f.startsWith(prefix))
     .map((f) => {
       const full = path.join(dir, f)
       const stat = fs.statSync(full)
       return { path: full, mtimeMs: stat.mtimeMs }
     })
     .sort((a, b) => b.mtimeMs - a.mtimeMs)
+}
+
+/** Delete every backup of `prefix` beyond the `keepCount` most recent. */
+function rotateBackups(dir: string, prefix: string, keepCount: number): string[] {
+  const deleted: string[] = []
+  const all = listBackups(dir, prefix)
+  if (all.length <= keepCount) return deleted
+  for (const entry of all.slice(keepCount)) {
+    try {
+      fs.unlinkSync(entry.path)
+      deleted.push(entry.path)
+    } catch (err) {
+      console.error(`[kobo] Failed to delete old DB backup ${entry.path}:`, err)
+    }
+  }
+  return deleted
 }
 
 /**
@@ -73,17 +89,7 @@ export async function createDailyDbBackupIfNeeded(
     await db.backup(backupPath)
     result.created = backupPath
 
-    const all = listBackups(dir)
-    if (all.length > keepCount) {
-      for (const entry of all.slice(keepCount)) {
-        try {
-          fs.unlinkSync(entry.path)
-          result.deleted.push(entry.path)
-        } catch (err) {
-          console.error(`[kobo] Failed to delete old DB backup ${entry.path}:`, err)
-        }
-      }
-    }
+    result.deleted.push(...rotateBackups(dir, BACKUP_PREFIX, keepCount))
   } catch (err) {
     console.error('[kobo] DB daily backup failed:', err)
   }
@@ -93,10 +99,15 @@ export async function createDailyDbBackupIfNeeded(
 
 const PREMIGRATION_PREFIX = 'kobo.db.premigration-'
 
+/** Backups of this prefix kept. One full-size copy was added per shipped
+ *  migration — of schema AND of settings — and nothing ever removed them. */
+const DEFAULT_PREMIGRATION_KEEP = 5
+
 export async function createPreMigrationBackup(
   db: Database.Database,
   dbPath: string,
   tag: string,
+  keepCount: number = DEFAULT_PREMIGRATION_KEEP,
 ): Promise<DbBackupResult> {
   const dir = path.dirname(dbPath)
   const stamp = new Date().toISOString().replace(/[:.]/g, '-')
@@ -104,7 +115,9 @@ export async function createPreMigrationBackup(
   const backupPath = path.join(dir, `${PREMIGRATION_PREFIX}${tag}-${stamp}-${backupSequence}`)
   try {
     await db.backup(backupPath)
-    return { created: backupPath, deleted: [] }
+    // Rotation is scoped to the pre-migration prefix: the daily backups are a
+    // separate net with its own retention and must never be touched here.
+    return { created: backupPath, deleted: rotateBackups(dir, PREMIGRATION_PREFIX, keepCount) }
   } catch (err) {
     console.error('[kobo] Pre-migration backup failed:', err)
     throw err

--- a/src/server/services/pr-watcher-service.ts
+++ b/src/server/services/pr-watcher-service.ts
@@ -1,5 +1,6 @@
 import fs from 'node:fs'
 import { fetchSourceBranchAsync, isGitWorktree } from '../utils/git-ops.js'
+import { withGitRepoLock } from '../utils/git-repo-lock.js'
 import { stopDevServer } from './dev-server-service.js'
 import { getForgeProvider } from './forge/registry.js'
 import { resolveForge } from './forge/resolve.js'
@@ -189,7 +190,13 @@ export async function checkPrStatuses(): Promise<void> {
       // logic below. Its own try/catch so a git failure neither skips PR
       // transitions nor poisons other workspaces.
       try {
-        void fetchSourceBranchAsync(ws.worktreePath, ws.sourceBranch).catch(() => {})
+        // AWAITED, and serialised on the repository's common git dir: remote
+        // refs live there, shared by every worktree of the project. Firing this
+        // without awaiting made the stats below read the refs from BEFORE the
+        // fetch, so ahead/behind counters were always one tick stale; firing it
+        // concurrently across four worktrees made them fight over the same file
+        // lock, with the error swallowed.
+        await withGitRepoLock(ws.worktreePath, () => fetchSourceBranchAsync(ws.worktreePath, ws.sourceBranch))
         lastKnownGitStats.set(ws.id, await computeGitStats(ws, pr))
       } catch (err) {
         console.error(`[pr-watcher] computeGitStats failed for '${ws.name}':`, err instanceof Error ? err.message : err)
@@ -248,12 +255,23 @@ export async function checkPrStatuses(): Promise<void> {
           try {
             const { autoPurgeOnPrMerged } = getGlobalSettings()
             if (autoPurgeOnPrMerged) {
-              void purgeWorktree(ws.id).catch((err) => {
-                console.error(
-                  `[pr-watcher] auto-purge failed for '${ws.name}':`,
-                  err instanceof Error ? err.message : err,
-                )
-              })
+              void purgeWorktree(ws.id)
+                .then((result) => {
+                  // Auto-purge runs with nobody watching: without this trace an
+                  // outcome of 'removal-failed' left no record anywhere.
+                  if (result.outcome !== 'purged') {
+                    console.warn(
+                      `[pr-watcher] auto-purge for '${ws.name}' ended as '${result.outcome}':`,
+                      result.warnings.join('\n') || '(no warning)',
+                    )
+                  }
+                })
+                .catch((err) => {
+                  console.error(
+                    `[pr-watcher] auto-purge failed for '${ws.name}':`,
+                    err instanceof Error ? err.message : err,
+                  )
+                })
             }
           } catch (err) {
             console.error(

--- a/src/server/services/settings-service.ts
+++ b/src/server/services/settings-service.ts
@@ -262,6 +262,19 @@ export interface GlobalSettings {
   autoPurgeOnPrMerged: boolean
   autoLoopMaxRetries: number
   /**
+   * Delete agent events (`ws_events`) older than this many days, once at server
+   * start-up. `0` — the default — disables retention entirely: nothing is ever
+   * deleted, which is what every install did before this setting existed. The
+   * feature is opt-in because it destroys conversation history for good.
+   */
+  wsEventsRetentionDays: number
+  /**
+   * Newest events kept per workspace whatever their age, so an old but still
+   * open workspace keeps a readable history. Irrelevant while
+   * `wsEventsRetentionDays` is 0.
+   */
+  wsEventsKeepPerWorkspace: number
+  /**
    * Opt-in LAN network access. When false (default) the server binds
    * 127.0.0.1 only; when true it binds all interfaces and requires the
    * token for every non-loopback request. Seeded by settings migration v39.
@@ -1087,6 +1100,31 @@ const settingsMigrations: SettingsMigration[] = [
       global.whipVolume = normalizeWhipVolume(global.whipVolume)
     },
   },
+  {
+    version: 54,
+    name: 'add-ws-events-retention',
+    migrate: ({ global }) => {
+      // Seeded DISABLED (0), on fresh installs as well as migrated ones. This
+      // feature permanently deletes conversation history, so it is opt-in: a
+      // silent loss of history is worse than a growing file. A window the user
+      // already chose survives untouched; only a negative or non-integer value
+      // falls back to 0.
+      if (
+        typeof global.wsEventsRetentionDays !== 'number' ||
+        !Number.isInteger(global.wsEventsRetentionDays) ||
+        global.wsEventsRetentionDays < 0
+      ) {
+        global.wsEventsRetentionDays = 0
+      }
+      if (
+        typeof global.wsEventsKeepPerWorkspace !== 'number' ||
+        !Number.isInteger(global.wsEventsKeepPerWorkspace) ||
+        global.wsEventsKeepPerWorkspace < 0
+      ) {
+        global.wsEventsKeepPerWorkspace = 0
+      }
+    },
+  },
 ]
 
 /** Current settings schema version — always equals the highest migration version. */
@@ -1164,6 +1202,8 @@ function defaultSettings(): Settings {
       terminalCommand: '',
       autoPurgeOnPrMerged: false,
       autoLoopMaxRetries: 5,
+      wsEventsRetentionDays: 0,
+      wsEventsKeepPerWorkspace: 0,
       networkAccessEnabled: false,
       networkAccessToken: '',
       networkAccessBehindProxy: false,
@@ -1596,6 +1636,20 @@ export function updateGlobalSettings(data: Partial<GlobalSettings>): GlobalSetti
       delete (data as Record<string, unknown>).autoLoopMaxRetries
     }
   }
+  // Same shape as the autoLoopMaxRetries guard above: an invalid value is
+  // dropped so the stored one survives. Retention deletes history — a bad write
+  // here would delete more than the user ever asked for. `0` is NOT invalid:
+  // it is the default, and it means "never delete anything".
+  for (const key of ['wsEventsRetentionDays', 'wsEventsKeepPerWorkspace'] as const) {
+    if (key in data) {
+      const value = data[key]
+      const max = key === 'wsEventsRetentionDays' ? 3650 : 1_000_000
+      if (typeof value !== 'number' || !Number.isInteger(value) || value < 0 || value > max) {
+        console.warn(`[settings] Invalid ${key} value rejected: ${value}`)
+        delete (data as Record<string, unknown>)[key]
+      }
+    }
+  }
   const allowedGlobalKeys = [
     'defaultModelByEngine',
     'dangerouslySkipPermissions',
@@ -1617,6 +1671,8 @@ export function updateGlobalSettings(data: Partial<GlobalSettings>): GlobalSetti
     'terminalCommand',
     'autoPurgeOnPrMerged',
     'autoLoopMaxRetries',
+    'wsEventsRetentionDays',
+    'wsEventsKeepPerWorkspace',
     'browserNotifications',
     'audioNotifications',
     'audioQuestionNotifications',

--- a/src/server/services/websocket-service.ts
+++ b/src/server/services/websocket-service.ts
@@ -27,6 +27,11 @@ export interface WsMessage {
 /** Maps each WS client to the set of workspaceIds they are subscribed to */
 const clients = new Map<WebSocket, Set<string>>()
 
+/** Above this many bytes queued for a single client, we stop sending it events
+ *  rather than growing the process heap on its behalf. It will catch up through
+ *  `sync:request` on its next reconnect. */
+const MAX_BUFFERED_BYTES = 1024 * 1024
+
 // ── Message handler (decoupled routing) ────────────────────────────────────────
 
 /** Callback for routed WS messages (chat, workspace, devserver commands). */
@@ -121,13 +126,28 @@ export function handleConnection(ws: WebSocket): void {
     }
   })
 
-  // Ping every 30s to keep the connection alive and detect stale clients
+  // Heartbeat with a verdict. Pinging without ever waiting for a pong detected
+  // nothing: half-open sockets stayed in `clients` for ever, and every emit
+  // kept serialising a message for a peer that will never read it.
+  let isAlive = true
+  ws.on('pong', () => {
+    isAlive = true
+  })
   const pingInterval = setInterval(() => {
-    if (ws.readyState === ws.OPEN) {
-      ws.ping()
-    } else {
+    if (ws.readyState !== 1 /* WebSocket.OPEN */) {
       clearInterval(pingInterval)
+      clients.delete(ws)
+      return
     }
+    if (!isAlive) {
+      console.warn('[ws] client missed the heartbeat — terminating the connection')
+      clearInterval(pingInterval)
+      clients.delete(ws)
+      ws.terminate()
+      return
+    }
+    isAlive = false
+    ws.ping()
   }, 30_000)
 
   ws.on('close', () => {
@@ -173,6 +193,13 @@ export function emit(workspaceId: string, type: string, payload: unknown, sessio
   let emitSendErrorLogged = false
   for (const [ws, subs] of clients) {
     if (subs.has(workspaceId) && ws.readyState === 1 /* WebSocket.OPEN */) {
+      if (((ws as { bufferedAmount?: number }).bufferedAmount ?? 0) > MAX_BUFFERED_BYTES) {
+        if (!emitSendErrorLogged) {
+          console.warn(`[ws] client backlogged, dropping live events (workspace=${workspaceId}, type=${type})`)
+          emitSendErrorLogged = true
+        }
+        continue
+      }
       try {
         ws.send(message)
       } catch (err) {
@@ -200,6 +227,13 @@ export function emitEphemeral(workspaceId: string, type: string, payload: unknow
   let sendErrorLogged = false
   for (const [ws, subs] of clients) {
     if (subs.has(workspaceId) && ws.readyState === 1 /* WebSocket.OPEN */) {
+      if (((ws as { bufferedAmount?: number }).bufferedAmount ?? 0) > MAX_BUFFERED_BYTES) {
+        if (!sendErrorLogged) {
+          console.warn(`[ws] client backlogged, dropping ephemeral event (workspace=${workspaceId}, type=${type})`)
+          sendErrorLogged = true
+        }
+        continue
+      }
       try {
         ws.send(message)
       } catch (err) {
@@ -232,79 +266,116 @@ export function handleSyncRequest(ws: WebSocket, lastEventId: string, workspaceI
     return
   }
 
-  const db = getDb()
-
-  // Build a query with placeholders for all subscribed workspaces
-  const placeholders = resolvedIds.map(() => '?').join(', ')
-
-  let rows: Array<{
-    id: string
-    workspace_id: string
-    type: string
-    payload: string
-    session_id: string | null
-    created_at: string
-  }>
-
   // Initial window size: on a fresh connection (no lastEventId), we only
   // replay the most recent slice of history. The client fetches older
   // events on-demand via GET /api/workspaces/:id/events as the user scrolls
   // up. This keeps first-paint fast on long-lived workspaces with tens of
   // thousands of events without ever deleting anything from the DB.
   const INITIAL_WINDOW = 300
+  /** Hard ceiling on one replay message. A tab left open overnight used to ask
+   *  for every row since its cursor at once; the client simply asks again with
+   *  the new cursor when `truncated` is set. */
+  const MAX_REPLAY_EVENTS = 2_000
 
-  let mode: 'snapshot' | 'delta' = 'snapshot'
-  if (lastEventId) {
-    // Resume path: replay every event strictly after the cursor (delta
-    // since last seen). If the cursor is stale/unknown, fall back to the
-    // recent window rather than streaming the entire history.
-    const lastRow = db.prepare('SELECT rowid FROM ws_events WHERE id = ?').get(lastEventId) as
-      | { rowid: number }
-      | undefined
-
-    if (lastRow) {
-      mode = 'delta'
-      rows = db
-        .prepare(`SELECT * FROM ws_events WHERE workspace_id IN (${placeholders}) AND rowid > ? ORDER BY rowid ASC`)
-        .all(...resolvedIds, lastRow.rowid) as typeof rows
-    } else {
-      rows = db
-        .prepare(`SELECT * FROM ws_events WHERE workspace_id IN (${placeholders}) ORDER BY rowid DESC LIMIT ?`)
-        .all(...resolvedIds, INITIAL_WINDOW) as typeof rows
-      rows.reverse()
-    }
-  } else {
-    // Fresh connect: most recent INITIAL_WINDOW events, in chronological order.
-    rows = db
-      .prepare(`SELECT * FROM ws_events WHERE workspace_id IN (${placeholders}) ORDER BY rowid DESC LIMIT ?`)
-      .all(...resolvedIds, INITIAL_WINDOW) as typeof rows
-    rows.reverse()
+  interface EventRow {
+    rid: number
+    id: string
+    workspace_id: string
+    type: string
+    payload: string
+    session_id: string | null
+    created_at: string
   }
 
-  const events: WsEvent[] = rows.map((row) => {
-    let parsedPayload: unknown
-    try {
-      parsedPayload = JSON.parse(row.payload)
-    } catch {
-      console.error('[ws] corrupt ws_events row, falling back to raw:', {
-        id: row.id,
-        workspace_id: row.workspace_id,
-        type: row.type,
-      })
-      parsedPayload = { raw: row.payload }
-    }
-    return {
-      id: row.id,
-      workspaceId: row.workspace_id,
-      type: row.type,
-      payload: parsedPayload,
-      sessionId: row.session_id ?? undefined,
-      createdAt: row.created_at,
-      replayable: true,
-    }
-  })
+  try {
+    const db = getDb()
+    let mode: 'snapshot' | 'delta' = 'snapshot'
+    let truncated = false
+    const rows: EventRow[] = []
 
-  ws.send(JSON.stringify({ type: 'sync:response', payload: { events, mode } }))
+    const lastRow = lastEventId
+      ? (db.prepare('SELECT rowid FROM ws_events WHERE id = ?').get(lastEventId) as { rowid: number } | undefined)
+      : undefined
+
+    // One bounded query PER workspace. With `workspace_id IN (...)` SQLite
+    // materialised and sorted the whole history of every requested workspace
+    // before applying the limit — so the limit protected the message, not the
+    // server.
+    if (lastRow) {
+      mode = 'delta'
+      const statement = db.prepare(
+        'SELECT rowid AS rid, * FROM ws_events WHERE workspace_id = ? AND rowid > ? ORDER BY rowid ASC LIMIT ?',
+      )
+      for (const workspaceId of resolvedIds) {
+        const batch = statement.all(workspaceId, lastRow.rowid, MAX_REPLAY_EVENTS) as EventRow[]
+        if (batch.length === MAX_REPLAY_EVENTS) truncated = true
+        rows.push(...batch)
+      }
+    } else {
+      const statement = db.prepare(
+        'SELECT rowid AS rid, * FROM ws_events WHERE workspace_id = ? ORDER BY rowid DESC LIMIT ?',
+      )
+      for (const workspaceId of resolvedIds) {
+        const batch = statement.all(workspaceId, INITIAL_WINDOW) as EventRow[]
+        rows.push(...batch)
+      }
+    }
+
+    rows.sort((a, b) => a.rid - b.rid)
+    if (rows.length > MAX_REPLAY_EVENTS) {
+      if (mode === 'delta') {
+        // Keep the OLDEST slice: the client's cursor then advances and its next
+        // sync:request picks up exactly where this message stopped.
+        rows.length = MAX_REPLAY_EVENTS
+      } else {
+        // Snapshot mode has no cursor to advance — the client is looking at a
+        // fresh window and wants what just happened. Dropping the head here
+        // (rather than the tail) is the difference between "the last few
+        // minutes" and "ancient history with no way to reach the present".
+        rows.splice(0, rows.length - MAX_REPLAY_EVENTS)
+      }
+      truncated = true
+    }
+
+    const events: WsEvent[] = rows.map((row) => {
+      let parsedPayload: unknown
+      try {
+        parsedPayload = JSON.parse(row.payload)
+      } catch {
+        console.error('[ws] corrupt ws_events row, falling back to raw:', {
+          id: row.id,
+          workspace_id: row.workspace_id,
+          type: row.type,
+        })
+        parsedPayload = { raw: row.payload }
+      }
+      return {
+        id: row.id,
+        workspaceId: row.workspace_id,
+        type: row.type,
+        payload: parsedPayload,
+        sessionId: row.session_id ?? undefined,
+        createdAt: row.created_at,
+        replayable: true,
+      }
+    })
+
+    ws.send(JSON.stringify({ type: 'sync:response', payload: { events, mode, truncated } }))
+  } catch (err) {
+    // This handler runs inside ws's 'message' callback: an uncaught SQLite
+    // error here used to reach the process, not the client.
+    console.error('[ws] sync request failed:', err)
+    try {
+      ws.send(
+        JSON.stringify({
+          type: 'sync:error',
+          payload: { message: err instanceof Error ? err.message : String(err) },
+        }),
+      )
+    } catch {
+      /* the client is gone too — nothing left to tell it */
+    }
+  }
 }
 
 // ── Utilities ──────────────────────────────────────────────────────────────────

--- a/src/server/services/workspace-service.ts
+++ b/src/server/services/workspace-service.ts
@@ -1,3 +1,4 @@
+import type Database from 'better-sqlite3'
 import { nanoid } from 'nanoid'
 import { getDb } from '../db/index.js'
 import { resolveWorkspaceWorktreePath } from '../utils/worktree-paths.js'
@@ -1204,4 +1205,55 @@ export function deleteSession(sessionId: string, workspaceId: string): boolean {
   })
   transaction()
   return true
+}
+
+/**
+ * Recompute one session's persisted metrics from the events that remain, on an
+ * explicit database handle.
+ *
+ * Until v36 an `AFTER DELETE ... FOR EACH ROW` trigger did this per deleted
+ * row, re-aggregating the whole session every time — 79.7 s for 20 000 events,
+ * with the SQLite write lock held throughout. The trigger is gone; every code
+ * path that deletes `agent:event` rows while KEEPING the session calls this
+ * once, at the end of its transaction.
+ */
+export function recomputeSessionMetricsOn(db: Database.Database, workspaceId: string, sessionId: string): void {
+  db.prepare('DELETE FROM session_event_metrics WHERE workspace_id = ? AND session_id = ?').run(workspaceId, sessionId)
+  db.prepare(
+    `INSERT INTO session_event_metrics (
+       workspace_id, session_id, tool_calls, errors, input_tokens, output_tokens
+     )
+     SELECT
+       e.workspace_id,
+       e.session_id,
+       SUM(CASE WHEN json_extract(e.payload, '$.kind') = 'tool:call' THEN 1 ELSE 0 END),
+       SUM(CASE
+         WHEN json_extract(e.payload, '$.kind') = 'error'
+           OR (json_extract(e.payload, '$.kind') = 'tool:result'
+             AND json_extract(e.payload, '$.isError') = 1)
+         THEN 1 ELSE 0
+       END),
+       MAX(CASE
+         WHEN json_extract(e.payload, '$.kind') = 'usage'
+           AND json_type(e.payload, '$.inputTokens') IN ('integer', 'real')
+         THEN CAST(json_extract(e.payload, '$.inputTokens') AS INTEGER) ELSE 0
+       END),
+       MAX(CASE
+         WHEN json_extract(e.payload, '$.kind') = 'usage'
+           AND json_type(e.payload, '$.outputTokens') IN ('integer', 'real')
+         THEN CAST(json_extract(e.payload, '$.outputTokens') AS INTEGER) ELSE 0
+       END)
+     FROM ws_events e
+     JOIN agent_sessions s ON s.id = e.session_id AND s.workspace_id = e.workspace_id
+     WHERE e.workspace_id = ?
+       AND e.session_id = ?
+       AND e.type = 'agent:event'
+       AND json_valid(e.payload)
+     GROUP BY e.workspace_id, e.session_id`,
+  ).run(workspaceId, sessionId)
+}
+
+/** Same, on the singleton connection. */
+export function recomputeSessionMetrics(workspaceId: string, sessionId: string): void {
+  recomputeSessionMetricsOn(getDb(), workspaceId, sessionId)
 }

--- a/src/server/services/worktree-purge-service.ts
+++ b/src/server/services/worktree-purge-service.ts
@@ -14,7 +14,7 @@ import {
 } from './workspace-service.js'
 import { isPermissionError, removeWorktree } from './worktree-service.js'
 
-export type PurgeOutcome = 'purged' | 'already-purged' | 'worktree-not-owned' | 'not-found'
+export type PurgeOutcome = 'purged' | 'already-purged' | 'worktree-not-owned' | 'not-found' | 'removal-failed'
 
 export interface PurgeResult {
   outcome: PurgeOutcome
@@ -63,11 +63,20 @@ export async function purgeWorktree(workspaceId: string): Promise<PurgeResult> {
 
   if (fs.existsSync(workspace.worktreePath)) {
     try {
-      removeWorktree(workspace.projectPath, workspace.worktreePath)
+      await removeWorktree(workspace.projectPath, workspace.worktreePath)
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err)
       warnings.push(buildRemovalFailureMessage(workspace.worktreePath, workspace.projectPath, msg))
     }
+  }
+
+  // `worktree_purged_at` is not cosmetic: it drives the "restore" UI and the
+  // PR watcher's auto-restore probe, which tests whether the folder reappeared.
+  // Setting it on a directory that never left puts both in contradiction with
+  // the disk — and told the user the space was reclaimed when it wasn't.
+  if (fs.existsSync(workspace.worktreePath)) {
+    emitEphemeral(workspaceId, 'workspace:worktree-purge-failed', { workspaceId, warnings })
+    return { outcome: 'removal-failed', warnings }
   }
 
   try {

--- a/src/server/services/worktree-service.ts
+++ b/src/server/services/worktree-service.ts
@@ -2,6 +2,7 @@ import { execFileSync } from 'node:child_process'
 import fs from 'node:fs'
 import path from 'node:path'
 import { isGitBranchExistsError } from '../utils/git-ops.js'
+import { withGitRepoLock } from '../utils/git-repo-lock.js'
 import { resolveWorkspaceWorktreePath, resolveWorktreesRoot } from '../utils/worktree-paths.js'
 
 /** Parsed information about a single git worktree. */
@@ -155,13 +156,43 @@ export function createWorktree(
   return { worktreePath, base, branchCreated }
 }
 
+/** `git worktree remove` drops the administrative entry even when it fails to
+ *  delete the directory, and the prune only ever ran in the Docker fallback.
+ *  Prune the stale metadata, then refuse to report success while the folder is
+ *  still there — the purge feature marked workspaces as purged on that false
+ *  success, telling the user the disk space was reclaimed when it wasn't.
+ *
+ *  Callers hold the repository lock: acquiring it again here would deadlock on
+ *  the same key, since the chain is strictly sequential per common git dir. */
+function assertWorktreeGone(projectPath: string, worktreePath: string): void {
+  try {
+    git(projectPath, ['worktree', 'prune'])
+  } catch (err) {
+    console.warn(`[worktree] prune after removing '${worktreePath}' failed:`, err instanceof Error ? err.message : err)
+  }
+  if (fs.existsSync(worktreePath)) {
+    throw new Error(`Failed to remove worktree '${worktreePath}': the directory is still on disk after removal`)
+  }
+}
+
 /** Remove a git worktree and clean up the .git/info/exclude entry.
  *
  * If `git worktree remove` fails on a permission error (Docker dev servers leave
  * root-owned files in node_modules / vendor), and Docker is available, reclaim
  * ownership with a throwaway container (`chown -R <uid>:<gid>`) and retry once.
  * Otherwise rethrow so the caller's recovery toast (sudo rm -rf …) fires. */
-export function removeWorktree(projectPath: string, worktreePath: string): void {
+export function removeWorktree(projectPath: string, worktreePath: string): Promise<void> {
+  // `git worktree remove` and `git worktree prune` both rewrite the worktree
+  // administrative files of the COMMON git dir — the very state a concurrent
+  // source-branch change (fetch / reset / cherry-pick) is manipulating under
+  // the same lock. The whole removal sequence is held, Docker chown included:
+  // it sits between the `remove` and the `prune` that repairs its metadata, so
+  // releasing in the middle would expose a half-removed repository.
+  return withGitRepoLock(projectPath, () => removeWorktreeLocked(projectPath, worktreePath))
+}
+
+/** The actual removal. Always called with the repository lock held. */
+function removeWorktreeLocked(projectPath: string, worktreePath: string): void {
   try {
     git(projectPath, ['worktree', 'remove', worktreePath, '--force'])
   } catch (err) {
@@ -184,6 +215,7 @@ export function removeWorktree(projectPath: string, worktreePath: string): void 
         git(projectPath, ['worktree', 'prune'])
         console.log(`[worktree] Docker cleanup succeeded; removed '${worktreePath}'`)
         removeFromExclude(projectPath, worktreePath)
+        assertWorktreeGone(projectPath, worktreePath)
         return
       } catch (retryErr) {
         const retryMessage = retryErr instanceof Error ? retryErr.message : String(retryErr)
@@ -196,6 +228,7 @@ export function removeWorktree(projectPath: string, worktreePath: string): void 
   }
 
   removeFromExclude(projectPath, worktreePath)
+  assertWorktreeGone(projectPath, worktreePath)
 }
 
 /** List all git worktrees for a repository by parsing `git worktree list --porcelain`. */

--- a/src/server/services/ws-events-retention-service.ts
+++ b/src/server/services/ws-events-retention-service.ts
@@ -1,0 +1,178 @@
+import type Database from 'better-sqlite3'
+import { recomputeSessionMetricsOn } from './workspace-service.js'
+
+/** Rows deleted per transaction. Small enough that the SQLite write lock is
+ *  never held for more than a few milliseconds at a time — the whole point of
+ *  doing this AFTER the quadratic AFTER DELETE trigger was removed. */
+const BATCH_SIZE = 5_000
+
+/** Free-page ratio above which a full VACUUM is worth its cost. Production was
+ *  measured at 620 free pages out of 656 (95 %) for zero remaining rows. */
+const VACUUM_FREE_PAGE_RATIO = 0.25
+
+/** Retention is OPT-IN: absent or invalid settings mean "delete nothing". */
+const DISABLED = 0
+
+/** The slice of global settings this service reads. */
+export interface RetentionSettings {
+  wsEventsRetentionDays?: number
+  wsEventsKeepPerWorkspace?: number
+}
+
+export interface RetentionConfig {
+  /** Events older than this are candidates for deletion. `0` disables retention entirely. */
+  retentionDays: number
+  /** Newest events per workspace that are never deleted, however old they are. */
+  keepPerWorkspace: number
+}
+
+export interface RetentionResult {
+  deleted: number
+  sessionsRecomputed: number
+  vacuumed: boolean
+  freePagesBefore: number
+  freePagesAfter: number
+}
+
+/** Anything that is not a non-negative integer falls back to "disabled": a bad
+ *  value must never be read as a licence to delete. */
+function normalize(value: number | undefined): number {
+  return typeof value === 'number' && Number.isInteger(value) && value >= 0 ? value : DISABLED
+}
+
+/** Read the retention window from the global settings. */
+export function resolveRetentionConfig(global: RetentionSettings): RetentionConfig {
+  return {
+    retentionDays: normalize(global.wsEventsRetentionDays),
+    keepPerWorkspace: normalize(global.wsEventsKeepPerWorkspace),
+  }
+}
+
+/** Shared candidate selection: rows older than the cutoff that fall outside the
+ *  per-workspace tail. Used both to count (preview) and to delete. */
+const CANDIDATE_CTE = `
+  WITH ranked AS (
+    SELECT rowid AS rid,
+           workspace_id,
+           session_id,
+           created_at,
+           ROW_NUMBER() OVER (PARTITION BY workspace_id ORDER BY rowid DESC) AS rn
+    FROM ws_events
+  )`
+
+function cutoffFor(config: RetentionConfig, nowMs: number): string {
+  return new Date(nowMs - config.retentionDays * 24 * 60 * 60 * 1000).toISOString()
+}
+
+/**
+ * How many events `config` would delete right now. Deletes nothing — this backs
+ * the confirmation dialog, so the user is told the real volume before agreeing
+ * to destroy it.
+ */
+export function countPrunableWsEvents(
+  db: Database.Database,
+  config: RetentionConfig,
+  nowMs: number = Date.now(),
+): number {
+  if (config.retentionDays <= 0) return 0
+  const row = db
+    .prepare(
+      `${CANDIDATE_CTE}
+       SELECT COUNT(*) AS c FROM ranked WHERE created_at < ? AND rn > ?`,
+    )
+    .get(cutoffFor(config, nowMs), config.keepPerWorkspace) as { c: number }
+  return row.c
+}
+
+interface CandidateRow {
+  rid: number
+  workspace_id: string
+  session_id: string | null
+}
+
+/**
+ * Delete `ws_events` rows older than the retention window, batch by batch, then
+ * recompute the metrics of the sessions touched and reclaim the freed pages.
+ *
+ * Deletes agent output ONLY: workspaces, tasks, sessions, branches and worktrees
+ * are never touched.
+ *
+ * Order matters: this must never run while the removed `AFTER DELETE` trigger
+ * is present — it re-aggregated the whole session per deleted row and held the
+ * write lock long enough to make every concurrent WebSocket emit time out and
+ * lose its event.
+ */
+export function pruneWsEvents(
+  db: Database.Database,
+  config: RetentionConfig,
+  nowMs: number = Date.now(),
+): RetentionResult {
+  const freePagesBefore = (db.pragma('freelist_count', { simple: true }) as number) ?? 0
+  const result: RetentionResult = {
+    deleted: 0,
+    sessionsRecomputed: 0,
+    vacuumed: false,
+    freePagesBefore,
+    freePagesAfter: freePagesBefore,
+  }
+  if (config.retentionDays <= 0) return result
+
+  const cutoff = cutoffFor(config, nowMs)
+  const selectBatch = db.prepare(
+    `${CANDIDATE_CTE}
+     SELECT rid, workspace_id, session_id
+     FROM ranked
+     WHERE created_at < ? AND rn > ?
+     ORDER BY rid ASC
+     LIMIT ?`,
+  )
+  const deleteOne = db.prepare('DELETE FROM ws_events WHERE rowid = ?')
+  const touched = new Set<string>()
+
+  for (;;) {
+    const batch = selectBatch.all(cutoff, config.keepPerWorkspace, BATCH_SIZE) as CandidateRow[]
+    if (batch.length === 0) break
+    db.transaction(() => {
+      for (const row of batch) {
+        deleteOne.run(row.rid)
+        if (row.session_id) touched.add(`${row.workspace_id}::${row.session_id}`)
+      }
+    })()
+    result.deleted += batch.length
+    if (batch.length < BATCH_SIZE) break
+  }
+
+  // Once per session, at the very end — never per deleted row.
+  for (const key of touched) {
+    const separator = key.indexOf('::')
+    const workspaceId = key.slice(0, separator)
+    const sessionId = key.slice(separator + 2)
+    try {
+      recomputeSessionMetricsOn(db, workspaceId, sessionId)
+      result.sessionsRecomputed += 1
+    } catch (err) {
+      console.error(`[retention] metric recompute failed (workspace=${workspaceId}, session=${sessionId}):`, err)
+    }
+  }
+
+  if (result.deleted === 0) return result
+
+  // Truncate the WAL, then compact only when it is actually worth it.
+  try {
+    db.pragma('wal_checkpoint(TRUNCATE)')
+  } catch (err) {
+    console.error('[retention] wal_checkpoint failed:', err)
+  }
+  const freelist = (db.pragma('freelist_count', { simple: true }) as number) ?? 0
+  const pageCount = (db.pragma('page_count', { simple: true }) as number) ?? 0
+  if (pageCount > 0 && freelist / pageCount >= VACUUM_FREE_PAGE_RATIO) {
+    try {
+      db.exec('VACUUM')
+      result.vacuumed = true
+    } catch (err) {
+      console.error('[retention] VACUUM failed:', err)
+    }
+  }
+  result.freePagesAfter = (db.pragma('freelist_count', { simple: true }) as number) ?? 0
+  return result
+}

--- a/src/server/utils/git-ops.ts
+++ b/src/server/utils/git-ops.ts
@@ -75,6 +75,46 @@ async function gitAsync(repoPath: string, args: string[], timeout = READ_ONLY_GI
   return stdout.trimEnd()
 }
 
+/** Raised when a stale `index.lock` blocks every write on a worktree. */
+export class GitIndexLockError extends Error {
+  readonly lockPath: string
+
+  constructor(lockPath: string) {
+    super(
+      `The git index of this worktree is locked by '${lockPath}'. A previous git command was killed before it ` +
+        `could release it — typically a setup or cleanup script that hit its timeout and was SIGKILLed mid-commit. ` +
+        `If no git process is running on this worktree, remove the file: rm -f '${lockPath}'`,
+    )
+    this.name = 'GitIndexLockError'
+    this.lockPath = lockPath
+  }
+}
+
+/**
+ * Absolute path of this worktree's `index.lock` when it exists, else `null`.
+ *
+ * The lock lives in the worktree's OWN git dir (`--absolute-git-dir`), not in
+ * the common dir shared with the other worktrees: each worktree has its own
+ * index. Returns `null` rather than throwing outside a repository — callers use
+ * this to produce a better error, never to decide whether git is usable.
+ */
+export function getIndexLockPath(repoPath: string): string | null {
+  let gitDir: string
+  try {
+    gitDir = git(repoPath, ['rev-parse', '--absolute-git-dir'])
+  } catch {
+    return null
+  }
+  const lockPath = join(gitDir, 'index.lock')
+  return existsSync(lockPath) ? lockPath : null
+}
+
+/** Throw `GitIndexLockError` when a stale index lock would make every write fail. */
+export function assertNoIndexLock(repoPath: string): void {
+  const lockPath = getIndexLockPath(repoPath)
+  if (lockPath) throw new GitIndexLockError(lockPath)
+}
+
 /** Return the name of the currently checked-out branch. */
 export function getCurrentBranch(repoPath: string): string {
   return git(repoPath, ['rev-parse', '--abbrev-ref', 'HEAD'])
@@ -516,19 +556,65 @@ export function reconstructBranchOnto(
   return backupBranch
 }
 
-/** List `kobo-backup/<workingBranch>-<ts>` branches, newest timestamp first. */
+/** List `kobo-backup/<workingBranch>-<ts>` branches, newest timestamp first.
+ *
+ *  THROWS on a git failure instead of returning an empty list: an empty list is
+ *  the caller's signal that no rollback exists, and swallowing an inherited
+ *  lock or a buffer overflow here made the cancel route answer "automatic
+ *  restore impossible" while the backup branch was sitting right there. */
 export function listBackupBranches(repoPath: string, workingBranch: string): string[] {
+  const prefix = `kobo-backup/${workingBranch}-`
+  let out: string
   try {
-    const prefix = `kobo-backup/${workingBranch}-`
-    const out = git(repoPath, ['branch', '--list', `${prefix}*`, '--format=%(refname:short)'])
-    return out
-      .split('\n')
-      .map((s) => s.trim())
-      .filter((b) => b.startsWith(prefix) && /^\d+$/.test(b.slice(prefix.length)))
-      .sort((a, b) => Number(b.slice(prefix.length)) - Number(a.slice(prefix.length)))
-  } catch {
-    return []
+    out = git(repoPath, ['branch', '--list', `${prefix}*`, '--format=%(refname:short)'])
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    throw new Error(`Failed to list backup branches for '${workingBranch}': ${message}`)
   }
+  return out
+    .split('\n')
+    .map((s) => s.trim())
+    .filter((b) => b.startsWith(prefix) && /^\d+$/.test(b.slice(prefix.length)))
+    .sort((a, b) => Number(b.slice(prefix.length)) - Number(a.slice(prefix.length)))
+}
+
+/** Keep the `keep` newest backup branches of `workingBranch`, delete the rest.
+ *
+ *  Each backup branch pins every commit of a previous version of the branch, so
+ *  git's garbage collector can never reclaim them: without rotation the
+ *  repository grows by one full branch history per source-branch change, for
+ *  ever. Best-effort — a failure to delete one branch must not fail the
+ *  operation that just succeeded.
+ *
+ *  Never throws, but never stays silent either: "nothing to rotate" and "the
+ *  rotation could not run" are two different answers, and reporting the second
+ *  as the first turns a persistent git failure into unbounded growth that only
+ *  a server log would ever have revealed. */
+export function pruneBackupBranches(
+  repoPath: string,
+  workingBranch: string,
+  keep = 3,
+): { removed: string[]; warnings: string[] } {
+  const warnings: string[] = []
+  let branches: string[]
+  try {
+    branches = listBackupBranches(repoPath, workingBranch)
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    warnings.push(`Backup branch rotation skipped for '${workingBranch}': ${message}`)
+    return { removed: [], warnings }
+  }
+  const removed: string[] = []
+  for (const branch of branches.slice(keep)) {
+    try {
+      git(repoPath, ['branch', '-D', branch])
+      removed.push(branch)
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      warnings.push(`Failed to delete backup branch '${branch}': ${message}`)
+    }
+  }
+  return { removed, warnings }
 }
 
 /** Abort any in-progress operation, then hard-reset `workingBranch` to a backup branch. */
@@ -1111,6 +1197,23 @@ export function isGitWorktree(repoPath: string): boolean {
 }
 
 /**
+ * True when `name` is a branch name Kōbō may hand to git.
+ *
+ * The first character MUST be alphanumeric. Without that anchor a leading `-`
+ * passes any `[A-Za-z0-9/_.-]+` check and git reads the whole argument as an
+ * OPTION — `--force`, `--exec=…` — rather than as a branch. (There is no shell
+ * injection to worry about here: every git call in this project goes through an
+ * argument array. The exposure is option injection.)
+ * The remaining rules mirror `git check-ref-format`.
+ */
+export function isValidBranchName(name: string): boolean {
+  if (!/^[A-Za-z0-9][A-Za-z0-9/_.-]*$/.test(name)) return false
+  if (name.includes('..') || name.includes('//')) return false
+  if (name.endsWith('/') || name.endsWith('.') || name.endsWith('.lock')) return false
+  return true
+}
+
+/**
  * Turn an arbitrary string into a git-ref-safe segment, capped to `maxLen`.
  * Strips accents (é→e), collapses every run of non-alphanumeric characters
  * (backslashes, colons, spaces, dots… — all unsafe or awkward in a ref/path)
@@ -1293,9 +1396,49 @@ export function stashPush(repoPath: string, label: string): void {
   git(repoPath, ['stash', 'push', '--include-untracked', '-m', label])
 }
 
-/** Pop the most recent stash entry. */
-export function stashPop(repoPath: string): void {
-  git(repoPath, ['stash', 'pop'])
+/**
+ * Index of the newest stash entry whose message contains `label`, or `null`.
+ * `%gd` is the ref (`stash@{N}`), `%gs` the reflog subject (`On <branch>: <label>`).
+ */
+export function findStashIndexByLabel(repoPath: string, label: string): number | null {
+  let out: string
+  try {
+    out = git(repoPath, ['stash', 'list', '--format=%gd%x09%gs'])
+  } catch {
+    return null
+  }
+  if (!out) return null
+  for (const line of out.split('\n')) {
+    const separator = line.indexOf('\t')
+    if (separator < 0) continue
+    const ref = line.slice(0, separator).trim()
+    const subject = line.slice(separator + 1)
+    if (!subject.includes(label)) continue
+    const match = /^stash@\{(\d+)\}$/.exec(ref)
+    if (match) return Number(match[1])
+  }
+  return null
+}
+
+/**
+ * Pop a stash entry. With `label`, pops the newest entry whose message contains
+ * it instead of blindly popping `stash@{0}`.
+ *
+ * `stashPush` has always written a label, but nothing ever read it back. The
+ * agent and the integrated terminal both stash routinely before a rebase — do
+ * that between our push and our pop and the bare `git stash pop` restores THEIR
+ * entry, burying the user's work one slot deeper where nothing surfaces it.
+ */
+export function stashPop(repoPath: string, label?: string): void {
+  if (!label) {
+    git(repoPath, ['stash', 'pop'])
+    return
+  }
+  const index = findStashIndexByLabel(repoPath, label)
+  if (index === null) {
+    throw new Error(`No stash entry labelled '${label}' to restore`)
+  }
+  git(repoPath, ['stash', 'pop', `stash@{${index}}`])
 }
 
 /** Stage every change (tracked + untracked) and commit it. Hooks run normally

--- a/src/server/utils/git-repo-lock.ts
+++ b/src/server/utils/git-repo-lock.ts
@@ -1,0 +1,54 @@
+import { execFileSync } from 'node:child_process'
+import path from 'node:path'
+
+/**
+ * One promise chain per shared git directory. Same mechanism as the per-worktree
+ * lock in `image-service.ts`, keyed differently: remote refs, packed-refs and
+ * the object database live in the COMMON git dir, so two worktrees of the same
+ * project contend on the same file locks even though their working directories
+ * are disjoint.
+ */
+const locks = new Map<string, Promise<unknown>>()
+
+/**
+ * Absolute path of the git directory shared by every worktree of a repository.
+ *
+ * Falls back to the resolved input path when git cannot answer (not a
+ * repository, git missing): a wrong key only costs parallelism, never
+ * correctness, whereas throwing here would break every caller.
+ */
+export function resolveGitCommonDir(repoPath: string): string {
+  try {
+    const out = execFileSync('git', ['rev-parse', '--git-common-dir'], {
+      cwd: repoPath,
+      encoding: 'utf-8',
+      timeout: 15_000,
+      env: { ...process.env, GIT_TERMINAL_PROMPT: '0' },
+    }).trim()
+    return path.resolve(repoPath, out)
+  } catch {
+    return path.resolve(repoPath)
+  }
+}
+
+/** Run `fn` with exclusive access to `repoPath`'s shared git directory. */
+export function withGitRepoLock<T>(repoPath: string, fn: () => T | Promise<T>): Promise<T> {
+  const key = resolveGitCommonDir(repoPath)
+  const previous = locks.get(key) ?? Promise.resolve()
+  // The second argument to .then() means: even if the previous operation in the
+  // queue rejected, still run fn — one failure must not block the whole queue.
+  const next = previous.then(fn, fn)
+  locks.set(
+    key,
+    next.then(
+      () => {},
+      () => {},
+    ),
+  )
+  return next
+}
+
+/** Test-only: drop every queued chain so tests don't inherit each other's state. */
+export function _resetGitRepoLocksForTest(): void {
+  locks.clear()
+}

--- a/src/server/utils/script-runner.ts
+++ b/src/server/utils/script-runner.ts
@@ -2,6 +2,7 @@ import { spawn } from 'node:child_process'
 import fs from 'node:fs'
 import path from 'node:path'
 import * as wsService from '../services/websocket-service.js'
+import { getIndexLockPath } from './git-ops.js'
 
 /** Default wall-clock budget for a user script before it is force-killed. */
 export const SCRIPT_TIMEOUT_MS = 5 * 60 * 1000 // 5 minutes
@@ -74,6 +75,16 @@ export function runScript(opts: RunScriptOptions): Promise<{ exitCode: number }>
       wsService.emit(workspaceId, `${eventPrefix}:output`, {
         text: `[kobo] Script timed out after ${Math.round(timeoutMs / 60000)} minutes`,
       })
+      // SIGKILL on the process group gives a running `git commit` no chance to
+      // release its index lock. Name the file here, while the user is looking
+      // at this feed — otherwise the next git write fails with a raw git error
+      // whose cause is three screens above.
+      const lockPath = getIndexLockPath(worktreePath)
+      if (lockPath) {
+        wsService.emit(workspaceId, `${eventPrefix}:output`, {
+          text: `[kobo] A git index lock was left behind at ${lockPath}. Remove it before the next git command: rm -f '${lockPath}'`,
+        })
+      }
     }, timeoutMs)
 
     const ansiPattern = new RegExp(`${String.fromCharCode(27)}\\[[0-9;]*[a-zA-Z]`, 'g')


### PR DESCRIPTION
## Summary
- Removes the AFTER DELETE trigger that re-aggregated a whole session's metrics per deleted row (up to 107s to delete a 20k-event workspace, dropping concurrent sessions' events under the write lock); replaces it with a single application-side recompute per transaction, plus five hot indexes.
- Serializes every write to the common git repository (PR sync, source-branch changes, worktree removal) behind one lock keyed by the resolved common git dir, so two worktrees of the same project can no longer race.
- Adds opt-in event-history retention (0/disabled by default) with a preview + confirmation dialog, stale index-lock detection, label-based stash/backup-branch lookup, and anchored branch-name validation.
- Worktree removal no longer reports success while the directory still exists on disk.

## Test plan
- [x] `make ci` passes locally (install, audit, lint, tsc, backend + client test suites)
- [x] Backend 2367 -> 2390 tests, client unchanged at 710, all green