### PR TITLE
perf(client): stop re-rendering frozen content and racing stale requests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -240,7 +240,7 @@ Sequence: `captureRestoreData` (best-effort forge lookup for PR number / URL / m
 
 ### Bulk workspace info refresh
 
-`GET /api/workspaces/info` returns `{ workspaces, prSnapshots, gitStats }` in one shot. The client polls this endpoint every 30 s so every non-archived workspace stays ≤ 30 s fresh without a per-card stats request. The server-side pr-watcher feeds the same caches (`lastKnownGitStats` map, PR snapshots) so the work is shared between the polling client and the watchdog loop.
+`GET /api/workspaces/info` returns `{ workspaces, prSnapshots, gitStats }` in one shot. The client polls this endpoint every 15 s so every non-archived workspace stays ≤ 15 s fresh without a per-card stats request. The poll is skipped while the browser tab is hidden and fires once immediately when the tab becomes visible again. The server-side pr-watcher feeds the same caches (`lastKnownGitStats` map, PR snapshots) so the work is shared between the polling client and the watchdog loop.
 
 ### File editing in the diff viewer
 

--- a/src/__tests__/routes-git.test.ts
+++ b/src/__tests__/routes-git.test.ts
@@ -6,6 +6,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 vi.mock('../server/utils/git-ops.js', () => ({
   listBranches: vi.fn(),
   listRemoteBranches: vi.fn(),
+  listWorktreeFiles: vi.fn(),
 }))
 
 vi.mock('../server/services/worktree-service.js', () => ({
@@ -81,6 +82,41 @@ describe('GET /api/git/branches', () => {
     const data = await res.json()
     expect(data.local).toEqual([])
     expect(data.remote).toEqual([])
+  })
+})
+
+describe('GET /api/git/files', () => {
+  it('caps the listing at the server maximum when no limit is asked for', async () => {
+    vi.mocked(gitOps.listWorktreeFiles).mockReturnValue(['a.ts', 'b.ts'])
+    const res = await app.request('/api/git/files?path=/tmp/wt')
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ files: ['a.ts', 'b.ts'] })
+    expect(gitOps.listWorktreeFiles).toHaveBeenCalledWith('/tmp/wt', 5000)
+  })
+
+  it('honours a smaller explicit limit', async () => {
+    vi.mocked(gitOps.listWorktreeFiles).mockReturnValue([])
+    await app.request('/api/git/files?path=/tmp/wt&limit=100')
+    expect(gitOps.listWorktreeFiles).toHaveBeenCalledWith('/tmp/wt', 100)
+  })
+
+  it('never lets a caller ask for more than the server maximum', async () => {
+    vi.mocked(gitOps.listWorktreeFiles).mockReturnValue([])
+    await app.request('/api/git/files?path=/tmp/wt&limit=999999')
+    expect(gitOps.listWorktreeFiles).toHaveBeenCalledWith('/tmp/wt', 5000)
+  })
+
+  it('falls back to the maximum on a nonsense limit', async () => {
+    vi.mocked(gitOps.listWorktreeFiles).mockReturnValue([])
+    await app.request('/api/git/files?path=/tmp/wt&limit=-3')
+    expect(gitOps.listWorktreeFiles).toHaveBeenCalledWith('/tmp/wt', 5000)
+    await app.request('/api/git/files?path=/tmp/wt&limit=abc')
+    expect(gitOps.listWorktreeFiles).toHaveBeenLastCalledWith('/tmp/wt', 5000)
+  })
+
+  it('rejects a missing path', async () => {
+    const res = await app.request('/api/git/files')
+    expect(res.status).toBe(400)
   })
 })
 

--- a/src/client/src/__tests__/ActivityFeed.test.ts
+++ b/src/client/src/__tests__/ActivityFeed.test.ts
@@ -20,12 +20,29 @@ const QScrollAreaStub = defineComponent({
         verticalPosition: 0,
         verticalContainerSize: 400,
       }),
+      getScrollTarget: () => document.createElement('div'),
       setScrollPosition: vi.fn(),
       emitScroll: (info: { verticalPosition: number; verticalSize: number; verticalContainerSize: number }) =>
         emit('scroll', info),
     }
     expose(api)
     return () => h('div', { class: 'q-scroll-area-stub' }, slots.default?.())
+  },
+})
+
+const QVirtualScrollStub = defineComponent({
+  name: 'QVirtualScroll',
+  props: { items: { type: Array, default: () => [] } },
+  setup(props, { slots, expose }) {
+    expose({ scrollTo: vi.fn() })
+    // Render everything: virtualisation is a rendering strategy, not a
+    // behaviour this suite asserts on.
+    return () =>
+      h(
+        'div',
+        { class: 'q-virtual-scroll-stub' },
+        props.items.map((item, index) => slots.default?.({ item, index })),
+      )
   },
 })
 
@@ -36,6 +53,7 @@ const globalStubs = {
   'q-spinner-dots': { template: '<span class="q-spinner-dots"></span>' },
   'q-expansion-item': { template: '<div><slot /></div>' },
   'q-scroll-area': QScrollAreaStub,
+  'q-virtual-scroll': QVirtualScrollStub,
 }
 
 describe('ActivityFeed.vue', () => {
@@ -293,5 +311,74 @@ describe('ActivityFeed.vue', () => {
       null,
     ])
     expect(streamStore.sessionIdsFor('ws-1')).toEqual(['sess-1'])
+  })
+
+  it('ignores a second jump-to-previous click while the first is still walking back', async () => {
+    const workspaceStore = useWorkspaceStore()
+    const streamStore = useAgentStreamStore()
+    workspaceStore.selectedWorkspaceId = 'ws-1'
+    workspaceStore.selectedSessionId = null
+    streamStore.reset(
+      'ws-1',
+      [{ kind: 'message:text', messageId: 'm', text: 'only agent output', streaming: false }],
+      ['2026-01-01T00:00:02Z'],
+      { oldestId: 'cursor-1', hasMoreOlder: true, sessionIds: [null], eventIds: ['cursor-1'] },
+    )
+
+    // Every older page comes back empty: the walk keeps asking until the cap.
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      json: async () => ({ events: [], hasMore: true }),
+    } as Response)
+
+    const wrapper = mount(ActivityFeed, {
+      props: { workspaceId: 'ws-1' },
+      global: { plugins: [i18n], stubs: globalStubs },
+    })
+    await vi.advanceTimersByTimeAsync(250)
+    await nextTick()
+    vi.mocked(fetch).mockClear()
+
+    const buttons = wrapper.findAll('button')
+    const upButton = buttons[buttons.length - 1]
+
+    // Two clicks in a row, before the first walk had any chance to finish.
+    const firstClick = upButton.trigger('click')
+    const secondClick = upButton.trigger('click')
+    await Promise.all([firstClick, secondClick])
+    await vi.advanceTimersByTimeAsync(5000)
+    await nextTick()
+
+    const callsFromOneWalk = vi.mocked(fetch).mock.calls.length
+    // A single walk is capped at MAX_ATTEMPTS = 15 pages. Two concurrent walks
+    // would have produced more.
+    expect(callsFromOneWalk).toBeLessThanOrEqual(15)
+  })
+
+  it('renders its turns through the virtual list', async () => {
+    const workspaceStore = useWorkspaceStore()
+    const streamStore = useAgentStreamStore()
+    workspaceStore.selectedWorkspaceId = 'ws-1'
+    workspaceStore.selectedSessionId = null
+    streamStore.reset(
+      'ws-1',
+      [
+        { kind: 'message:text', messageId: 'm1', text: 'one', streaming: false },
+        { kind: 'message:text', messageId: 'm2', text: 'two', streaming: false },
+      ],
+      ['2026-01-01T00:00:01Z', '2026-01-01T00:00:02Z'],
+      { oldestId: 'c1', hasMoreOlder: false, sessionIds: [null, null], eventIds: ['c1', 'c2'] },
+    )
+    vi.mocked(fetch).mockResolvedValue({ ok: true, json: async () => ({ events: [], hasMore: false }) } as Response)
+
+    const wrapper = mount(ActivityFeed, {
+      props: { workspaceId: 'ws-1' },
+      global: { plugins: [i18n], stubs: globalStubs },
+    })
+    await vi.advanceTimersByTimeAsync(250)
+    await nextTick()
+
+    expect(wrapper.find('.q-virtual-scroll-stub').exists()).toBe(true)
+    expect(wrapper.findAll('.turn-card-stub').length).toBeGreaterThan(0)
   })
 })

--- a/src/client/src/__tests__/agent-event-view.test.ts
+++ b/src/client/src/__tests__/agent-event-view.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import {
   type ConversationItem,
   foldEvents,
@@ -262,5 +262,232 @@ describe('mergeWithUserMessages', () => {
     const texts = merged.filter((i) => i.type === 'text') as Array<Extract<ConversationItem, { type: 'text' }>>
     expect(texts.find((t) => t.messageId === 'm1')?.streaming).toBe(false)
     expect(texts.find((t) => t.messageId === 'm2')?.streaming).toBe(true)
+  })
+})
+
+describe('foldEventsCached', () => {
+  it('produces the same items as a full fold when events are appended one by one', async () => {
+    const { createFoldCache, foldEvents, foldEventsCached } = await import('../services/agent-event-view')
+    const events: AgentEvent[] = [
+      { kind: 'message:text', messageId: 'm1', text: 'Hel', streaming: true },
+      { kind: 'message:text', messageId: 'm1', text: 'lo', streaming: true },
+      { kind: 'tool:call', messageId: 'm1', toolCallId: 'tc1', name: 'Bash', input: { command: 'ls' } },
+      { kind: 'tool:result', toolCallId: 'tc1', output: 'a.ts', isError: false },
+      { kind: 'message:end', messageId: 'm1' },
+    ]
+
+    const cache = createFoldCache()
+    for (let i = 1; i <= events.length; i++) {
+      foldEventsCached(cache, events.slice(0, i), undefined, true)
+    }
+
+    expect(foldEventsCached(cache, events, undefined, true)).toEqual(foldEvents(events, undefined, true))
+  })
+
+  it('only folds the newly appended tail', async () => {
+    const { createFoldCache, foldEventsCached } = await import('../services/agent-event-view')
+    const events: AgentEvent[] = [
+      { kind: 'message:text', messageId: 'm1', text: 'one', streaming: false },
+      { kind: 'message:text', messageId: 'm2', text: 'two', streaming: false },
+    ]
+    const cache = createFoldCache()
+    const first = foldEventsCached(cache, events, undefined, true)
+    const firstItem = first[0]
+
+    events.push({ kind: 'message:text', messageId: 'm3', text: 'three', streaming: false })
+    const second = foldEventsCached(cache, events, undefined, true)
+
+    // The item objects of already-folded events are REUSED, not rebuilt — this
+    // is what lets the markdown memo hold on to a frozen message.
+    expect(second[0]).toBe(firstItem)
+    expect(second).toHaveLength(3)
+  })
+
+  it('rebuilds from scratch when older history is prepended', async () => {
+    const { createFoldCache, foldEvents, foldEventsCached } = await import('../services/agent-event-view')
+    const recent: AgentEvent[] = [{ kind: 'message:text', messageId: 'm2', text: 'now', streaming: false }]
+    const cache = createFoldCache()
+    foldEventsCached(cache, recent, undefined, true)
+
+    const withOlder: AgentEvent[] = [
+      { kind: 'message:text', messageId: 'm1', text: 'before', streaming: false },
+      ...recent,
+    ]
+    expect(foldEventsCached(cache, withOlder, undefined, true)).toEqual(foldEvents(withOlder, undefined, true))
+  })
+
+  it('rebuilds from scratch when the stream is replaced by a shorter one', async () => {
+    const { createFoldCache, foldEvents, foldEventsCached } = await import('../services/agent-event-view')
+    const cache = createFoldCache()
+    foldEventsCached(
+      cache,
+      [
+        { kind: 'message:text', messageId: 'a', text: '1', streaming: false },
+        { kind: 'message:text', messageId: 'b', text: '2', streaming: false },
+      ],
+      undefined,
+      true,
+    )
+    const replacement: AgentEvent[] = [{ kind: 'message:text', messageId: 'z', text: 'z', streaming: false }]
+    expect(foldEventsCached(cache, replacement, undefined, true)).toEqual(foldEvents(replacement, undefined, true))
+  })
+
+  it('closes the trailing streaming message when the session goes idle', async () => {
+    const { createFoldCache, foldEventsCached } = await import('../services/agent-event-view')
+    const events: AgentEvent[] = [{ kind: 'message:text', messageId: 'm1', text: 'typing', streaming: true }]
+    const cache = createFoldCache()
+
+    const live = foldEventsCached(cache, events, undefined, true)
+    expect((live[0] as { streaming: boolean }).streaming).toBe(true)
+
+    const idle = foldEventsCached(cache, events, undefined, false)
+    expect((idle[0] as { streaming: boolean }).streaming).toBe(false)
+  })
+
+  // Vue re-renders a child component only when the props it receives change by
+  // REFERENCE. The feed passes each ConversationItem as a prop under a stable
+  // key, so an item mutated in place would keep its reference and freeze the
+  // card forever: text deltas invisible, spinner stuck, tool result missing.
+  // Every update must therefore publish a NEW object.
+  it('publishes a new object reference when a text delta extends an existing item', async () => {
+    const { createFoldCache, foldEventsCached } = await import('../services/agent-event-view')
+    const events: AgentEvent[] = [{ kind: 'message:text', messageId: 'm1', text: 'Hel', streaming: true }]
+    const cache = createFoldCache()
+    const first = foldEventsCached(cache, events, undefined, true)
+    const firstItem = first[0]
+
+    events.push({ kind: 'message:text', messageId: 'm1', text: 'lo', streaming: true })
+    const second = foldEventsCached(cache, events, undefined, true)
+
+    expect(second[0]).not.toBe(firstItem)
+    expect((second[0] as { text: string }).text).toBe('Hello')
+    expect((firstItem as { text: string }).text).toBe('Hel')
+  })
+
+  it('publishes a new object reference when message:end closes a streaming item', async () => {
+    const { createFoldCache, foldEventsCached } = await import('../services/agent-event-view')
+    const events: AgentEvent[] = [{ kind: 'message:text', messageId: 'm1', text: 'hi', streaming: true }]
+    const cache = createFoldCache()
+    const firstItem = foldEventsCached(cache, events, undefined, true)[0]
+
+    events.push({ kind: 'message:end', messageId: 'm1' })
+    const second = foldEventsCached(cache, events, undefined, true)
+
+    expect(second[0]).not.toBe(firstItem)
+    expect((second[0] as { streaming: boolean }).streaming).toBe(false)
+  })
+
+  it('publishes a new object reference when the session goes idle (closeStaleStreamingText)', async () => {
+    const { createFoldCache, foldEventsCached } = await import('../services/agent-event-view')
+    const events: AgentEvent[] = [{ kind: 'message:text', messageId: 'm1', text: 'typing', streaming: true }]
+    const cache = createFoldCache()
+    const liveItem = foldEventsCached(cache, events, undefined, true)[0]
+
+    const idle = foldEventsCached(cache, events, undefined, false)
+
+    expect(idle[0]).not.toBe(liveItem)
+    expect((idle[0] as { streaming: boolean }).streaming).toBe(false)
+
+    // Idempotent: a second idle fold changes nothing, so the reference is kept.
+    expect(foldEventsCached(cache, events, undefined, false)[0]).toBe(idle[0])
+  })
+
+  it('publishes a new object reference when a tool result lands on an existing call', async () => {
+    const { createFoldCache, foldEventsCached } = await import('../services/agent-event-view')
+    const events: AgentEvent[] = [
+      { kind: 'tool:call', messageId: 'm1', toolCallId: 'tc1', name: 'Bash', input: { command: 'ls' } },
+    ]
+    const cache = createFoldCache()
+    const callItem = foldEventsCached(cache, events, undefined, true)[0]
+
+    events.push({ kind: 'tool:result', toolCallId: 'tc1', output: 'a.ts', isError: false })
+    const second = foldEventsCached(cache, events, undefined, true)
+
+    expect(second[0]).not.toBe(callItem)
+    expect((second[0] as { result?: { output: unknown } }).result).toEqual({ output: 'a.ts', isError: false })
+  })
+
+  it('keeps folding text deltas correctly after the item has been replaced', async () => {
+    const { createFoldCache, foldEvents, foldEventsCached } = await import('../services/agent-event-view')
+    const events: AgentEvent[] = [{ kind: 'message:text', messageId: 'm1', text: 'a', streaming: true }]
+    const cache = createFoldCache()
+    // Force a copy-on-write pass (idle close), then keep streaming into it.
+    foldEventsCached(cache, events, undefined, false)
+    events.push({ kind: 'message:text', messageId: 'm1', text: 'b', streaming: true })
+    events.push({ kind: 'message:end', messageId: 'm1' })
+    expect(foldEventsCached(cache, events, undefined, true)).toEqual(foldEvents(events, undefined, true))
+  })
+
+  it('carries timestamps and event ids onto the appended items', async () => {
+    const { createFoldCache, foldEventsCached } = await import('../services/agent-event-view')
+    const cache = createFoldCache()
+    const events: AgentEvent[] = [{ kind: 'message:text', messageId: 'm1', text: 'a', streaming: false }]
+    foldEventsCached(cache, events, ['2026-01-01T00:00:00Z'], true, ['evt-1'])
+
+    events.push({ kind: 'message:text', messageId: 'm2', text: 'b', streaming: false })
+    const items = foldEventsCached(cache, events, ['2026-01-01T00:00:00Z', '2026-01-01T00:00:01Z'], true, [
+      'evt-1',
+      'evt-2',
+    ])
+
+    expect(items[1].ts).toBe('2026-01-01T00:00:01Z')
+    expect(items[1].eventIds).toEqual(['evt-2'])
+  })
+})
+
+describe('mergeWithUserMessages fast path', () => {
+  it('merges two already-sorted lists without calling sort', async () => {
+    const { mergeWithUserMessages } = await import('../services/agent-event-view')
+    const agentItems = [
+      { type: 'text' as const, messageId: 'm1', text: 'a', streaming: false, ts: '2026-01-01T00:00:01Z' },
+      { type: 'text' as const, messageId: 'm2', text: 'b', streaming: false, ts: '2026-01-01T00:00:03Z' },
+    ]
+    const userMessages = [
+      { content: 'u1', sender: 'user', ts: '2026-01-01T00:00:00Z' },
+      { content: 'u2', sender: 'user', ts: '2026-01-01T00:00:02Z' },
+    ]
+
+    const sortSpy = vi.spyOn(Array.prototype, 'sort')
+    const merged = mergeWithUserMessages(agentItems, userMessages)
+    const sorted = sortSpy.mock.calls.length
+    sortSpy.mockRestore()
+
+    expect(merged.map((i) => i.ts)).toEqual([
+      '2026-01-01T00:00:00Z',
+      '2026-01-01T00:00:01Z',
+      '2026-01-01T00:00:02Z',
+      '2026-01-01T00:00:03Z',
+    ])
+    expect(sorted).toBe(0)
+  })
+
+  it('publishes a new object reference for a streaming item closed by a newer user message', async () => {
+    const { mergeWithUserMessages } = await import('../services/agent-event-view')
+    const streaming = {
+      type: 'text' as const,
+      messageId: 'm1',
+      text: 'half',
+      streaming: true,
+      ts: '2026-01-01T00:00:01Z',
+    }
+    const agentItems: ConversationItem[] = [streaming]
+    const merged = mergeWithUserMessages(agentItems, [{ content: 'u1', sender: 'user', ts: '2026-01-01T00:00:02Z' }])
+
+    const closed = merged.find((i) => i.type === 'text')
+    expect(closed).not.toBe(streaming)
+    expect((closed as { streaming: boolean }).streaming).toBe(false)
+    // The source list is realigned too, so the next merge is a no-op and the
+    // reference stays stable afterwards.
+    expect(agentItems[0]).toBe(closed)
+  })
+
+  it('still falls back to a sort when a list is out of order', async () => {
+    const { mergeWithUserMessages } = await import('../services/agent-event-view')
+    const agentItems = [
+      { type: 'text' as const, messageId: 'm2', text: 'b', streaming: false, ts: '2026-01-01T00:00:03Z' },
+      { type: 'text' as const, messageId: 'm1', text: 'a', streaming: false, ts: '2026-01-01T00:00:01Z' },
+    ]
+    const merged = mergeWithUserMessages(agentItems, [{ content: 'u1', sender: 'user', ts: '2026-01-01T00:00:02Z' }])
+    expect(merged.map((i) => i.ts)).toEqual(['2026-01-01T00:00:01Z', '2026-01-01T00:00:02Z', '2026-01-01T00:00:03Z'])
   })
 })

--- a/src/client/src/__tests__/agent-stream-store.test.ts
+++ b/src/client/src/__tests__/agent-stream-store.test.ts
@@ -1,5 +1,5 @@
 import { createPinia, setActivePinia } from 'pinia'
-import { beforeEach, describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 describe('agent-stream store', () => {
   beforeEach(() => setActivePinia(createPinia()))
@@ -43,5 +43,81 @@ describe('agent-stream store', () => {
     expect(store.eventIdsFor('w1')[0]).toBe('event-1')
     expect(store.oldestIdFor('w1')).toBe('event-1')
     expect(store.hasMoreOlderFor('w1')).toBe(true)
+  })
+
+  it('does not bump a workspace version when another workspace receives an event', async () => {
+    const { useAgentStreamStore } = await import('../stores/agent-stream.js')
+    const store = useAgentStreamStore()
+    store.append('w1', { kind: 'message:text', messageId: 'm', text: 'hi', streaming: true })
+
+    const before = store.versionFor('w1')
+    for (let i = 0; i < 50; i++) {
+      store.append('w2', { kind: 'message:text', messageId: 'n', text: '.', streaming: true })
+    }
+
+    // A burst on a background workspace must not invalidate the foreground one:
+    // WorkspaceList subscribes to EVERY workspace, so this happened constantly.
+    expect(store.versionFor('w1')).toBe(before)
+    expect(store.versionFor('w2')).toBeGreaterThan(before)
+  })
+
+  it('never scans the id array to deduplicate an append', async () => {
+    const { useAgentStreamStore } = await import('../stores/agent-stream.js')
+    const store = useAgentStreamStore()
+    for (let i = 0; i < 1000; i++) {
+      store.append('w1', { kind: 'message:end', messageId: `m-${i}` }, undefined, `evt-${i}`)
+    }
+
+    const includesSpy = vi.spyOn(Array.prototype, 'includes')
+    store.append('w1', { kind: 'message:end', messageId: 'm-new' }, undefined, 'evt-new')
+    const scannedForTheNewId = includesSpy.mock.calls.some((call) => call[0] === 'evt-new')
+    includesSpy.mockRestore()
+
+    expect(scannedForTheNewId).toBe(false)
+    expect(store.eventsFor('w1')).toHaveLength(1001)
+  })
+
+  it('still rejects a duplicate event id after a thousand appends', async () => {
+    const { useAgentStreamStore } = await import('../stores/agent-stream.js')
+    const store = useAgentStreamStore()
+    for (let i = 0; i < 1000; i++) {
+      store.append('w1', { kind: 'message:end', messageId: `m-${i}` }, undefined, `evt-${i}`)
+    }
+    store.append('w1', { kind: 'message:end', messageId: 'm-0' }, undefined, 'evt-0')
+    expect(store.eventsFor('w1')).toHaveLength(1000)
+  })
+
+  it('forgets the ids it trimmed so old history can be re-delivered', async () => {
+    const { MAX_LIVE_EVENTS_PER_WORKSPACE, useAgentStreamStore } = await import('../stores/agent-stream.js')
+    const store = useAgentStreamStore()
+    for (let i = 0; i < MAX_LIVE_EVENTS_PER_WORKSPACE + 1; i++) {
+      store.append('w1', { kind: 'message:end', messageId: `m-${i}` }, undefined, `evt-${i}`)
+    }
+    // `evt-0` was trimmed off the front — the index must have dropped it too,
+    // otherwise it could never be re-appended after a reconnect replay.
+    expect(store.eventIdsFor('w1')).not.toContain('evt-0')
+    store.append('w1', { kind: 'message:end', messageId: 'm-0' }, undefined, 'evt-0')
+    expect(store.eventIdsFor('w1')).toContain('evt-0')
+  })
+
+  it('rebuilds the id index on reset so a stale id never blocks a fresh event', async () => {
+    const { useAgentStreamStore } = await import('../stores/agent-stream.js')
+    const store = useAgentStreamStore()
+    store.append('w1', { kind: 'message:end', messageId: 'm-old' }, undefined, 'evt-old')
+    store.reset('w1', [{ kind: 'message:end', messageId: 'm-new' }], ['2026-01-01T00:00:00Z'], {
+      eventIds: ['evt-new'],
+      sessionIds: [null],
+    })
+    store.append('w1', { kind: 'message:end', messageId: 'm-old' }, undefined, 'evt-old')
+    expect(store.eventIdsFor('w1')).toEqual(['evt-new', 'evt-old'])
+  })
+
+  it('drops an id from the index when the event is removed', async () => {
+    const { useAgentStreamStore } = await import('../stores/agent-stream.js')
+    const store = useAgentStreamStore()
+    store.append('w1', { kind: 'message:end', messageId: 'm-1' }, undefined, 'evt-1')
+    store.removeByEventId('w1', 'evt-1')
+    store.append('w1', { kind: 'message:end', messageId: 'm-1' }, undefined, 'evt-1')
+    expect(store.eventIdsFor('w1')).toEqual(['evt-1'])
   })
 })

--- a/src/client/src/__tests__/background-polling.test.ts
+++ b/src/client/src/__tests__/background-polling.test.ts
@@ -1,0 +1,39 @@
+// Assertions on the source, on the model of the plan-0 process-safety-net
+// test. These three behaviours live inside Vue components, which this project
+// does not unit-test; a source assertion is a regression guard against silent
+// re-introduction, not a behavioural test.
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+// vitest runs with cwd = src/client
+const readClient = (relative: string) => readFileSync(join(process.cwd(), relative), 'utf-8')
+const readRepo = (relative: string) => readFileSync(join(process.cwd(), '../..', relative), 'utf-8')
+
+describe('idle cost of an open tab', () => {
+  it('does not pad the activity-feed chunk with an artificial timer', () => {
+    const source = readClient('src/pages/WorkspacePage.vue')
+    expect(source).not.toMatch(/setTimeout\(resolve, 500\)/)
+    expect(source).toMatch(/defineAsyncComponent\(\(\) => import\('src\/components\/ActivityFeed\.vue'\)\)/)
+  })
+
+  it('skips the bulk workspace poll while the tab is hidden, and refreshes on return', () => {
+    const source = readClient('src/components/WorkspaceList.vue')
+    expect(source).toMatch(/document\.visibilityState === 'hidden'/)
+    expect(source).toMatch(/addEventListener\('visibilitychange'/)
+    expect(source).toMatch(/removeEventListener\('visibilitychange'/)
+  })
+
+  it('slows the voice-model poll down and stops swallowing its failures', () => {
+    const source = readClient('src/pages/SettingsPage.vue')
+    expect(source).toMatch(/VOICE_MODELS_POLL_MS = 2500/)
+    expect(source).not.toMatch(/}, 800\)/)
+    expect(source).not.toMatch(/fetchVoiceModels\(\)\.catch\(\(\) => \{\}\)/)
+  })
+
+  it('documents the interval the client actually uses', () => {
+    const agents = readRepo('AGENTS.md')
+    expect(agents).not.toMatch(/polls this endpoint every 30 s/)
+    expect(agents).toMatch(/polls this endpoint every 15 s/)
+  })
+})

--- a/src/client/src/__tests__/build-path-tree.test.ts
+++ b/src/client/src/__tests__/build-path-tree.test.ts
@@ -88,3 +88,32 @@ describe('countLeaves()', () => {
     expect(aFolder?.children ? countLeaves(aFolder.children) : 0).toBe(3)
   })
 })
+
+describe('collectFolderKeys', () => {
+  const files = [{ path: 'src/server/routes/git.ts' }, { path: 'src/client/src/utils/color.ts' }, { path: 'README.md' }]
+
+  it('collects every folder key when no depth is given', async () => {
+    const { buildPathTree, collectFolderKeys } = await import('../utils/build-path-tree')
+    const keys = collectFolderKeys(buildPathTree(files))
+    expect(keys).toContain('dir:src')
+    expect(keys).toContain('dir:src/server')
+    expect(keys).toContain('dir:src/server/routes')
+    expect(keys).toContain('dir:src/client/src/utils')
+    expect(keys).not.toContain('file:README.md')
+  })
+
+  it('stops at the requested depth', async () => {
+    const { buildPathTree, collectFolderKeys } = await import('../utils/build-path-tree')
+    expect(collectFolderKeys(buildPathTree(files), 1)).toEqual(['dir:src'])
+  })
+
+  it('returns an empty list for a flat tree', async () => {
+    const { buildPathTree, collectFolderKeys } = await import('../utils/build-path-tree')
+    expect(collectFolderKeys(buildPathTree([{ path: 'a.ts' }, { path: 'b.ts' }]))).toEqual([])
+  })
+
+  it('returns an empty list for a zero depth', async () => {
+    const { buildPathTree, collectFolderKeys } = await import('../utils/build-path-tree')
+    expect(collectFolderKeys(buildPathTree(files), 0)).toEqual([])
+  })
+})

--- a/src/client/src/__tests__/conversation-turns.test.ts
+++ b/src/client/src/__tests__/conversation-turns.test.ts
@@ -65,3 +65,99 @@ describe('groupIntoTurns', () => {
     expect(turns.map((t) => t.speaker)).toEqual(['system-prompt', 'user'])
   })
 })
+
+describe('itemKey / turnKey', () => {
+  it('keys a text message by its message id, not by its position', async () => {
+    const { itemKey } = await import('../services/conversation-turns')
+    const item = { type: 'text' as const, messageId: 'm-42', text: 'hi', streaming: false }
+    expect(itemKey(item)).toBe('text:m-42')
+  })
+
+  it('keys a tool call by its tool-call id', async () => {
+    const { itemKey } = await import('../services/conversation-turns')
+    const a = { type: 'tool' as const, toolCallId: 'tc-1', name: 'Bash', input: {} }
+    const b = { type: 'tool' as const, toolCallId: 'tc-2', name: 'Bash', input: {} }
+    expect(itemKey(a)).not.toBe(itemKey(b))
+  })
+
+  it('gives a turn the same key before and after older history is prepended', async () => {
+    const { groupIntoTurns, turnKey } = await import('../services/conversation-turns')
+    const recent = { type: 'text' as const, messageId: 'm-recent', text: 'now', streaming: false }
+    // A different speaker than `recent` so groupIntoTurns doesn't merge them
+    // into a single turn — the point here is a *turn* shifting position, not
+    // an item merging with its neighbor.
+    const older = { type: 'user' as const, content: 'before', sender: 'user', eventIds: ['u-older'] }
+
+    const before = groupIntoTurns([recent])
+    const after = groupIntoTurns([older, recent])
+
+    // The recent turn moved from index 0 to index 1 — an index key would have
+    // made Vue rebuild it (and hand its children's local state to the wrong
+    // item). Its data identity, and therefore its key, is unchanged.
+    expect(turnKey(before[0])).toBe(turnKey(after[1]))
+    expect(turnKey(after[0])).not.toBe(turnKey(after[1]))
+  })
+
+  it('never collides between a user message and an agent message', async () => {
+    const { itemKey } = await import('../services/conversation-turns')
+    const user = { type: 'user' as const, content: 'x', sender: 'user', ts: '2026-01-01T00:00:00Z' }
+    const agent = { type: 'text' as const, messageId: '2026-01-01T00:00:00Z', text: 'x', streaming: false }
+    expect(itemKey(user)).not.toBe(itemKey(agent))
+  })
+
+  it('distinguishes two thinking blocks that share a message id', async () => {
+    const { itemKey } = await import('../services/conversation-turns')
+    const a = { type: 'thinking' as const, messageId: 'm-1', text: 'a', eventIds: ['evt-1'] }
+    const b = { type: 'thinking' as const, messageId: 'm-1', text: 'b', eventIds: ['evt-2'] }
+    expect(itemKey(a)).not.toBe(itemKey(b))
+  })
+
+  it('produces unique keys across a whole grouped conversation', async () => {
+    const { groupIntoTurns, turnKey } = await import('../services/conversation-turns')
+    const turns = groupIntoTurns([
+      { type: 'user', content: 'go', sender: 'user', ts: '2026-01-01T00:00:00Z', eventIds: ['u-1'] },
+      { type: 'text', messageId: 'm-1', text: 'ok', streaming: false, ts: '2026-01-01T00:00:01Z' },
+      { type: 'tool', toolCallId: 'tc-1', name: 'Bash', input: {}, ts: '2026-01-01T00:00:02Z' },
+      { type: 'user', content: 'again', sender: 'user', ts: '2026-01-01T00:00:03Z', eventIds: ['u-2'] },
+      { type: 'text', messageId: 'm-2', text: 'done', streaming: false, ts: '2026-01-01T00:00:04Z' },
+    ])
+    const keys = turns.map(turnKey)
+    expect(new Set(keys).size).toBe(keys.length)
+  })
+})
+
+describe('findPreviousUserTurnIndex', () => {
+  const turns = [
+    { speaker: 'user' },
+    { speaker: 'agent' },
+    { speaker: 'agent' },
+    { speaker: 'user' },
+    { speaker: 'agent' },
+  ]
+
+  it('finds the last user turn strictly before the current position', async () => {
+    const { findPreviousUserTurnIndex } = await import('../services/conversation-turns')
+    expect(findPreviousUserTurnIndex(turns, 4)).toBe(3)
+    expect(findPreviousUserTurnIndex(turns, 3)).toBe(0)
+    expect(findPreviousUserTurnIndex(turns, 2)).toBe(0)
+  })
+
+  it('returns -1 when no user turn precedes the position', async () => {
+    const { findPreviousUserTurnIndex } = await import('../services/conversation-turns')
+    expect(findPreviousUserTurnIndex(turns, 0)).toBe(-1)
+    expect(findPreviousUserTurnIndex([{ speaker: 'agent' }], 1)).toBe(-1)
+  })
+
+  it('handles an empty list and an out-of-range position', async () => {
+    const { findPreviousUserTurnIndex } = await import('../services/conversation-turns')
+    expect(findPreviousUserTurnIndex([], 0)).toBe(-1)
+    expect(findPreviousUserTurnIndex(turns, 999)).toBe(3)
+    expect(findPreviousUserTurnIndex(turns, -1)).toBe(-1)
+  })
+
+  it('ignores script and session turns', async () => {
+    const { findPreviousUserTurnIndex } = await import('../services/conversation-turns')
+    const mixed = [{ speaker: 'user' }, { speaker: 'script' }, { speaker: 'session' }, { speaker: 'agent' }]
+    expect(findPreviousUserTurnIndex(mixed, 3)).toBe(0)
+  })
+})

--- a/src/client/src/__tests__/form-fields-equal.test.ts
+++ b/src/client/src/__tests__/form-fields-equal.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it, vi } from 'vitest'
+
+describe('formFieldsEqual', () => {
+  it('returns true for two identical flat forms', async () => {
+    const { formFieldsEqual } = await import('../utils/form-fields-equal')
+    expect(formFieldsEqual({ a: 1, b: 'x', c: true }, { a: 1, b: 'x', c: true })).toBe(true)
+  })
+
+  it('returns false as soon as one primitive differs', async () => {
+    const { formFieldsEqual } = await import('../utils/form-fields-equal')
+    expect(formFieldsEqual({ a: 1, b: 'x' }, { a: 1, b: 'y' })).toBe(false)
+  })
+
+  it('treats null and undefined as distinct from empty string', async () => {
+    const { formFieldsEqual } = await import('../utils/form-fields-equal')
+    expect(formFieldsEqual({ a: null }, { a: '' })).toBe(false)
+    expect(formFieldsEqual({ a: null }, { a: null })).toBe(true)
+    expect(formFieldsEqual({ a: undefined }, { a: undefined })).toBe(true)
+  })
+
+  it('compares arrays element by element, order included', async () => {
+    const { formFieldsEqual } = await import('../utils/form-fields-equal')
+    expect(formFieldsEqual({ tags: ['a', 'b'] }, { tags: ['a', 'b'] })).toBe(true)
+    expect(formFieldsEqual({ tags: ['a', 'b'] }, { tags: ['b', 'a'] })).toBe(false)
+    expect(formFieldsEqual({ tags: ['a'] }, { tags: ['a', 'b'] })).toBe(false)
+  })
+
+  it('compares nested plain objects', async () => {
+    const { formFieldsEqual } = await import('../utils/form-fields-equal')
+    expect(formFieldsEqual({ m: { x: 1 } }, { m: { x: 1 } })).toBe(true)
+    expect(formFieldsEqual({ m: { x: 1 } }, { m: { x: 2 } })).toBe(false)
+    expect(formFieldsEqual({ m: { x: 1 } }, { m: { x: 1, y: 2 } })).toBe(false)
+  })
+
+  it('detects a key present on one side only', async () => {
+    const { formFieldsEqual } = await import('../utils/form-fields-equal')
+    expect(formFieldsEqual({ a: 1 }, { a: 1, b: 2 })).toBe(false)
+    expect(formFieldsEqual({ a: 1, b: 2 }, { a: 1 })).toBe(false)
+  })
+
+  it('never serialises a multi-kilobyte script field', async () => {
+    const { formFieldsEqual } = await import('../utils/form-fields-equal')
+    const script = 'echo hello\n'.repeat(500)
+    const stringify = vi.spyOn(JSON, 'stringify')
+    // Same string reference on both sides: a `===` is enough, no serialisation.
+    expect(formFieldsEqual({ setupScript: script }, { setupScript: script })).toBe(true)
+    expect(stringify).not.toHaveBeenCalled()
+    stringify.mockRestore()
+  })
+
+  it('short-circuits on the first differing field', async () => {
+    const { formFieldsEqual } = await import('../utils/form-fields-equal')
+    let touched = 0
+    const probe = {
+      get value() {
+        touched++
+        return 1
+      },
+    }
+    const a = { first: 'x', second: probe }
+    const b = { first: 'y', second: probe }
+    expect(formFieldsEqual(a, b)).toBe(false)
+    // `second` must never have been reached: the walk stopped at `first`.
+    expect(touched).toBe(0)
+  })
+})
+
+describe('captureFormSnapshot', () => {
+  it('detaches arrays from the live form so an in-place push is still detected', async () => {
+    const { captureFormSnapshot } = await import('../utils/form-snapshot')
+    const { formFieldsEqual } = await import('../utils/form-fields-equal')
+    const tags = ['a']
+    const live = { tags }
+
+    const saved = captureFormSnapshot(live)
+    tags.push('b')
+
+    expect(saved.tags).toEqual(['a'])
+    expect(formFieldsEqual(live, saved)).toBe(false)
+  })
+
+  it('detaches nested objects so a v-model on a nested field is still detected', async () => {
+    const { captureFormSnapshot } = await import('../utils/form-snapshot')
+    const { formFieldsEqual } = await import('../utils/form-fields-equal')
+    const live = { devServer: { startCommand: 'npm run dev' }, e2e: { framework: 'playwright' } }
+
+    const saved = captureFormSnapshot(live)
+    live.devServer.startCommand = 'pnpm dev'
+
+    expect((saved.devServer as { startCommand: string }).startCommand).toBe('npm run dev')
+    expect(formFieldsEqual(live, saved)).toBe(false)
+  })
+
+  it('keeps an untouched form equal to its snapshot', async () => {
+    const { captureFormSnapshot } = await import('../utils/form-snapshot')
+    const { formFieldsEqual } = await import('../utils/form-fields-equal')
+    const live = { tags: ['a'], nested: { n: 1 }, flag: true, empty: null, missing: undefined }
+    expect(formFieldsEqual(live, captureFormSnapshot(live))).toBe(true)
+  })
+})
+
+describe('captureFormSnapshot on Vue reactive state', () => {
+  // The settings form holds `reactive()` / `ref()` state, so the values reaching
+  // the snapshot are Proxy objects. `structuredClone` REFUSES to clone a Proxy
+  // ("DataCloneError: #<Object> could not be cloned"), which took the whole
+  // Settings page down at setup() time.
+  it('clones a reactive form without throwing, and detaches it', async () => {
+    const { reactive } = await import('vue')
+    const { captureFormSnapshot } = await import('../utils/form-snapshot')
+    const { formFieldsEqual } = await import('../utils/form-fields-equal')
+    const form = reactive({ tags: ['a'], devServer: { startCommand: 'npm run dev' } })
+
+    const saved = captureFormSnapshot({ ...form })
+    form.tags.push('b')
+    form.devServer.startCommand = 'pnpm dev'
+
+    expect(saved.tags).toEqual(['a'])
+    expect((saved.devServer as { startCommand: string }).startCommand).toBe('npm run dev')
+    expect(formFieldsEqual({ ...form }, saved)).toBe(false)
+  })
+})

--- a/src/client/src/__tests__/fuzzy-match.test.ts
+++ b/src/client/src/__tests__/fuzzy-match.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { fuzzyMatch, fuzzyRank } from '../utils/fuzzy-match'
 
 describe('fuzzyMatch', () => {
@@ -47,5 +47,58 @@ describe('fuzzyRank', () => {
   it('returns every item for an empty query', () => {
     const items = ['a.ts', 'b.ts']
     expect(fuzzyRank('', items)).toHaveLength(2)
+  })
+})
+
+describe('fuzzyRankTop', () => {
+  const corpus = [
+    'src/server/routes/git.ts',
+    'src/client/src/utils/fuzzy-match.ts',
+    'src/client/src/components/GitPanel.vue',
+    'docs/git.md',
+    'README.md',
+    'src/__tests__/routes-git.test.ts',
+  ]
+
+  it('returns exactly what fuzzyRank would return, truncated', async () => {
+    const { fuzzyRank, fuzzyRankTop } = await import('../utils/fuzzy-match')
+    for (const query of ['git', 'gt', 'srcgit', 'md', '']) {
+      expect(fuzzyRankTop(query, corpus, 3)).toEqual(fuzzyRank(query, corpus).slice(0, 3))
+    }
+  })
+
+  it('keeps the earlier item on a score tie, like the stable sort did', async () => {
+    const { fuzzyRank, fuzzyRankTop } = await import('../utils/fuzzy-match')
+    const ties = ['aa/x.ts', 'bb/x.ts', 'cc/x.ts']
+    expect(fuzzyRankTop('x', ties, 2)).toEqual(fuzzyRank('x', ties).slice(0, 2))
+  })
+
+  it('scores every item exactly once — a single pass, no sort', async () => {
+    const { fuzzyMatch, fuzzyRankTop } = await import('../utils/fuzzy-match')
+    const items = Array.from({ length: 5000 }, (_, i) => `src/pkg/module-${i}/index.ts`)
+    const score = vi.fn(fuzzyMatch)
+
+    fuzzyRankTop('index', items, 50, score)
+
+    // The old path scored every item, wrapped each one in an object, then
+    // sorted the whole list before slicing fifty. One call per item and no
+    // second traversal is the whole point.
+    expect(score).toHaveBeenCalledTimes(items.length)
+  })
+
+  it('never returns more than the limit', async () => {
+    const { fuzzyRankTop } = await import('../utils/fuzzy-match')
+    const items = Array.from({ length: 200 }, (_, i) => `file-${i}.ts`)
+    expect(fuzzyRankTop('file', items, 50)).toHaveLength(50)
+  })
+
+  it('returns an empty list for a non-zero corpus and a zero limit', async () => {
+    const { fuzzyRankTop } = await import('../utils/fuzzy-match')
+    expect(fuzzyRankTop('a', ['abc'], 0)).toEqual([])
+  })
+
+  it('drops non-matching items', async () => {
+    const { fuzzyRankTop } = await import('../utils/fuzzy-match')
+    expect(fuzzyRankTop('zzz', corpus, 10)).toEqual([])
   })
 })

--- a/src/client/src/__tests__/heavy-chunks.test.ts
+++ b/src/client/src/__tests__/heavy-chunks.test.ts
@@ -1,0 +1,49 @@
+// Source assertions: what matters here is what the bundler is ASKED to emit,
+// which is a property of the import statements, not of runtime behaviour.
+// A `?worker` import emits its own chunk whether or not the code runs.
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const readClient = (relative: string) => readFileSync(join(process.cwd(), relative), 'utf-8')
+
+describe('DiffViewer monaco footprint', () => {
+  const source = readClient('src/components/DiffViewer.vue')
+
+  it('imports the base editor worker and nothing else', () => {
+    const workerImports = source.match(/^import .*\?worker'$/gm) ?? []
+    expect(workerImports).toEqual(["import EditorWorker from 'monaco-editor/editor/editor.worker.js?worker'"])
+  })
+
+  it('hands the base worker to every label', () => {
+    expect(source).toMatch(/getWorker: \(\) => new EditorWorker\(\)/)
+  })
+
+  it('turns off every worker-backed language service', () => {
+    expect(source).toMatch(/disableWorkerBackedLanguageServices\(monaco\)/)
+    for (const defaults of [
+      'typescriptDefaults',
+      'javascriptDefaults',
+      'cssDefaults',
+      'scssDefaults',
+      'lessDefaults',
+      'jsonDefaults',
+      'htmlDefaults',
+      'handlebarDefaults',
+      'razorDefaults',
+    ]) {
+      expect(source).toContain(`${defaults}.setModeConfiguration(NO_LANGUAGE_PROVIDERS)`)
+    }
+  })
+})
+
+describe('MainLayout panel footprint', () => {
+  const source = readClient('src/layouts/MainLayout.vue')
+
+  it('loads the four heavy panels on demand', () => {
+    for (const panel of ['GitPanel', 'TerminalPanel', 'DocumentsPanel', 'SchedulePanel']) {
+      expect(source).not.toMatch(new RegExp(`^import ${panel} from`, 'm'))
+      expect(source).toContain(`const ${panel} = defineAsyncComponent(() => import('src/components/${panel}.vue'))`)
+    }
+  })
+})

--- a/src/client/src/__tests__/inline-diff.test.ts
+++ b/src/client/src/__tests__/inline-diff.test.ts
@@ -123,3 +123,71 @@ describe('parseUnifiedDiff — deleted lines that look like a file header', () =
     ])
   })
 })
+
+describe('computeInlineDiff() bounds', () => {
+  it('exposes a line cap', async () => {
+    const { INLINE_DIFF_MAX_LINES } = await import('../services/inline-diff')
+    expect(INLINE_DIFF_MAX_LINES).toBe(800)
+  })
+
+  it('keeps the common prefix and suffix as context around a small edit', async () => {
+    const { computeInlineDiff } = await import('../services/inline-diff')
+    const before = ['a', 'b', 'OLD', 'c', 'd'].join('\n')
+    const after = ['a', 'b', 'NEW', 'c', 'd'].join('\n')
+    expect(computeInlineDiff(before, after)).toEqual([
+      { type: 'context', content: 'a' },
+      { type: 'context', content: 'b' },
+      { type: 'del', content: 'OLD' },
+      { type: 'add', content: 'NEW' },
+      { type: 'context', content: 'c' },
+      { type: 'context', content: 'd' },
+    ])
+  })
+
+  it('degrades to a flat del/add block past the cap instead of allocating a huge table', async () => {
+    const { INLINE_DIFF_MAX_LINES, computeInlineDiff } = await import('../services/inline-diff')
+    const n = INLINE_DIFF_MAX_LINES + 10
+    const before = ['header', ...Array.from({ length: n }, (_, i) => `old-${i}`), 'footer'].join('\n')
+    const after = ['header', ...Array.from({ length: n }, (_, i) => `new-${i}`), 'footer'].join('\n')
+
+    const lines = computeInlineDiff(before, after)
+
+    // The trimmed prefix and suffix survive; the middle is not LCS-matched.
+    expect(lines[0]).toEqual({ type: 'context', content: 'header' })
+    expect(lines[lines.length - 1]).toEqual({ type: 'context', content: 'footer' })
+    expect(lines.filter((l) => l.type === 'del')).toHaveLength(n)
+    expect(lines.filter((l) => l.type === 'add')).toHaveLength(n)
+    // Every deletion comes before every addition — no interleaving.
+    const firstAdd = lines.findIndex((l) => l.type === 'add')
+    const lastDel = lines.map((l) => l.type).lastIndexOf('del')
+    expect(lastDel).toBeLessThan(firstAdd)
+  })
+
+  it('still uses the LCS walk when only the changed middle is small', async () => {
+    const { INLINE_DIFF_MAX_LINES, computeInlineDiff } = await import('../services/inline-diff')
+    // A two-thousand-line file with a one-line change: after trimming, the
+    // middle is a single line, far under the cap.
+    const shared = Array.from({ length: INLINE_DIFF_MAX_LINES * 2 }, (_, i) => `line-${i}`)
+    const before = [...shared, 'OLD', ...shared].join('\n')
+    const after = [...shared, 'NEW', ...shared].join('\n')
+
+    const lines = computeInlineDiff(before, after)
+
+    expect(lines.filter((l) => l.type === 'del')).toEqual([{ type: 'del', content: 'OLD' }])
+    expect(lines.filter((l) => l.type === 'add')).toEqual([{ type: 'add', content: 'NEW' }])
+  })
+
+  it('handles a pure append and a pure truncation', async () => {
+    const { computeInlineDiff } = await import('../services/inline-diff')
+    expect(computeInlineDiff('a\nb', 'a\nb\nc')).toEqual([
+      { type: 'context', content: 'a' },
+      { type: 'context', content: 'b' },
+      { type: 'add', content: 'c' },
+    ])
+    expect(computeInlineDiff('a\nb\nc', 'a\nb')).toEqual([
+      { type: 'context', content: 'a' },
+      { type: 'context', content: 'b' },
+      { type: 'del', content: 'c' },
+    ])
+  })
+})

--- a/src/client/src/__tests__/latest-request.test.ts
+++ b/src/client/src/__tests__/latest-request.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest'
+
+describe('createLatestRequest', () => {
+  it('aborts the previous request when a new one begins', async () => {
+    const { createLatestRequest } = await import('../utils/latest-request')
+    const guard = createLatestRequest()
+
+    const first = guard.begin()
+    expect(first.aborted).toBe(false)
+
+    const second = guard.begin()
+    // Three quick clicks in the diff tree used to leave three requests in
+    // flight; whichever landed last won, regardless of what was asked for.
+    expect(first.aborted).toBe(true)
+    expect(second.aborted).toBe(false)
+  })
+
+  it('only recognises the newest signal as current', async () => {
+    const { createLatestRequest } = await import('../utils/latest-request')
+    const guard = createLatestRequest()
+    const first = guard.begin()
+    const second = guard.begin()
+    expect(guard.isCurrent(first)).toBe(false)
+    expect(guard.isCurrent(second)).toBe(true)
+  })
+
+  it('stops recognising any signal once aborted', async () => {
+    const { createLatestRequest } = await import('../utils/latest-request')
+    const guard = createLatestRequest()
+    const signal = guard.begin()
+    guard.abort()
+    expect(signal.aborted).toBe(true)
+    expect(guard.isCurrent(signal)).toBe(false)
+  })
+
+  it('is a no-op when aborting before any request', async () => {
+    const { createLatestRequest } = await import('../utils/latest-request')
+    const guard = createLatestRequest()
+    expect(() => guard.abort()).not.toThrow()
+  })
+})
+
+describe('isAbortError', () => {
+  it('recognises the DOMException produced by aborting a fetch', async () => {
+    const { isAbortError } = await import('../utils/latest-request')
+    expect(isAbortError(new DOMException('aborted', 'AbortError'))).toBe(true)
+  })
+
+  it('does not swallow a real failure', async () => {
+    const { isAbortError } = await import('../utils/latest-request')
+    expect(isAbortError(new Error('HTTP 500'))).toBe(false)
+    expect(isAbortError(null)).toBe(false)
+    expect(isAbortError('boom')).toBe(false)
+  })
+})

--- a/src/client/src/__tests__/raf-coalesce.test.ts
+++ b/src/client/src/__tests__/raf-coalesce.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it, vi } from 'vitest'
+
+/** Deterministic stand-in for requestAnimationFrame. */
+function manualScheduler() {
+  const queued: Array<() => void> = []
+  return {
+    schedule: (cb: () => void) => queued.push(cb),
+    cancel: (id: number) => queued.splice(id - 1, 1),
+    flush: () => {
+      const pending = queued.splice(0, queued.length)
+      for (const cb of pending) cb()
+    },
+    get size() {
+      return queued.length
+    },
+  }
+}
+
+describe('coalesceFrames', () => {
+  it('collapses a burst of requests into a single call', async () => {
+    const { coalesceFrames } = await import('../utils/raf-coalesce')
+    const scheduler = manualScheduler()
+    const fn = vi.fn()
+    const coalescer = coalesceFrames(fn, scheduler.schedule, scheduler.cancel)
+
+    // Monaco fires onDidScrollChange once per frame while dragging; the naive
+    // handler mutated one reactive field per comment zone on every one.
+    for (let i = 0; i < 20; i++) coalescer.request()
+    expect(fn).not.toHaveBeenCalled()
+
+    scheduler.flush()
+    expect(fn).toHaveBeenCalledTimes(1)
+  })
+
+  it('accepts a new request after the frame ran', async () => {
+    const { coalesceFrames } = await import('../utils/raf-coalesce')
+    const scheduler = manualScheduler()
+    const fn = vi.fn()
+    const coalescer = coalesceFrames(fn, scheduler.schedule, scheduler.cancel)
+
+    coalescer.request()
+    scheduler.flush()
+    coalescer.request()
+    scheduler.flush()
+
+    expect(fn).toHaveBeenCalledTimes(2)
+  })
+
+  it('cancel drops the pending frame', async () => {
+    const { coalesceFrames } = await import('../utils/raf-coalesce')
+    const scheduler = manualScheduler()
+    const fn = vi.fn()
+    const coalescer = coalesceFrames(fn, scheduler.schedule, scheduler.cancel)
+
+    coalescer.request()
+    coalescer.cancel()
+    scheduler.flush()
+
+    expect(fn).not.toHaveBeenCalled()
+  })
+
+  it('cancel is a no-op when nothing is pending', async () => {
+    const { coalesceFrames } = await import('../utils/raf-coalesce')
+    const scheduler = manualScheduler()
+    const coalescer = coalesceFrames(vi.fn(), scheduler.schedule, scheduler.cancel)
+    expect(() => coalescer.cancel()).not.toThrow()
+  })
+})

--- a/src/client/src/__tests__/render-chat-markdown.test.ts
+++ b/src/client/src/__tests__/render-chat-markdown.test.ts
@@ -6,7 +6,7 @@
 // negatives for the sanitization assertions below. jsdom is the reference DOM
 // DOMPurify is built against and matches real-browser behaviour, so this one
 // file opts into it. Production is unaffected (real browser DOM).
-import { describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 describe('renderChatMarkdown', () => {
   it('forces target=_blank and rel attrs on absolute http(s) links', async () => {
@@ -40,5 +40,97 @@ describe('renderChatMarkdown', () => {
       addAttr: ['data-document-path'],
     })
     expect(html).toContain('data-document-path="docs/x.md"')
+  })
+})
+
+describe('renderChatMarkdownCached', () => {
+  beforeEach(async () => {
+    const { resetChatMarkdownCache } = await import('../utils/render-chat-markdown')
+    resetChatMarkdownCache()
+  })
+
+  it('renders a frozen message only once, however many times it is asked for', async () => {
+    const { renderChatMarkdownCached } = await import('../utils/render-chat-markdown')
+    const render = vi.fn((raw: string) => `<p>${raw}</p>`)
+
+    const first = renderChatMarkdownCached('msg-1', 'hello world', render)
+    const second = renderChatMarkdownCached('msg-1', 'hello world', render)
+    const third = renderChatMarkdownCached('msg-1', 'hello world', render)
+
+    expect(first).toBe('<p>hello world</p>')
+    expect(second).toBe(first)
+    expect(third).toBe(first)
+    // The whole point: folding recreates the item object on every token, but
+    // the conversion must not run again for a message that has not changed.
+    expect(render).toHaveBeenCalledTimes(1)
+  })
+
+  it('re-renders when the message grows by one token', async () => {
+    const { renderChatMarkdownCached } = await import('../utils/render-chat-markdown')
+    const render = vi.fn((raw: string) => `<p>${raw}</p>`)
+
+    renderChatMarkdownCached('msg-1', 'hel', render)
+    const grown = renderChatMarkdownCached('msg-1', 'hello', render)
+
+    expect(grown).toBe('<p>hello</p>')
+    expect(render).toHaveBeenCalledTimes(2)
+  })
+
+  it('never returns one message content for another of the same length', async () => {
+    const { renderChatMarkdownCached } = await import('../utils/render-chat-markdown')
+    const render = vi.fn((raw: string) => `<p>${raw}</p>`)
+
+    const a = renderChatMarkdownCached('msg-a', 'aaaaa', render)
+    const b = renderChatMarkdownCached('msg-b', 'bbbbb', render)
+
+    expect(a).toBe('<p>aaaaa</p>')
+    expect(b).toBe('<p>bbbbb</p>')
+    expect(render).toHaveBeenCalledTimes(2)
+  })
+
+  it('keeps the cache bounded by evicting the oldest entry', async () => {
+    const { RENDER_CACHE_LIMIT, renderChatMarkdownCached } = await import('../utils/render-chat-markdown')
+    const render = vi.fn((raw: string) => `<p>${raw}</p>`)
+
+    for (let i = 0; i < RENDER_CACHE_LIMIT + 1; i++) {
+      renderChatMarkdownCached(`msg-${i}`, `body-${i}`, render)
+    }
+    const callsAfterFill = render.mock.calls.length
+
+    // The very first key must have been evicted → it renders again.
+    renderChatMarkdownCached('msg-0', 'body-0', render)
+    expect(render.mock.calls.length).toBe(callsAfterFill + 1)
+
+    // The most recent key is still cached → it does not render again.
+    renderChatMarkdownCached(`msg-${RENDER_CACHE_LIMIT}`, `body-${RENDER_CACHE_LIMIT}`, render)
+    expect(render.mock.calls.length).toBe(callsAfterFill + 1)
+  })
+
+  it('falls back to the real markdown renderer when no renderer is supplied', async () => {
+    const { renderChatMarkdownCached } = await import('../utils/render-chat-markdown')
+    const html = renderChatMarkdownCached('msg-default', '**bold**')
+    expect(html).toContain('<strong>bold</strong>')
+  })
+})
+
+describe('escapeStreamingText', () => {
+  it('escapes HTML so a half-written message can never inject markup', async () => {
+    const { escapeStreamingText } = await import('../utils/render-chat-markdown')
+    expect(escapeStreamingText('<img src=x onerror=alert(1)>')).toBe('&lt;img src=x onerror=alert(1)&gt;')
+  })
+
+  it('escapes ampersands before anything else', async () => {
+    const { escapeStreamingText } = await import('../utils/render-chat-markdown')
+    expect(escapeStreamingText('a & <b>')).toBe('a &amp; &lt;b&gt;')
+  })
+
+  it('turns newlines into line breaks', async () => {
+    const { escapeStreamingText } = await import('../utils/render-chat-markdown')
+    expect(escapeStreamingText('one\ntwo')).toBe('one<br>two')
+  })
+
+  it('leaves an unterminated code fence alone instead of parsing it', async () => {
+    const { escapeStreamingText } = await import('../utils/render-chat-markdown')
+    expect(escapeStreamingText('```ts\nconst a = 1')).toBe('```ts<br>const a = 1')
   })
 })

--- a/src/client/src/__tests__/review-comment-counts.test.ts
+++ b/src/client/src/__tests__/review-comment-counts.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it, vi } from 'vitest'
+
+describe('countCommentsByPath', () => {
+  it('counts comments per file', async () => {
+    const { countCommentsByPath } = await import('../utils/review-comment-counts')
+    const { byFile } = countCommentsByPath([
+      { filePath: 'src/a.ts' },
+      { filePath: 'src/a.ts' },
+      { filePath: 'src/b.ts' },
+    ])
+    expect(byFile.get('src/a.ts')).toBe(2)
+    expect(byFile.get('src/b.ts')).toBe(1)
+  })
+
+  it('counts comments on every ancestor folder', async () => {
+    const { countCommentsByPath } = await import('../utils/review-comment-counts')
+    const { byFolder } = countCommentsByPath([{ filePath: 'src/server/routes/git.ts' }])
+    expect(byFolder.get('src')).toBe(1)
+    expect(byFolder.get('src/server')).toBe(1)
+    expect(byFolder.get('src/server/routes')).toBe(1)
+    // The file itself is not a folder.
+    expect(byFolder.get('src/server/routes/git.ts')).toBeUndefined()
+  })
+
+  it('adds up sibling files under a shared ancestor', async () => {
+    const { countCommentsByPath } = await import('../utils/review-comment-counts')
+    const { byFolder } = countCommentsByPath([
+      { filePath: 'src/a/x.ts' },
+      { filePath: 'src/b/y.ts' },
+      { filePath: 'src/b/z.ts' },
+    ])
+    expect(byFolder.get('src')).toBe(3)
+    expect(byFolder.get('src/a')).toBe(1)
+    expect(byFolder.get('src/b')).toBe(2)
+  })
+
+  it('handles a root-level file with no folder at all', async () => {
+    const { countCommentsByPath } = await import('../utils/review-comment-counts')
+    const { byFile, byFolder } = countCommentsByPath([{ filePath: 'README.md' }])
+    expect(byFile.get('README.md')).toBe(1)
+    expect(byFolder.size).toBe(0)
+  })
+
+  it('walks each comment exactly once, whatever the tree depth', async () => {
+    const { countCommentsByPath } = await import('../utils/review-comment-counts')
+    const comments = Array.from({ length: 500 }, (_, i) => ({ filePath: `src/pkg/mod-${i}/file.ts` }))
+    const spy = vi.spyOn(String.prototype, 'split')
+    countCommentsByPath(comments)
+    const calls = spy.mock.calls.length
+    spy.mockRestore()
+    // One split per comment. The old code re-scanned the entire comment list
+    // once per folder node, twice per render.
+    expect(calls).toBe(comments.length)
+  })
+
+  it('returns empty maps for an empty list', async () => {
+    const { countCommentsByPath } = await import('../utils/review-comment-counts')
+    const { byFile, byFolder } = countCommentsByPath([])
+    expect(byFile.size).toBe(0)
+    expect(byFolder.size).toBe(0)
+  })
+})

--- a/src/client/src/__tests__/wait-for.test.ts
+++ b/src/client/src/__tests__/wait-for.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { nextTick, ref } from 'vue'
+
+describe('waitForCondition', () => {
+  beforeEach(() => vi.useFakeTimers())
+  afterEach(() => vi.useRealTimers())
+
+  it('resolves immediately when the condition already holds', async () => {
+    const { waitForCondition } = await import('../utils/wait-for')
+    const source = ref(5)
+    await expect(waitForCondition(source, (v) => v > 0, 1000)).resolves.toBe(true)
+  })
+
+  it('resolves as soon as the value changes, without waiting for a poll tick', async () => {
+    const { waitForCondition } = await import('../utils/wait-for')
+    const source = ref(0)
+    const settled = vi.fn()
+    const promise = waitForCondition(source, (v) => v > 0, 5000).then(settled)
+
+    expect(settled).not.toHaveBeenCalled()
+    source.value = 1
+    await nextTick()
+    await promise
+    // No timer had to fire: the old busy loop woke up fifty times a second and
+    // could not react faster than its own interval.
+    expect(settled).toHaveBeenCalledWith(true)
+  })
+
+  it('resolves false when the timeout expires', async () => {
+    const { waitForCondition } = await import('../utils/wait-for')
+    const source = ref(0)
+    const promise = waitForCondition(source, (v) => v > 0, 1000)
+    await vi.advanceTimersByTimeAsync(1000)
+    await expect(promise).resolves.toBe(false)
+  })
+
+  it('stops watching once resolved', async () => {
+    const { waitForCondition } = await import('../utils/wait-for')
+    const source = ref(0)
+    const predicate = vi.fn((v: number) => v > 0)
+    const promise = waitForCondition(source, predicate, 5000)
+    source.value = 1
+    await nextTick()
+    await promise
+    const callsAtResolution = predicate.mock.calls.length
+
+    source.value = 2
+    await nextTick()
+    source.value = 3
+    await nextTick()
+
+    expect(predicate.mock.calls.length).toBe(callsAtResolution)
+  })
+
+  it('clears its timer once resolved so no stray callback fires', async () => {
+    const { waitForCondition } = await import('../utils/wait-for')
+    const source = ref(0)
+    const promise = waitForCondition(source, (v) => v > 0, 1000)
+    source.value = 1
+    await nextTick()
+    await expect(promise).resolves.toBe(true)
+    // If the timeout were still armed, advancing past it would be the moment
+    // a stray `finish(false)` callback could fire. It must resolve cleanly
+    // instead of throwing (vitest 4's advanceTimersByTimeAsync resolves with
+    // a fluent `vi` reference rather than `undefined`, hence not asserting
+    // the resolved value itself).
+    await expect(vi.advanceTimersByTimeAsync(2000)).resolves.not.toThrow()
+  })
+
+  it('accepts a getter as the source', async () => {
+    const { waitForCondition } = await import('../utils/wait-for')
+    const source = ref('pending')
+    const promise = waitForCondition(
+      () => source.value,
+      (v) => v === 'done',
+      5000,
+    )
+    source.value = 'done'
+    await nextTick()
+    await expect(promise).resolves.toBe(true)
+  })
+})

--- a/src/client/src/components/ActivityFeed.vue
+++ b/src/client/src/components/ActivityFeed.vue
@@ -16,29 +16,34 @@
       </div>
     </transition>
     <q-scroll-area ref="scrollRef" class="activity-feed-scroll" @scroll="onScroll">
-      <!-- Zero-height origin marker — always at scroll position 0 within the
-           scroll content. Used to compute accurate card Y coordinates
-           without depending on Quasar's internal DOM. -->
-      <div ref="contentOriginRef" class="content-origin-marker" />
       <div v-if="loadingOlder" class="text-center q-py-sm text-caption text-grey-6">
         <q-spinner size="sm" /> {{ $t('activity.loading_older') }}
       </div>
-      <div class="q-pa-md">
-        <TurnCard
-          v-for="(turn, i) in turns"
-          :key="i"
-          ref="turnRefs"
-          :turn="turn"
-          :highlighted="turn.items.some((item) => item.eventIds?.includes(highlightedEventId ?? '') ?? false)"
-          @scroll-to="onTurnScrollTo"
-        />
-        <!-- Un workspace neuf n'a rien à montrer : le dire, plutôt que de
-             laisser une zone vide qui ressemble à une panne. -->
-        <div v-if="turns.length === 0 && rawLines.length === 0 && !loadingOlder" class="activity-feed-empty">
-          <q-icon name="forum" size="28px" />
-          <div class="activity-feed-empty__title">{{ $t('activity.empty') }}</div>
-          <div class="activity-feed-empty__hint">{{ $t('activity.emptyHint') }}</div>
-        </div>
+      <q-virtual-scroll
+        ref="virtualScrollRef"
+        class="q-pa-md"
+        :items="turns"
+        :scroll-target="scrollTargetEl ?? undefined"
+        :virtual-scroll-item-size="160"
+        :virtual-scroll-slice-size="20"
+        @virtual-scroll="onVirtualScroll"
+      >
+        <template #default="{ item: turn, index }: { item: Turn; index: number }">
+          <TurnCard
+            :key="turnKey(turn)"
+            :turn="turn"
+            :data-turn-index="index"
+            :highlighted="turn.items.some((i) => i.eventIds?.includes(highlightedEventId ?? '') ?? false)"
+            @scroll-to="onTurnScrollTo"
+          />
+        </template>
+      </q-virtual-scroll>
+      <!-- Un workspace neuf n'a rien à montrer : le dire, plutôt que de
+           laisser une zone vide qui ressemble à une panne. -->
+      <div v-if="turns.length === 0 && rawLines.length === 0 && !loadingOlder" class="activity-feed-empty q-pa-md">
+        <q-icon name="forum" size="28px" />
+        <div class="activity-feed-empty__title">{{ $t('activity.empty') }}</div>
+        <div class="activity-feed-empty__hint">{{ $t('activity.emptyHint') }}</div>
       </div>
       <div v-if="rawLines.length" class="q-px-md q-pb-md">
         <q-expansion-item :label="$t('activity.raw_lines', { n: rawLines.length })" dense>
@@ -72,6 +77,8 @@
         size="sm"
         class="activity-feed-nav-btn"
         :title="$t('activity.prev_user_message')"
+        :loading="navigatingUp"
+        :disable="navigatingUp"
         @click="goToPreviousUserMessage"
       />
     </div>
@@ -80,12 +87,19 @@
 
 <script setup lang="ts">
 import type { QScrollArea } from 'quasar'
-import { foldEvents, isNormalSessionEnd, mergeWithUserMessages, type UserMessage } from 'src/services/agent-event-view'
-import { groupIntoTurns } from 'src/services/conversation-turns'
+import {
+  createFoldCache,
+  foldEventsCached,
+  isNormalSessionEnd,
+  mergeWithUserMessages,
+  type UserMessage,
+} from 'src/services/agent-event-view'
+import { findPreviousUserTurnIndex, groupIntoTurns, type Turn, turnKey } from 'src/services/conversation-turns'
 import { useAgentStreamStore } from 'src/stores/agent-stream'
 import { useSettingsStore } from 'src/stores/settings'
 import { useWorkspaceStore } from 'src/stores/workspace'
 import type { AgentEvent } from 'src/types/agent-event'
+import { waitForCondition } from 'src/utils/wait-for'
 import { isBusyStatus } from 'src/utils/workspace-status'
 import { computed, nextTick, onMounted, onUnmounted, ref, watch } from 'vue'
 import TurnCard from './TurnCard.vue'
@@ -147,6 +161,12 @@ const sessionActive = computed(() => {
   return isBusyStatus(ws?.status)
 })
 
+// One resumable fold state per (workspace, session) view. Re-created whenever
+// the view changes; foldEventsCached also invalidates it on its own whenever
+// the stream is not a pure append.
+let foldCache = createFoldCache()
+let foldCacheKey = ''
+
 const turns = computed(() => {
   // Filter the stream's parallel arrays (events / timestamps / sessionIds) by
   // the currently selected session BEFORE folding. Without this, session #1's
@@ -165,7 +185,12 @@ const turns = computed(() => {
       filteredIds.push(allIds[i] ?? null)
     }
   }
-  const agentItems = foldEvents(filteredEvents, filteredTs, sessionActive.value, filteredIds)
+  const viewKey = `${props.workspaceId}::${selectedSessionId.value ?? '*'}`
+  if (viewKey !== foldCacheKey) {
+    foldCache = createFoldCache()
+    foldCacheKey = viewKey
+  }
+  const agentItems = foldEventsCached(foldCache, filteredEvents, filteredTs, sessionActive.value, filteredIds)
   const merged = mergeWithUserMessages(agentItems, userMessages.value)
   const filtered = merged.filter((item) => {
     if (item.type === 'thinking') return false
@@ -223,7 +248,7 @@ function onScroll(info: ScrollInfo) {
   if (!initialScrollDone) return
 
   if (info.verticalPosition <= FETCH_MORE_THRESHOLD_PX && !loadingOlder.value && currentHasMoreOlder()) {
-    void loadOlder()
+    void loadOlderOnce()
   }
 }
 
@@ -265,6 +290,19 @@ function oldestVisibleEventId(workspaceId: string): string | undefined {
 const MIN_LOADER_MS = 200
 const COOLDOWN_AFTER_PREPEND_MS = 400
 const WORKSPACE_SWITCH_SPINNER_MS = 200
+
+// One load at a time, and the in-flight promise is shareable: callers that
+// need to wait for it can `await` instead of polling `loadingOlder` every
+// fifty milliseconds.
+let inFlightLoadOlder: Promise<void> | null = null
+
+function loadOlderOnce(): Promise<void> {
+  if (inFlightLoadOlder) return inFlightLoadOlder
+  inFlightLoadOlder = loadOlder().finally(() => {
+    inFlightLoadOlder = null
+  })
+  return inFlightLoadOlder
+}
 
 async function loadOlder(): Promise<void> {
   const workspaceId = props.workspaceId
@@ -477,22 +515,19 @@ async function focusHistoryEvent(event: Event): Promise<void> {
     // switch spinner. Wait until the scroll area is mounted, then let the
     // session/filter watchers render the focused window before resolving the
     // corresponding TurnCard template ref.
-    const deadline = Date.now() + 5000
-    while (switching.value && Date.now() < deadline) {
-      await new Promise((resolve) => window.setTimeout(resolve, 20))
-    }
+    // Wake on the actual state change, not fifty times a second for 5 s.
+    await waitForCondition(switching, (isSwitching) => !isSwitching, 5000)
     await nextTick()
     await new Promise<void>((resolve) => requestAnimationFrame(() => requestAnimationFrame(() => resolve())))
     const turnIndex = turns.value.findIndex((turn) =>
       turn.items.some((item) => item.eventIds?.includes(detail.eventId!) ?? false),
     )
-    const card = turnRefs.value[turnIndex]?.$el as HTMLElement | undefined
-    const area = scrollRef.value
-    const origin = contentOriginRef.value
-    if (!card || !area || !origin) return
-    const y = card.getBoundingClientRect().top - origin.getBoundingClientRect().top
+    if (turnIndex < 0) return
     highlightedEventId.value = detail.eventId
-    area.setScrollPosition('vertical', Math.max(0, y - 16), 250)
+    // Index-based: the target card may not be in the DOM at all until the
+    // virtual list scrolls to it.
+    virtualScrollRef.value?.scrollTo(turnIndex, 'center')
+    firstVisibleTurnIndex.value = turnIndex
     window.setTimeout(() => {
       if (highlightedEventId.value === detail.eventId) highlightedEventId.value = null
     }, 1800)
@@ -501,90 +536,61 @@ async function focusHistoryEvent(event: Event): Promise<void> {
   }
 }
 
-// Collected via Vue template refs on <TurnCard v-for … ref="turnRefs">.
-// Parallel to `turns.value` — same index, same length.
-const turnRefs = ref<Array<{ $el: HTMLElement } | null>>([])
+// Handle on the virtual list, used to scroll by index instead of by pixel.
+const virtualScrollRef = ref<{ scrollTo(index: number, edge?: 'start' | 'center' | 'end'): void } | null>(null)
+// The QScrollArea's inner scrollable element — QVirtualScroll needs an
+// explicit scroll target when it does not own its own scroller.
+const scrollTargetEl = ref<Element | null>(null)
+// First turn index currently in view, fed by QVirtualScroll's own event.
+const firstVisibleTurnIndex = ref(0)
 
-// Zero-height marker rendered at the very top of the scroll content.
-// Its viewport Y gives us a stable "origin" for Y coords inside the
-// content, independent of q-scroll-area's internal DOM structure and
-// whatever transform strategy it uses.
-const contentOriginRef = ref<HTMLElement | null>(null)
-
-// Resolve the list of <user turn> DOM elements in DOM order. Prefers
-// template refs (typed, in sync with `turns`); falls back to querying
-// the `.turn-card--user` class if refs haven't populated yet.
-function collectUserTurnElements(): HTMLElement[] {
-  const turnList = turns.value
-  const refList = turnRefs.value
-  const result: HTMLElement[] = []
-  if (refList.length === turnList.length) {
-    for (let i = 0; i < turnList.length; i++) {
-      if (turnList[i].speaker !== 'user') continue
-      const instance = refList[i]
-      const el = instance?.$el as HTMLElement | undefined
-      if (el) result.push(el)
-    }
-    if (result.length > 0) return result
-  }
-  // Fallback path — direct DOM selector on the content origin's parent
-  // (the scroll content). Covers the first-click-before-refs-populate case.
-  const origin = contentOriginRef.value
-  const host = origin?.parentElement
-  if (host) {
-    const cards = host.querySelectorAll<HTMLElement>('.turn-card--user')
-    for (const c of cards) result.push(c)
-  }
-  return result
+function onVirtualScroll(details: { index: number }): void {
+  firstVisibleTurnIndex.value = details.index
 }
 
-// Find the absolute Y (relative to the content origin marker) of the last
-// user turn card whose top sits strictly *above* the current scroll
-// position. Returns null if no such card exists in the currently-rendered
-// DOM.
-function findPreviousUserTurnY(): number | null {
-  const area = scrollRef.value
-  if (!area) return null
-  const origin = contentOriginRef.value
-  if (!origin) return null
-  const currentPos = area.getScroll().verticalPosition
-  const originTop = origin.getBoundingClientRect().top
-  // Margin so a user card pinned at the top doesn't count as "previous".
-  const margin = 40
-  let bestY: number | null = null
-  for (const el of collectUserTurnElements()) {
-    // cardY = distance from the content-origin marker (at scroll-pos 0)
-    //       = el.top - origin.top in viewport coords.
-    // Since both move together with the scroll, their difference stays
-    // equal to the card's position in the content.
-    const cardY = el.getBoundingClientRect().top - originTop
-    if (cardY < currentPos - margin) bestY = cardY
-    else break
-  }
-  return bestY
-}
+// True while a "jump to previous user message" is walking back through the
+// history. Drives the button's disabled + loading state, and blocks reentrant
+// clicks: three impatient clicks used to start three concurrent walks fighting
+// over the same `loadingOlder` flag.
+const navigatingUp = ref(false)
 
 async function goToPreviousUserMessage(): Promise<void> {
-  const area = scrollRef.value
-  if (!area) return
-  let targetY = findPreviousUserTurnY()
-  // Long workspaces may open with 300 recent agent events and *zero* user
-  // turns in the current DOM (agent dominates the tail of the stream).
-  // Keep fetching older batches until a user turn appears, we run out of
-  // history, or we hit a safety cap (≈15 * 200 = 3000 events back).
-  if (targetY === null) {
-    const MAX_ATTEMPTS = 15
-    for (let i = 0; i < MAX_ATTEMPTS; i++) {
-      if (!currentHasMoreOlder()) break
-      while (loadingOlder.value) await new Promise((r) => setTimeout(r, 50))
-      await loadOlder()
-      await nextTick()
-      targetY = findPreviousUserTurnY()
-      if (targetY !== null) break
+  if (navigatingUp.value) return
+  navigatingUp.value = true
+  // The walk spans several awaits (history fetches). `props.workspaceId` is
+  // reactive: if the user switches workspace mid-walk, every step after the
+  // switch would keep walking — on the NEW workspace — fetching its history
+  // and yanking its scroll position. Pin the workspace the walk started on and
+  // bail out as soon as it no longer matches, exactly as if the component had
+  // been torn down.
+  const walkWorkspaceId = props.workspaceId
+  try {
+    let target = findPreviousUserTurnIndex(turns.value, firstVisibleTurnIndex.value)
+    // Long workspaces may open with 300 recent agent events and *zero* user
+    // turns loaded. Keep fetching older batches until a user turn appears, we
+    // run out of history, or we hit a safety cap (≈15 * 200 = 3000 events).
+    if (target < 0) {
+      const MAX_ATTEMPTS = 15
+      for (let i = 0; i < MAX_ATTEMPTS; i++) {
+        if (walkWorkspaceId !== props.workspaceId) return
+        if (!currentHasMoreOlder()) break
+        const before = turns.value.length
+        await loadOlderOnce()
+        await nextTick()
+        if (walkWorkspaceId !== props.workspaceId) return
+        // Older turns are prepended, so the current position shifts down by
+        // however many turns were added.
+        firstVisibleTurnIndex.value += turns.value.length - before
+        target = findPreviousUserTurnIndex(turns.value, firstVisibleTurnIndex.value)
+        if (target >= 0) break
+      }
     }
-  }
-  if (targetY !== null) {
-    area.setScrollPosition('vertical', Math.max(0, targetY - 12), 250)
+    if (target >= 0 && walkWorkspaceId === props.workspaceId) {
+      virtualScrollRef.value?.scrollTo(target, 'start')
+      firstVisibleTurnIndex.value = target
+    }
+  } finally {
+    navigatingUp.value = false
   }
 }
 
@@ -638,10 +644,10 @@ async function showSwitchingSpinner() {
   switching.value = true
   const startedAt = Date.now()
   await new Promise((r) => setTimeout(r, WORKSPACE_SWITCH_SPINNER_MS))
-  const deadline = startedAt + EMPTY_FEED_GRACE_MS
-  while (rawEventCount.value === 0 && Date.now() < deadline) {
-    await new Promise((r) => setTimeout(r, 50))
-  }
+  // Wait for the sync:response to land, capped — the remaining budget after
+  // the minimum spinner display.
+  const remaining = Math.max(0, startedAt + EMPTY_FEED_GRACE_MS - Date.now())
+  await waitForCondition(rawEventCount, (count) => count > 0, remaining)
   switching.value = false
 }
 
@@ -657,10 +663,23 @@ watch(switching, async (isSwitching) => {
   if (!isSwitching && eventCount.value === 0 && selectedSessionId.value) {
     void fetchSessionIfMissing()
   }
+  // QVirtualScroll needs the QScrollArea's inner scroller; the q-scroll-area
+  // is remounted every time the spinner reappears/disappears (v-if), so its
+  // scroll target must be re-resolved on the same transition.
+  if (!isSwitching) {
+    void nextTick(() => {
+      scrollTargetEl.value = scrollRef.value?.getScrollTarget() ?? null
+    })
+  }
 })
 
 onMounted(() => {
   window.addEventListener('kobo:focus-history-event', focusHistoryEvent)
+  // QVirtualScroll needs the QScrollArea's inner scroller; it only exists once
+  // the scroll area is mounted.
+  void nextTick(() => {
+    scrollTargetEl.value = scrollRef.value?.getScrollTarget() ?? null
+  })
   void showSwitchingSpinner()
   if (eventCount.value > 0) void armInitialScroll()
   // Fire the session-scoped fetch in parallel with sync:response, not after
@@ -860,13 +879,6 @@ async function handleScrollToBottomClick() {
 }
 .activity-feed-nav-btn:hover {
   opacity: 1;
-}
-.content-origin-marker {
-  height: 0;
-  width: 0;
-  margin: 0;
-  padding: 0;
-  pointer-events: none;
 }
 /* Kill any horizontal overflow from long file paths, long words in code
    blocks, or oversized bash commands. We only want vertical scrolling. */

--- a/src/client/src/components/DiffViewer.vue
+++ b/src/client/src/components/DiffViewer.vue
@@ -275,7 +275,7 @@
           children-key="children"
           dark
           dense
-          default-expand-all
+          v-model:expanded="expandedNodes"
           no-selection-unset
           :selected="selectedNodeKey"
           :filter="fileFilter"
@@ -519,19 +519,18 @@
 
 <script setup lang="ts">
 import EditorWorker from 'monaco-editor/editor/editor.worker.js?worker'
-import CssWorker from 'monaco-editor/language/css/css.worker.js?worker'
-import HtmlWorker from 'monaco-editor/language/html/html.worker.js?worker'
-import JsonWorker from 'monaco-editor/language/json/json.worker.js?worker'
-import TypeScriptWorker from 'monaco-editor/language/typescript/ts.worker.js?worker'
 import { useQuasar } from 'quasar'
 import { useIsMobile } from 'src/composables/use-is-mobile'
 import { type ReviewComment, useReviewDraft } from 'src/composables/use-review-draft'
 import { useWebSocketStore } from 'src/stores/websocket'
 import { useWorkspaceStore } from 'src/stores/workspace'
 import { ApiError, apiFetch } from 'src/utils/api'
-import { buildPathTree, countLeaves, type PathTreeNode } from 'src/utils/build-path-tree'
+import { buildPathTree, collectFolderKeys, countLeaves, type PathTreeNode } from 'src/utils/build-path-tree'
+import { createLatestRequest, isAbortError } from 'src/utils/latest-request'
 import { monacoLanguageForPath } from 'src/utils/monaco-language'
 import { takePendingDiffOpen } from 'src/utils/pending-diff-open'
+import { coalesceFrames } from 'src/utils/raf-coalesce'
+import { countCommentsByPath } from 'src/utils/review-comment-counts'
 import { registerUnsavedScope, unregisterUnsavedScope } from 'src/utils/unsaved-guard'
 import { isBusyStatus } from 'src/utils/workspace-status'
 import { computed, nextTick, onMounted, onUnmounted, ref, watch } from 'vue'
@@ -577,6 +576,10 @@ const loadingFile = ref(false)
 const fileLoadError = ref<string | null>(null)
 /** Failure of the file-list request itself, told apart from "no changes". */
 const fileListError = ref<string | null>(null)
+// Two independent single-flight guards: selecting a file must not cancel the
+// file-list refresh, and vice-versa.
+const filesRequest = createLatestRequest()
+const fileDiffRequest = createLatestRequest()
 const editorContainer = ref<HTMLElement | null>(null)
 const viewMode = ref<'side' | 'inline'>('side')
 // Compact mode: collapse unchanged regions in the Monaco diff editor so the
@@ -692,23 +695,18 @@ async function onSubmitReview() {
   }
 }
 
-// Per-file comment count (computed reactively from the draft state).
-const commentsByFile = computed(() => {
-  const m = new Map<string, number>()
-  if (reviewMode.value !== 'review') return m
-  for (const c of reviewDraft.draft.value.comments) {
-    m.set(c.filePath, (m.get(c.filePath) ?? 0) + 1)
-  }
-  return m
-})
+// Per-file AND per-folder comment counts, computed once per draft change
+// instead of re-scanning the comment list for every folder node, twice per
+// render, on every scroll frame.
+const commentCounts = computed(() =>
+  countCommentsByPath(reviewMode.value === 'review' ? reviewDraft.draft.value.comments : []),
+)
+
+const commentsByFile = computed(() => commentCounts.value.byFile)
 
 function commentCountForFolder(folderPath: string): number {
-  if (reviewMode.value !== 'review' || !folderPath) return 0
-  let count = 0
-  for (const c of reviewDraft.draft.value.comments) {
-    if (c.filePath.startsWith(`${folderPath}/`)) count++
-  }
-  return count
+  if (!folderPath) return 0
+  return commentCounts.value.byFolder.get(folderPath) ?? 0
 }
 
 // Folder nodes have nodeKey `dir:src/components`. Derive the relative folder
@@ -766,6 +764,72 @@ function startFileListResize(event: MouseEvent) {
   document.addEventListener('mouseup', onMouseUp)
 }
 
+/**
+ * Every boolean provider flag of the four worker-backed language services.
+ * `dataProviders` (html) is deliberately absent: it is not a boolean.
+ * Unspecified fields become undefined — falsy — so a single object safely
+ * covers services whose ModeConfiguration shapes differ.
+ */
+const NO_LANGUAGE_PROVIDERS = {
+  codeActions: false,
+  colors: false,
+  completionItems: false,
+  definitions: false,
+  diagnostics: false,
+  documentFormattingEdits: false,
+  documentHighlights: false,
+  documentRangeFormattingEdits: false,
+  documentSymbols: false,
+  foldingRanges: false,
+  hovers: false,
+  inlayHints: false,
+  links: false,
+  onTypeFormattingEdits: false,
+  references: false,
+  rename: false,
+  selectionRanges: false,
+  signatureHelp: false,
+  tokens: false,
+} as const
+
+/**
+ * `import('monaco-editor')` resolves to esm/vs/index.js, which registers four
+ * worker-backed language services (typescript, css, html, json). Each hooks
+ * `languages.onLanguage(<id>)` and, when a model of that language is created,
+ * registers providers that ask MonacoEnvironment.getWorker for their OWN
+ * worker. We ship only the base worker — 274 kB instead of ~12 MB — so every
+ * provider must be off, otherwise the base worker would be handed a protocol
+ * it does not implement.
+ *
+ * A diff viewer needs none of them: it renders a diff and allows a plain edit
+ * saved through POST /save-file. Syntax colouring comes from
+ * languages/definitions/* (Monarch, main thread) and is unaffected.
+ *
+ * Note the accessors: in the ESM build these services are TOP-LEVEL exports
+ * (`monaco.typescript`, `monaco.css`, …), not `monaco.languages.*` as in the
+ * global build's monaco.d.ts.
+ */
+function disableWorkerBackedLanguageServices(m: typeof import('monaco-editor')): void {
+  const noDiagnostics = {
+    noSemanticValidation: true,
+    noSyntaxValidation: true,
+    noSuggestionDiagnostics: true,
+  }
+  m.typescript.typescriptDefaults.setDiagnosticsOptions(noDiagnostics)
+  m.typescript.javascriptDefaults.setDiagnosticsOptions(noDiagnostics)
+  m.typescript.typescriptDefaults.setEagerModelSync(false)
+  m.typescript.javascriptDefaults.setEagerModelSync(false)
+  m.typescript.typescriptDefaults.setModeConfiguration(NO_LANGUAGE_PROVIDERS)
+  m.typescript.javascriptDefaults.setModeConfiguration(NO_LANGUAGE_PROVIDERS)
+  m.css.cssDefaults.setModeConfiguration(NO_LANGUAGE_PROVIDERS)
+  m.css.scssDefaults.setModeConfiguration(NO_LANGUAGE_PROVIDERS)
+  m.css.lessDefaults.setModeConfiguration(NO_LANGUAGE_PROVIDERS)
+  m.json.jsonDefaults.setModeConfiguration(NO_LANGUAGE_PROVIDERS)
+  m.html.htmlDefaults.setModeConfiguration(NO_LANGUAGE_PROVIDERS)
+  m.html.handlebarDefaults.setModeConfiguration(NO_LANGUAGE_PROVIDERS)
+  m.html.razorDefaults.setModeConfiguration(NO_LANGUAGE_PROVIDERS)
+}
+
 // Monaco instances (lazy loaded)
 let monaco: typeof import('monaco-editor') | null = null
 let diffEditor: import('monaco-editor').editor.IStandaloneDiffEditor | null = null
@@ -799,16 +863,24 @@ const editorWrapperRef = ref<HTMLElement | null>(null)
 function refreshZonePositions() {
   if (!diffEditor) return
   const me = diffEditor.getModifiedEditor()
+  const scrollTop = me.getScrollTop()
   for (const z of mountedZones.value) {
     // `getTopForLineNumber(N)` accounts for view zones inserted before N,
     // so for our placeholder inserted `afterLineNumber: zone.line` we want
     // the position of `zone.line + 1` (the line BELOW the zone) MINUS the
     // zone height, which gives us the top of the placeholder itself.
-    z.topPx = me.getTopForLineNumber(z.line + 1) - me.getScrollTop() - z.heightPx
+    const top = me.getTopForLineNumber(z.line + 1) - scrollTop - z.heightPx
+    // Skip the write when nothing moved: mutating a deeply reactive object
+    // triggers a full re-render even when the value is identical.
+    if (z.topPx !== top) z.topPx = top
   }
 }
 
+// One position pass per animation frame, not one per scroll event.
+const zonePositionRefresh = coalesceFrames(refreshZonePositions)
+
 function disposeAllZones() {
+  zonePositionRefresh.cancel()
   if (!diffEditor) {
     mountedZones.value = []
     return
@@ -932,9 +1004,10 @@ function setupGutterAddButton() {
       if (line < 1 || !selectedFile.value) return
       addCommentOnLine(selectedFile.value, line)
     }),
-    // Keep overlay positions in sync with editor scroll + relayout.
-    modifiedEditor.onDidScrollChange(() => refreshZonePositions()),
-    modifiedEditor.onDidLayoutChange(() => refreshZonePositions()),
+    // Keep overlay positions in sync with editor scroll + relayout, at most
+    // once per animation frame.
+    modifiedEditor.onDidScrollChange(() => zonePositionRefresh.request()),
+    modifiedEditor.onDidLayoutChange(() => zonePositionRefresh.request()),
   )
 }
 
@@ -1072,6 +1145,23 @@ watch(isDrawerCollapsed, (collapsed) => {
 const tree = computed(() => buildPathTree(files.value))
 const selectedNodeKey = computed(() => (selectedFile.value ? `file:${selectedFile.value}` : ''))
 
+/** Above this many files, expanding the whole tree costs more than it helps. */
+const AUTO_EXPAND_FILE_LIMIT = 200
+
+const expandedNodes = ref<string[]>([])
+
+// Recompute the initial expansion whenever the file list changes: everything
+// open on a small diff, first level only on a large one. The user's manual
+// expansions afterwards are preserved by v-model.
+watch(
+  tree,
+  (nodes) => {
+    expandedNodes.value =
+      files.value.length <= AUTO_EXPAND_FILE_LIMIT ? collectFolderKeys(nodes) : collectFolderKeys(nodes, 1)
+  },
+  { immediate: true },
+)
+
 // ── File tree search ─────────────────────────────────────────────────────────
 
 const fileFilter = ref('')
@@ -1101,15 +1191,22 @@ async function loadFiles() {
     if (!isCommitsMode.value && diffMode.value === 'branch' && includeUntracked.value) {
       params.set('includeUntracked', '1')
     }
+    const signal = filesRequest.begin()
     const data = await apiFetch<{ files: DiffFile[]; sourceBranch?: string; workingBranch?: string }>(
       `/api/workspaces/${props.workspaceId}/diff?${params}`,
-      { cache: 'no-store' },
+      { cache: 'no-store', signal },
     )
+    // A response that is no longer the current one must never touch the view:
+    // the fetch may have resolved just before a newer call aborted it.
+    if (!filesRequest.isCurrent(signal)) return
     files.value = data.files
     sourceBranch.value = data.sourceBranch ?? ''
     workingBranch.value = data.workingBranch ?? ''
     fileListError.value = null
   } catch (err) {
+    // A cancelled request is the expected outcome of a fast second call, not
+    // a failure worth logging or surfacing in the file-list error state.
+    if (isAbortError(err)) return
     // This used to be a bare `console.error`, in the very component whose job
     // is to show failures: the tree simply stayed empty and the user read it
     // as "no changes". Record the failure; never clear `files`.
@@ -1137,25 +1234,15 @@ async function loadFileDiff(filePath: string) {
     fileLoadError.value = null
 
     if (!monaco) {
-      // Configure Monaco workers per language for proper syntax support
-      self.MonacoEnvironment = {
-        getWorker(_workerId: string, label: string) {
-          if (label === 'json') {
-            return new JsonWorker()
-          }
-          if (label === 'css' || label === 'scss' || label === 'less') {
-            return new CssWorker()
-          }
-          if (label === 'html' || label === 'handlebars' || label === 'razor') {
-            return new HtmlWorker()
-          }
-          if (label === 'typescript' || label === 'javascript') {
-            return new TypeScriptWorker()
-          }
-          return new EditorWorker()
-        },
-      }
+      // The base worker computes the diff, resolves links and does basic
+      // tokenisation — everything this viewer actually needs. The four
+      // language-service workers (TypeScript 6.6 MB, its secondary API 3.5 MB,
+      // CSS 1.1 MB, HTML 704 kB, JSON 401 kB) served diagnostics and
+      // IntelliSense that this read-mostly view never surfaced, yet Vite
+      // emitted their bundles unconditionally.
+      self.MonacoEnvironment = { getWorker: () => new EditorWorker() }
       monaco = await import('monaco-editor')
+      disableWorkerBackedLanguageServices(monaco)
       monaco.editor.defineTheme('kobo-dark', {
         base: 'vs-dark',
         inherit: true,
@@ -1171,10 +1258,15 @@ async function loadFileDiff(filePath: string) {
     const fileQuery = isCommitsMode.value
       ? `path=${encodeURIComponent(filePath)}&mode=commits&from=${encodeURIComponent(props.compareFrom!)}&to=${encodeURIComponent(props.compareTo!)}`
       : `path=${encodeURIComponent(filePath)}&mode=${diffMode.value}`
+    const signal = fileDiffRequest.begin()
     const data = await apiFetch<{ original?: string; modified?: string; modifiedSha?: string }>(
       `/api/workspaces/${props.workspaceId}/diff-file?${fileQuery}`,
-      { cache: 'no-store' },
+      { cache: 'no-store', signal },
     )
+    // Bail out BEFORE building the new editor: a superseded response must
+    // leave the view — and the baseSha/baseContent snapshot that the save
+    // path relies on — exactly as the newest request left it.
+    if (!fileDiffRequest.isCurrent(signal)) return
 
     const language = monacoLanguageForPath(filePath)
 
@@ -1228,6 +1320,9 @@ async function loadFileDiff(filePath: string) {
       renderCommentZonesForFile(filePath)
     }
   } catch (err) {
+    // A cancelled request is the expected outcome of a fast second click, not
+    // a failure worth surfacing in the inline error state.
+    if (isAbortError(err)) return
     const message = err instanceof Error ? err.message : String(err)
     fileLoadError.value = message
     console.error('Failed to load file diff:', err)
@@ -1714,6 +1809,8 @@ onUnmounted(() => {
   // editor and (in Review mode) view zones / mounted Vue apps.
   reviewDraft.flush() // before disposeEditor in case the user closed mid-edit
   disposeEditor()
+  filesRequest.abort()
+  fileDiffRequest.abort()
   unregisterUnsavedScope('diff:file')
 })
 </script>

--- a/src/client/src/components/TurnCard.vue
+++ b/src/client/src/components/TurnCard.vue
@@ -21,7 +21,7 @@
       </span>
     </div>
     <div class="turn-body">
-      <template v-for="(item, i) in turn.items" :key="i">
+      <template v-for="item in turn.items" :key="itemKey(item)">
         <TextMessageItem v-if="item.type === 'text'" :item="item" />
         <ThinkingItem v-else-if="item.type === 'thinking'" :item="item" />
         <ToolCallItem v-else-if="item.type === 'tool'" :item="item" />
@@ -52,7 +52,7 @@
 </template>
 
 <script setup lang="ts">
-import type { Turn } from 'src/services/conversation-turns'
+import { itemKey, type Turn } from 'src/services/conversation-turns'
 import { computed, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 import AgentErrorItem from './items/AgentErrorItem.vue'

--- a/src/client/src/components/WorkspaceList.vue
+++ b/src/client/src/components/WorkspaceList.vue
@@ -1353,6 +1353,22 @@ function goToChangelog() {
   router.push({ name: 'changelog' })
 }
 
+const WORKSPACE_INFO_POLL_MS = 15_000
+
+function pollWorkspacesInfoIfVisible(): void {
+  // A hidden tab has nobody to inform. Skipping the request also stops the
+  // server-side git-stats refresh from running for every tab left open
+  // overnight.
+  if (document.visibilityState === 'hidden') return
+  void store.fetchWorkspacesInfo()
+}
+
+function onVisibilityChange(): void {
+  // Coming back to the tab: refresh straight away instead of showing stale
+  // data for up to WORKSPACE_INFO_POLL_MS.
+  if (document.visibilityState === 'visible') void store.fetchWorkspacesInfo()
+}
+
 onMounted(async () => {
   await store.fetchWorkspaces()
   // Silently fetch archived workspaces so the Archived group header renders
@@ -1376,12 +1392,12 @@ onMounted(async () => {
   // by polling the server-cached bulk endpoint. Fetch once immediately so the
   // git-stats / CI recap are populated at load instead of after the first tick.
   void store.fetchWorkspacesInfo()
-  workspaceInfoInterval = setInterval(() => {
-    void store.fetchWorkspacesInfo()
-  }, 15_000)
+  workspaceInfoInterval = setInterval(pollWorkspacesInfoIfVisible, WORKSPACE_INFO_POLL_MS)
+  document.addEventListener('visibilitychange', onVisibilityChange)
 })
 
 onBeforeUnmount(() => {
+  document.removeEventListener('visibilitychange', onVisibilityChange)
   if (workspaceInfoInterval) {
     clearInterval(workspaceInfoInterval)
     workspaceInfoInterval = null

--- a/src/client/src/components/items/TextMessageItem.vue
+++ b/src/client/src/components/items/TextMessageItem.vue
@@ -12,7 +12,7 @@ import type { ConversationItem } from 'src/services/agent-event-view'
 import { useDocumentsStore } from 'src/stores/documents'
 import { useWorkspaceStore } from 'src/stores/workspace'
 import { injectDocumentLinks } from 'src/utils/inject-document-links'
-import { sanitizeChatHtml } from 'src/utils/render-chat-markdown'
+import { escapeStreamingText, renderChatMarkdownCached, sanitizeChatHtml } from 'src/utils/render-chat-markdown'
 import { computed } from 'vue'
 
 const props = defineProps<{
@@ -29,10 +29,23 @@ const knownDocumentPaths = computed(() => {
 })
 
 const html = computed(() => {
-  const raw = marked.parse(props.item.text, { async: false, breaks: true, gfm: true }) as string
-  const withLinks = injectDocumentLinks(raw, knownDocumentPaths.value)
-  // Allow the data-document-path attribute through the sanitizer.
-  return sanitizeChatHtml(withLinks, { addAttr: ['data-document-path'] })
+  const item = props.item
+  // While the engine is typing, the text is a truncated markdown fragment.
+  // Parsing it on every token is the single most expensive thing this
+  // component does, and the intermediate render is unstable anyway (an
+  // unterminated code fence flips the whole message in and out of <pre>).
+  if (item.streaming) return escapeStreamingText(item.text)
+
+  const paths = knownDocumentPaths.value
+  // The key carries BOTH the message identity and the document paths, because
+  // injectDocumentLinks changes the output when the workspace's document list
+  // changes. renderChatMarkdownCached appends the text length itself.
+  return renderChatMarkdownCached(`${item.messageId}|${paths.join(',')}`, item.text, (raw) => {
+    const parsed = marked.parse(raw, { async: false, breaks: true, gfm: true }) as string
+    const withLinks = injectDocumentLinks(parsed, paths)
+    // Allow the data-document-path attribute through the sanitizer.
+    return sanitizeChatHtml(withLinks, { addAttr: ['data-document-path'] })
+  })
 })
 
 function onMessageClick(event: MouseEvent) {

--- a/src/client/src/composables/use-file-mention.ts
+++ b/src/client/src/composables/use-file-mention.ts
@@ -1,4 +1,4 @@
-import { fuzzyRank } from 'src/utils/fuzzy-match'
+import { fuzzyRankTop } from 'src/utils/fuzzy-match'
 import { computed, type Ref, ref, watch } from 'vue'
 
 /**
@@ -10,6 +10,10 @@ import { computed, type Ref, ref, watch } from 'vue'
  * @param getInputEl      accessor for the live `<textarea>` (for caret position)
  * @param getWorktreePath accessor for the current workspace's worktree path
  */
+
+/** Rows the mention popup can usefully show. */
+const MAX_FILE_MATCHES = 50
+
 export function useFileMention(
   message: Ref<string>,
   getInputEl: () => HTMLTextAreaElement | HTMLInputElement | null,
@@ -87,8 +91,10 @@ export function useFileMention(
     closeDropdown()
   }
 
-  /** Fuzzy-ranked file matches, capped for popup rendering. */
-  const fileMatches = computed<string[]>(() => fuzzyRank(fileFilter.value, files.value).slice(0, 50))
+  /** Fuzzy-ranked file matches, capped for popup rendering. Bounded top-K
+   *  selection: ranking then slicing meant a full sort of the whole worktree
+   *  on every keystroke. */
+  const fileMatches = computed<string[]>(() => fuzzyRankTop(fileFilter.value, files.value, MAX_FILE_MATCHES))
 
   // Keep the selection index inside bounds when the filter shrinks the list.
   watch(

--- a/src/client/src/layouts/MainLayout.vue
+++ b/src/client/src/layouts/MainLayout.vue
@@ -126,14 +126,10 @@
 import { useQuasar } from 'quasar'
 import AcceptancePanel from 'src/components/AcceptancePanel.vue'
 import AgentTodosPanel from 'src/components/AgentTodosPanel.vue'
-import DocumentsPanel from 'src/components/DocumentsPanel.vue'
-import GitPanel from 'src/components/GitPanel.vue'
 import PwaStatusBanner from 'src/components/PwaStatusBanner.vue'
-import SchedulePanel from 'src/components/SchedulePanel.vue'
 import SessionTimelinePanel from 'src/components/SessionTimelinePanel.vue'
 import SubagentsPanel from 'src/components/SubagentsPanel.vue'
 import TasksPanel from 'src/components/TasksPanel.vue'
-import TerminalPanel from 'src/components/TerminalPanel.vue'
 import ToolsPanel from 'src/components/ToolsPanel.vue'
 import WhatsNewDialog from 'src/components/WhatsNewDialog.vue'
 import WorkspaceList from 'src/components/WorkspaceList.vue'
@@ -144,8 +140,18 @@ import { useDocumentsStore } from 'src/stores/documents'
 import { useLayoutStore } from 'src/stores/layout'
 import { useWorkspaceStore } from 'src/stores/workspace'
 import { cappedDrawerWidth } from 'src/utils/drawer-width'
-import { computed, nextTick, onMounted, onUnmounted, provide, ref, watch } from 'vue'
+import { computed, defineAsyncComponent, nextTick, onMounted, onUnmounted, provide, ref, watch } from 'vue'
 import { useRoute } from 'vue-router'
+
+// The four heaviest panels of the right drawer. q-tab-panels only renders the
+// active panel, so deferring their chunk means they are not downloaded until
+// the user actually opens their tab — and never at all on the settings page.
+// GitPanel drags DiffViewer + monaco, TerminalPanel drags @xterm/xterm and its
+// stylesheet, DocumentsPanel drags marked + dompurify.
+const DocumentsPanel = defineAsyncComponent(() => import('src/components/DocumentsPanel.vue'))
+const GitPanel = defineAsyncComponent(() => import('src/components/GitPanel.vue'))
+const SchedulePanel = defineAsyncComponent(() => import('src/components/SchedulePanel.vue'))
+const TerminalPanel = defineAsyncComponent(() => import('src/components/TerminalPanel.vue'))
 
 // First-run onboarding tour, and the post-update "What's new" dialog.
 const { maybeStartOnFirstVisit } = useOnboarding()

--- a/src/client/src/pages/SettingsPage.vue
+++ b/src/client/src/pages/SettingsPage.vue
@@ -65,7 +65,7 @@
 
             <!-- Localization -->
             <div
-              v-show="activeTab === 'general'"
+              v-if="activeTab === 'general'"
               data-tour="settings-card-general"
               class="settings-subcard q-pa-md rounded-borders q-pb-sm q-mb-md"
             >
@@ -86,7 +86,7 @@
             </div>
 
             <!-- Workspace list display -->
-            <div v-show="activeTab === 'general'" class="settings-subcard q-pa-md rounded-borders q-pb-sm q-mb-md">
+            <div v-if="activeTab === 'general'" class="settings-subcard q-pa-md rounded-borders q-pb-sm q-mb-md">
               <div class="text-subtitle2 q-mb-sm">{{ $t('settings.workspaceListSection') }}</div>
               <q-toggle
                 v-model="globalFlattenWorkspaceList"
@@ -101,7 +101,7 @@
 
             <!-- Skill suite -->
             <div
-              v-show="activeTab === 'skills'"
+              v-if="activeTab === 'skills'"
               data-tour="settings-card-skills"
               class="settings-subcard q-pa-md rounded-borders q-pb-sm q-mb-md"
             >
@@ -189,7 +189,7 @@
 
             <!-- Default agent configuration -->
             <div
-              v-show="activeTab === 'agents'"
+              v-if="activeTab === 'agents'"
               data-tour="settings-card-agents"
               class="settings-subcard q-pa-md rounded-borders q-pb-sm q-mb-md"
             >
@@ -248,7 +248,7 @@
             </div>
 
             <!-- Activity feed display -->
-            <div v-show="activeTab === 'general'" class="settings-subcard q-pa-md rounded-borders q-pb-sm q-mb-md">
+            <div v-if="activeTab === 'general'" class="settings-subcard q-pa-md rounded-borders q-pb-sm q-mb-md">
               <div class="text-subtitle2 q-mb-sm">{{ $t('settings.activityFeed') }}</div>
               <div class="row items-center q-gutter-lg">
                 <q-toggle
@@ -271,7 +271,7 @@
             </div>
 
             <!-- Whip settings -->
-            <div v-show="activeTab === 'general'" class="settings-subcard q-pa-md rounded-borders q-pb-sm q-mb-md">
+            <div v-if="activeTab === 'general'" class="settings-subcard q-pa-md rounded-borders q-pb-sm q-mb-md">
               <div class="text-subtitle2 q-mb-xs">{{ $t('settings.whipSettings') }}</div>
               <div class="text-grey-6 text-caption q-mb-md">{{ $t('settings.whipSettingsHint') }}</div>
               <q-toggle
@@ -314,7 +314,7 @@
 
             <!-- Notifications -->
             <div
-              v-show="activeTab === 'notifications'"
+              v-if="activeTab === 'notifications'"
               data-tour="settings-card-notifications"
               class="settings-subcard q-pa-md rounded-borders q-pb-sm q-mb-md"
             >
@@ -529,7 +529,7 @@
 
             <!-- Voice transcription — Runtime status -->
             <div
-              v-show="activeTab === 'voice'"
+              v-if="activeTab === 'voice'"
               data-tour="settings-card-voice"
               class="settings-subcard q-pa-md rounded-borders q-pb-sm q-mb-md"
             >
@@ -621,7 +621,7 @@ where ffmpeg</pre>
             </div>
 
             <!-- Voice transcription — Activation -->
-            <div v-show="activeTab === 'voice'" class="settings-subcard q-pa-md rounded-borders q-pb-sm q-mb-md">
+            <div v-if="activeTab === 'voice'" class="settings-subcard q-pa-md rounded-borders q-pb-sm q-mb-md">
               <div class="text-subtitle2 q-mb-sm">{{ $t('voice.sectionActivation') }}</div>
               <q-toggle
                 v-model="globalVoiceEnabled"
@@ -665,7 +665,7 @@ where ffmpeg</pre>
             </div>
 
             <!-- Voice transcription — Models -->
-            <div v-show="activeTab === 'voice'" class="settings-subcard q-pa-md rounded-borders q-pb-sm q-mb-md">
+            <div v-if="activeTab === 'voice'" class="settings-subcard q-pa-md rounded-borders q-pb-sm q-mb-md">
               <div class="text-subtitle2 q-mb-sm">{{ $t('voice.sectionModels') }}</div>
               <q-select
                 v-model="globalVoiceModel"
@@ -773,7 +773,7 @@ where ffmpeg</pre>
             </div>
 
             <!-- Voice transcription — Advanced options -->
-            <div v-show="activeTab === 'voice'" class="settings-subcard q-pa-md rounded-borders q-pb-sm q-mb-md">
+            <div v-if="activeTab === 'voice'" class="settings-subcard q-pa-md rounded-borders q-pb-sm q-mb-md">
               <div class="text-subtitle2 q-mb-sm">{{ $t('voice.sectionAdvanced') }}</div>
               <q-expansion-item
                 dense
@@ -1025,7 +1025,7 @@ where ffmpeg</pre>
             </div>
 
             <!-- Editor -->
-            <div v-show="activeTab === 'general'" class="settings-subcard q-pa-md rounded-borders q-pb-sm q-mb-md">
+            <div v-if="activeTab === 'general'" class="settings-subcard q-pa-md rounded-borders q-pb-sm q-mb-md">
               <div class="text-subtitle2 q-mb-sm">{{ $t('settings.editorCommand') }}</div>
               <div class="text-caption text-grey-7 q-mb-sm">{{ $t('settings.editorCommandHint') }}</div>
               <q-input
@@ -1039,7 +1039,7 @@ where ffmpeg</pre>
             </div>
 
             <!-- File manager -->
-            <div v-show="activeTab === 'general'" class="settings-subcard q-pa-md rounded-borders q-pb-sm q-mb-md">
+            <div v-if="activeTab === 'general'" class="settings-subcard q-pa-md rounded-borders q-pb-sm q-mb-md">
               <div class="text-subtitle2 q-mb-sm">{{ $t('settings.fileManagerCommand') }}</div>
               <div class="text-caption text-grey-7 q-mb-sm">{{ $t('settings.fileManagerCommandHint') }}</div>
               <q-input
@@ -1053,7 +1053,7 @@ where ffmpeg</pre>
             </div>
 
             <!-- Terminal -->
-            <div v-show="activeTab === 'general'" class="settings-subcard q-pa-md rounded-borders q-pb-sm q-mb-md">
+            <div v-if="activeTab === 'general'" class="settings-subcard q-pa-md rounded-borders q-pb-sm q-mb-md">
               <div class="text-subtitle2 q-mb-sm">{{ $t('settings.terminalCommand') }}</div>
               <div class="text-caption text-grey-7 q-mb-sm">{{ $t('settings.terminalCommandHint') }}</div>
               <q-input
@@ -1066,11 +1066,11 @@ where ffmpeg</pre>
               />
             </div>
 
-            <div v-show="activeTab === 'notion'" class="settings-subcard q-pa-md rounded-borders q-pb-sm q-mb-md">
+            <div v-if="activeTab === 'notion'" class="settings-subcard q-pa-md rounded-borders q-pb-sm q-mb-md">
               <q-toggle v-model="globalNotionEnabled" :label="$t('settings.integrationEnabled')" dark dense color="indigo-4" />
             </div>
             <div
-              v-show="activeTab === 'notion'"
+              v-if="activeTab === 'notion'"
               data-tour="settings-card-notion"
               :class="['settings-subcard q-pa-md rounded-borders q-pb-sm q-mb-md', { 'opacity-50': !globalNotionEnabled }]"
             >
@@ -1111,14 +1111,14 @@ where ffmpeg</pre>
             </div>
 
             <div
-              v-show="activeTab === 'sentry'"
+              v-if="activeTab === 'sentry'"
               data-tour="settings-card-sentry"
               class="settings-subcard q-pa-md rounded-borders q-pb-sm q-mb-md"
             >
               <q-toggle v-model="globalSentryEnabled" :label="$t('settings.integrationEnabled')" dark dense color="indigo-4" />
             </div>
 
-            <div v-show="activeTab === 'sentry'" :class="['settings-subcard q-pa-md rounded-borders q-pb-sm q-mb-md', { 'opacity-50': !globalSentryEnabled }]">
+            <div v-if="activeTab === 'sentry'" :class="['settings-subcard q-pa-md rounded-borders q-pb-sm q-mb-md', { 'opacity-50': !globalSentryEnabled }]">
               <div class="text-subtitle2 q-mb-sm">{{ $t('settings.mcpSelection') }}</div>
               <div class="text-caption text-grey-7 q-mb-sm">{{ $t('settings.mcpSelectionHint') }}</div>
               <div class="q-mb-sm">
@@ -1152,7 +1152,7 @@ where ffmpeg</pre>
             </div>
 
             <div
-              v-show="activeTab === 'forge'"
+              v-if="activeTab === 'forge'"
               data-tour="settings-card-forge"
               class="settings-subcard q-pa-md rounded-borders q-pb-sm q-mb-md"
             >
@@ -1214,7 +1214,7 @@ where ffmpeg</pre>
             </div>
 
             <!-- Notion assignment -->
-            <div v-show="activeTab === 'notion'" :class="['settings-subcard q-pa-md rounded-borders q-pb-sm q-mb-md', { 'opacity-50': !globalNotionEnabled }]">
+            <div v-if="activeTab === 'notion'" :class="['settings-subcard q-pa-md rounded-borders q-pb-sm q-mb-md', { 'opacity-50': !globalNotionEnabled }]">
               <div class="text-subtitle2 q-mb-sm">{{ $t('settings.notionAssignee') }}</div>
               <div class="text-caption text-grey-7 q-mb-sm">{{ $t('settings.notionAssigneeHint') }}</div>
               <div class="q-mb-sm">
@@ -1320,7 +1320,7 @@ where ffmpeg</pre>
             </div>
 
             <!-- Workspace tags -->
-            <div v-show="activeTab === 'general'" class="settings-subcard q-pa-md rounded-borders q-pb-sm q-mb-md">
+            <div v-if="activeTab === 'general'" class="settings-subcard q-pa-md rounded-borders q-pb-sm q-mb-md">
               <div class="text-subtitle2 q-mb-sm">{{ $t('settings.tagsTitle') }}</div>
               <div class="text-caption text-grey-7 q-mb-sm">{{ $t('settings.tagsHint') }}</div>
               <q-select
@@ -1339,7 +1339,7 @@ where ffmpeg</pre>
             </div>
 
             <!-- Branch prefixes -->
-            <div v-show="activeTab === 'general'" class="settings-subcard q-pa-md rounded-borders q-pb-sm q-mb-md">
+            <div v-if="activeTab === 'general'" class="settings-subcard q-pa-md rounded-borders q-pb-sm q-mb-md">
               <div class="text-subtitle2 q-mb-sm">{{ $t('settings.branchPrefixesTitle') }}</div>
               <div class="text-caption text-grey-7 q-mb-sm">{{ $t('settings.branchPrefixesHint') }}</div>
 
@@ -1436,7 +1436,7 @@ where ffmpeg</pre>
 
             <!-- Setup script -->
             <div
-              v-show="activeTab === 'scripts'"
+              v-if="activeTab === 'scripts'"
               data-tour="settings-card-scripts"
               class="settings-subcard q-pa-md rounded-borders q-pb-sm q-mb-md"
             >
@@ -1455,7 +1455,7 @@ where ffmpeg</pre>
             </div>
 
             <!-- Onboarding tour -->
-            <div v-show="activeTab === 'general'" class="settings-subcard q-pa-md rounded-borders q-pb-sm q-mb-md">
+            <div v-if="activeTab === 'general'" class="settings-subcard q-pa-md rounded-borders q-pb-sm q-mb-md">
               <div class="text-subtitle2 q-mb-sm">{{ $t('settings.onboardingTitle') }}</div>
               <div class="text-caption text-grey-7 q-mb-sm">{{ $t('settings.onboardingHint') }}</div>
               <q-btn
@@ -1469,7 +1469,7 @@ where ffmpeg</pre>
             </div>
 
             <!-- Cleanup script -->
-            <div v-show="activeTab === 'scripts'" class="settings-subcard q-pa-md rounded-borders q-pb-sm q-mb-md">
+            <div v-if="activeTab === 'scripts'" class="settings-subcard q-pa-md rounded-borders q-pb-sm q-mb-md">
               <div class="text-subtitle2 q-mb-sm">{{ $t('settings.cleanupScript') }}</div>
               <div class="text-caption text-grey-7 q-mb-sm">{{ $t('settings.cleanupScriptHint') }}</div>
               <q-input
@@ -1504,7 +1504,7 @@ where ffmpeg</pre>
             </div>
 
             <!-- Archive script -->
-            <div v-show="activeTab === 'scripts'" class="settings-subcard q-pa-md rounded-borders q-pb-sm q-mb-md">
+            <div v-if="activeTab === 'scripts'" class="settings-subcard q-pa-md rounded-borders q-pb-sm q-mb-md">
               <div class="text-subtitle2 q-mb-sm">{{ $t('settings.archiveScript') }}</div>
               <div class="text-caption text-grey-7 q-mb-sm">{{ $t('settings.archiveScriptHint') }}</div>
               <q-input
@@ -1520,7 +1520,7 @@ where ffmpeg</pre>
             </div>
 
             <!-- Change-source-branch script -->
-            <div v-show="activeTab === 'scripts'" class="settings-subcard q-pa-md rounded-borders q-pb-sm q-mb-md">
+            <div v-if="activeTab === 'scripts'" class="settings-subcard q-pa-md rounded-borders q-pb-sm q-mb-md">
               <div class="row items-center justify-between q-mb-sm">
                 <div class="text-subtitle2">{{ $t('settings.changeSourceBranchScript') }}</div>
                 <q-btn
@@ -1548,7 +1548,7 @@ where ffmpeg</pre>
             </div>
 
             <div
-              v-show="activeTab === 'worktrees'"
+              v-if="activeTab === 'worktrees'"
               data-tour="settings-card-worktrees"
               class="settings-subcard q-pa-md rounded-borders q-pb-sm q-mb-md"
             >
@@ -1679,7 +1679,7 @@ where ffmpeg</pre>
 
             <!-- Network access -->
             <div
-              v-show="activeTab === 'general'"
+              v-if="activeTab === 'general'"
               class="settings-subcard q-pa-md rounded-borders q-pb-sm q-mb-md"
             >
               <div class="text-subtitle2 q-mb-sm">{{ $t('settings.network.title') }}</div>
@@ -1743,7 +1743,7 @@ where ffmpeg</pre>
 
             <!-- Import / Export config -->
             <div
-              v-show="activeTab === 'export'"
+              v-if="activeTab === 'export'"
               data-tour="settings-card-export"
               class="settings-subcard q-pa-md rounded-borders q-pb-sm q-mb-md"
             >
@@ -1779,7 +1779,7 @@ where ffmpeg</pre>
           </div>
 
         <!-- Projects panel -->
-        <div v-show="activeTab === 'projects'" class="q-pa-none">
+        <div v-if="activeTab === 'projects'" class="q-pa-none">
           <div class="row q-gutter-md" style="min-height: 500px;">
             <!-- Left column: project list (30%) -->
             <div class="project-list-col">
@@ -2332,7 +2332,7 @@ where ffmpeg</pre>
           </div>
         </div>
         <!-- Templates panel -->
-        <div v-show="activeTab === 'templates'" class="q-pa-none">
+        <div v-if="activeTab === 'templates'" class="q-pa-none">
           <div data-tour="settings-card-templates" class="settings-card rounded-borders q-pa-lg">
             <div class="row items-center justify-between q-mb-md">
               <div class="text-subtitle1 text-weight-medium text-grey-3">
@@ -2529,6 +2529,8 @@ import { useLayoutStore } from 'src/stores/layout'
 import type { ProjectSettings } from 'src/stores/settings'
 import { useSettingsStore } from 'src/stores/settings'
 import { type Template, useTemplatesStore } from 'src/stores/templates'
+import { formFieldsEqual } from 'src/utils/form-fields-equal'
+import { captureFormSnapshot } from 'src/utils/form-snapshot'
 import {
   DEFAULT_NOTIFICATION_SOUND,
   DEFAULT_PR_NOTIFICATION_AUDIO_SETTINGS,
@@ -3508,11 +3510,18 @@ const selectedProject = computed<ProjectSettings | null>(() => {
 // rendu et la barre « modifications non enregistrées » clignotait à chaque
 // ouverture, le temps que `onMounted` finisse ses `await` et appelle
 // `syncGlobalForm()`.
-const globalSavedSnapshot = ref<string>(captureGlobalSnapshot())
-const projectSavedSnapshot = ref<string>('')
+// Snapshots are OBJECTS, not JSON strings: serialising 76 fields — five of them
+// multi-kilobyte scripts — on every keystroke was what made typing stutter.
+const globalSavedSnapshot = ref<Record<string, unknown>>(captureGlobalSnapshot())
+const projectSavedSnapshot = ref<Record<string, unknown>>({})
 
-function captureGlobalSnapshot(): string {
-  return JSON.stringify({
+/**
+ * Live view of the global form. Shares references with the refs it reads, so
+ * it is cheap enough to recompute on every keystroke — but it must NEVER be
+ * stored as a saved-state snapshot: use `captureGlobalSnapshot()` for that.
+ */
+function readGlobalForm(): Record<string, unknown> {
+  return {
     claudeModel: globalClaudeModel.value,
     codexModel: globalCodexModel.value,
     prPrompt: globalPrPrompt.value,
@@ -3587,15 +3596,31 @@ function captureGlobalSnapshot(): string {
     voicePrompt: globalVoicePrompt.value,
     voiceTranslateToEnglish: globalVoiceTranslateToEnglish.value,
     voiceSuppressNst: globalVoiceSuppressNst.value,
-  })
+  }
 }
 
-function captureProjectSnapshot(): string {
-  return JSON.stringify(projectForm.value)
+/** Live view of the project form — same caveat as `readGlobalForm`. */
+function readProjectForm(): Record<string, unknown> {
+  return { ...projectForm.value }
 }
 
-const isGlobalDirty = computed(() => captureGlobalSnapshot() !== globalSavedSnapshot.value)
-const isProjectDirty = computed(() => captureProjectSnapshot() !== projectSavedSnapshot.value)
+// Saved-state snapshots must be DETACHED from the live form: arrays (tags,
+// branch prefixes) and nested objects (devServer, e2e, finalization) are edited
+// in place, and a snapshot sharing those references would mutate along with the
+// value it is compared against — the savebar would never appear and the edit
+// would be lost silently.
+function captureGlobalSnapshot(): Record<string, unknown> {
+  return captureFormSnapshot(readGlobalForm())
+}
+
+function captureProjectSnapshot(): Record<string, unknown> {
+  return captureFormSnapshot(readProjectForm())
+}
+
+// The dirty checks compare the LIVE form against the detached snapshot: no
+// deep clone on every keystroke, and any in-place mutation still shows up.
+const isGlobalDirty = computed(() => !formFieldsEqual(readGlobalForm(), globalSavedSnapshot.value))
+const isProjectDirty = computed(() => !formFieldsEqual(readProjectForm(), projectSavedSnapshot.value))
 
 const savebarVisible = computed(() => {
   // A failed load must never offer a Save: the form is on defaults.
@@ -4117,12 +4142,19 @@ function formatBytes(bytes: number | undefined | null): string {
   return `${value < 10 ? value.toFixed(1) : Math.round(value)} ${units[i]}`
 }
 
+// 800 ms was ~75 requests per minute for the whole duration of a model
+// download — minutes, not seconds — with every failure silently discarded.
+const VOICE_MODELS_POLL_MS = 2500
+
 let voiceModelsPollTimer: ReturnType<typeof setInterval> | null = null
 function startVoiceModelsPolling() {
   if (voiceModelsPollTimer) return
   voiceModelsPollTimer = setInterval(() => {
-    store.fetchVoiceModels().catch(() => {})
-  }, 800)
+    if (document.visibilityState === 'hidden') return
+    store.fetchVoiceModels().catch((err) => {
+      console.error('[settings] voice model polling failed:', err)
+    })
+  }, VOICE_MODELS_POLL_MS)
 }
 function stopVoiceModelsPolling() {
   if (voiceModelsPollTimer) {
@@ -4223,7 +4255,7 @@ function addNewProject() {
 function selectProject(index: number) {
   // Same gate as savebarVisible / the settings:project unsaved-scope: dirty
   // alone is trivially true before any project was ever selected, since
-  // projectSavedSnapshot starts at '' while captureProjectSnapshot() never is.
+  // projectSavedSnapshot starts at {} while captureProjectSnapshot() never is.
   if (isProjectDirty.value && (selectedProject.value !== null || isNewProject.value)) {
     $q.dialog({
       title: t('settings.unsavedChanges.title'),

--- a/src/client/src/pages/WorkspacePage.vue
+++ b/src/client/src/pages/WorkspacePage.vue
@@ -410,11 +410,10 @@ import { computed, defineAsyncComponent, nextTick, onMounted, onUnmounted, ref, 
 import { useI18n } from 'vue-i18n'
 import { useRoute, useRouter } from 'vue-router'
 
-const ActivityFeed = defineAsyncComponent(() =>
-  Promise.all([import('src/components/ActivityFeed.vue'), new Promise((resolve) => setTimeout(resolve, 500))]).then(
-    ([module]) => module,
-  ),
-)
+// No artificial delay: ActivityFeed shows its own 200 ms switch spinner
+// (WORKSPACE_SWITCH_SPINNER_MS), so padding the chunk load with half a second
+// added latency to every workspace open and hid nothing.
+const ActivityFeed = defineAsyncComponent(() => import('src/components/ActivityFeed.vue'))
 
 import AgentBusyBanner from 'src/components/AgentBusyBanner.vue'
 import AgentErrorBanner from 'src/components/AgentErrorBanner.vue'

--- a/src/client/src/services/agent-event-view.ts
+++ b/src/client/src/services/agent-event-view.ts
@@ -101,6 +101,37 @@ export function getLatestThinkingItem(
   return null
 }
 
+type TextItem = Extract<ConversationItem, { type: 'text' }>
+type ToolItem = Extract<ConversationItem, { type: 'tool' }>
+
+/**
+ * A cached item plus the index it occupies in `items`. The index is what makes
+ * copy-on-write possible: updating an item means publishing a NEW object at the
+ * same slot, and the slot has to be known without scanning the list.
+ */
+interface Slot<T extends ConversationItem> {
+  item: T
+  index: number
+}
+
+/**
+ * Resumable state of a fold. `count` is how many events have been consumed and
+ * `lastEvent` is the object that sat at `count - 1`: together they detect a
+ * pure append by reference, which is the only case worth optimising and the
+ * only one that is safe to resume.
+ */
+export interface FoldCache {
+  count: number
+  lastEvent: AgentEvent | null
+  items: ConversationItem[]
+  textItems: Map<string, Slot<TextItem>>
+  toolItems: Map<string, Slot<ToolItem>>
+}
+
+export function createFoldCache(): FoldCache {
+  return { count: 0, lastEvent: null, items: [], textItems: new Map(), toolItems: new Map() }
+}
+
 /**
  * Fold a flat AgentEvent stream into ConversationItems.
  * `timestamps` is an optional parallel array (same length as `events`) that
@@ -116,25 +147,77 @@ export function foldEvents(
   sessionActive = true,
   eventIds?: Array<string | null>,
 ): ConversationItem[] {
-  const items: ConversationItem[] = []
-  const textItems = new Map<
-    string,
-    { type: 'text'; messageId: string; text: string; streaming: boolean; ts?: string; eventIds?: string[] }
-  >()
-  const toolItems = new Map<
-    string,
-    {
-      type: 'tool'
-      toolCallId: string
-      name: string
-      input: unknown
-      result?: { output: unknown; isError: boolean }
-      ts?: string
-      eventIds?: string[]
-    }
-  >()
+  return foldEventsCached(createFoldCache(), events, timestamps, sessionActive, eventIds)
+}
 
-  for (let i = 0; i < events.length; i++) {
+/**
+ * Fold an AgentEvent stream into ConversationItems, resuming from `cache`.
+ *
+ * The feed used to re-fold the entire history on every token: forty messages
+ * reallocated a hundred and fifty times for one agent reply. Because a pure
+ * append leaves every already-folded event at the same index, the cache can
+ * consume only the tail — and, just as importantly, it REUSES the item objects,
+ * so a frozen message keeps its identity and the markdown memo keeps hitting.
+ *
+ * Reuse is strictly *copy-on-write*: an UNCHANGED item keeps its reference, a
+ * CHANGED one is replaced by a fresh object. Mutating in place would have kept
+ * the reference stable across a real content change, and the feed passes these
+ * items straight to child components under a stable key — Vue skips the patch
+ * when a prop is reference-equal, so an in-place mutation froze the card for
+ * good (invisible deltas, spinner that never stops, missing tool result).
+ */
+export function foldEventsCached(
+  cache: FoldCache,
+  events: AgentEvent[],
+  timestamps?: string[],
+  sessionActive = true,
+  eventIds?: Array<string | null>,
+): ConversationItem[] {
+  const isAppend = cache.count > 0 && events.length >= cache.count && events[cache.count - 1] === cache.lastEvent
+  if (!isAppend) {
+    // Prepended history, a session switch, a sync:response reset — anything
+    // that is not a pure append invalidates the resumable state.
+    cache.count = 0
+    cache.lastEvent = null
+    cache.items = []
+    cache.textItems = new Map()
+    cache.toolItems = new Map()
+  }
+
+  foldRange(cache, events, timestamps, eventIds, cache.count, events.length)
+  cache.count = events.length
+  cache.lastEvent = events.length > 0 ? events[events.length - 1] : null
+  closeStaleStreamingText(cache, sessionActive)
+  return cache.items
+}
+
+/**
+ * Publish `next` at the slot's index and re-point the slot at it. Never mutate
+ * the previous object: a component already rendering it must see a brand-new
+ * reference to notice the change.
+ */
+function replaceSlot<T extends ConversationItem>(items: ConversationItem[], slot: Slot<T>, next: T): void {
+  items[slot.index] = next
+  slot.item = next
+}
+
+/** Append an event id without mutating the previous array (it is shared). */
+function appendEventId(current: string[] | undefined, eventId: string | undefined): string[] | undefined {
+  if (!eventId || !current) return current
+  return [...current, eventId]
+}
+
+/** Consume `events[from … to)` into the cache. */
+function foldRange(
+  cache: FoldCache,
+  events: AgentEvent[],
+  timestamps: string[] | undefined,
+  eventIds: Array<string | null> | undefined,
+  from: number,
+  to: number,
+): void {
+  const { items, textItems, toolItems } = cache
+  for (let i = from; i < to; i++) {
     const ev = events[i]
     const ts = timestamps?.[i]
     const eventId = eventIds?.[i] ?? undefined
@@ -142,26 +225,31 @@ export function foldEvents(
       case 'message:text': {
         const existing = textItems.get(ev.messageId)
         if (existing) {
-          existing.text += ev.text
-          existing.streaming = ev.streaming
-          if (eventId) existing.eventIds?.push(eventId)
+          replaceSlot(items, existing, {
+            ...existing.item,
+            text: existing.item.text + ev.text,
+            streaming: ev.streaming,
+            eventIds: appendEventId(existing.item.eventIds, eventId),
+          })
         } else {
-          const item = {
-            type: 'text' as const,
+          const item: TextItem = {
+            type: 'text',
             messageId: ev.messageId,
             text: ev.text,
             streaming: ev.streaming,
             ts,
             eventIds: eventId ? [eventId] : undefined,
           }
-          textItems.set(ev.messageId, item)
+          textItems.set(ev.messageId, { item, index: items.length })
           items.push(item)
         }
         break
       }
       case 'message:end': {
         const existing = textItems.get(ev.messageId)
-        if (existing) existing.streaming = false
+        if (existing?.item.streaming) {
+          replaceSlot(items, existing, { ...existing.item, streaming: false })
+        }
         break
       }
       case 'message:thinking': {
@@ -175,23 +263,26 @@ export function foldEvents(
         break
       }
       case 'tool:call': {
-        const item = {
-          type: 'tool' as const,
+        const item: ToolItem = {
+          type: 'tool',
           toolCallId: ev.toolCallId,
           name: ev.name,
           input: ev.input,
           ts,
           eventIds: eventId ? [eventId] : undefined,
         }
-        toolItems.set(ev.toolCallId, item)
+        toolItems.set(ev.toolCallId, { item, index: items.length })
         items.push(item)
         break
       }
       case 'tool:result': {
         const existing = toolItems.get(ev.toolCallId)
         if (existing) {
-          existing.result = { output: ev.output, isError: ev.isError }
-          if (eventId) existing.eventIds?.push(eventId)
+          replaceSlot(items, existing, {
+            ...existing.item,
+            result: { output: ev.output, isError: ev.isError },
+            eventIds: appendEventId(existing.item.eventIds, eventId),
+          })
         }
         break
       }
@@ -256,25 +347,37 @@ export function foldEvents(
       }
     }
   }
+}
 
-  // Historical streams sometimes lack a proper `message:end` for messages
-  // that finished before this code existed. If a text item isn't the last
-  // text item in the sequence, its stream has effectively ended — close
-  // it so the UI doesn't render a perpetual spinner. The very last text
-  // item stays `streaming` only when the session is actually active
-  // (the agent is currently typing). Otherwise it's also closed.
-  let lastStreamingText: { streaming: boolean } | null = null
-  for (const it of items) {
-    if (it.type === 'text' && it.streaming) {
-      if (lastStreamingText) lastStreamingText.streaming = false
-      lastStreamingText = it
-    }
+/**
+ * Historical streams sometimes lack a proper `message:end` for messages that
+ * finished before this code existed. If a text item isn't the last text item in
+ * the sequence, its stream has effectively ended — close it so the UI doesn't
+ * render a perpetual spinner. The very last text item stays `streaming` only
+ * when the session is actually active. It only allocates for the items it
+ * actually closes, and is idempotent (an already-closed item is left strictly
+ * alone, reference included), so it can safely run after every incremental fold.
+ */
+function closeStaleStreamingText(cache: FoldCache, sessionActive: boolean): void {
+  const { items } = cache
+  let lastStreamingIndex = -1
+  for (let i = 0; i < items.length; i++) {
+    const it = items[i]
+    if (it.type !== 'text' || !it.streaming) continue
+    if (lastStreamingIndex >= 0) closeTextItemAt(cache, lastStreamingIndex)
+    lastStreamingIndex = i
   }
-  if (lastStreamingText && !sessionActive) {
-    lastStreamingText.streaming = false
-  }
+  if (lastStreamingIndex >= 0 && !sessionActive) closeTextItemAt(cache, lastStreamingIndex)
+}
 
-  return items
+/** Copy-on-write close of the text item sitting at `index`. */
+function closeTextItemAt(cache: FoldCache, index: number): void {
+  const it = cache.items[index]
+  if (it.type !== 'text' || !it.streaming) return
+  const next: TextItem = { ...it, streaming: false }
+  cache.items[index] = next
+  const slot = cache.textItems.get(it.messageId)
+  if (slot && slot.index === index) slot.item = next
 }
 
 export interface UserMessage {
@@ -282,6 +385,50 @@ export interface UserMessage {
   sender: string
   ts: string
   eventIds?: string[]
+}
+
+/** Sort key: a missing timestamp sinks to the end, as the old comparator did. */
+function tsRank(item: ConversationItem): string {
+  return item.ts ?? '￿'
+}
+
+function isSortedByTs(items: readonly ConversationItem[]): boolean {
+  for (let i = 1; i < items.length; i++) {
+    if (tsRank(items[i - 1]) > tsRank(items[i])) return false
+  }
+  return true
+}
+
+/**
+ * Merge two item lists in chronological order. Both inputs are almost always
+ * already sorted (events arrive in order, user messages too), so the common
+ * case is a linear two-pointer merge instead of a concat plus a full sort of
+ * the entire history on every token. Anything out of order falls back to the
+ * original comparator, so the result is identical either way.
+ */
+function mergeSortedByTs(a: ConversationItem[], b: ConversationItem[]): ConversationItem[] {
+  if (!isSortedByTs(a) || !isSortedByTs(b)) {
+    const merged = [...a, ...b]
+    merged.sort((x, y) => {
+      const tx = tsRank(x)
+      const ty = tsRank(y)
+      if (tx === ty) return 0
+      return tx < ty ? -1 : 1
+    })
+    return merged
+  }
+
+  const merged: ConversationItem[] = []
+  let i = 0
+  let j = 0
+  while (i < a.length && j < b.length) {
+    // `<=` keeps agent items before user items on an exact timestamp tie,
+    // matching the stable sort this replaces.
+    merged.push(tsRank(a[i]) <= tsRank(b[j]) ? a[i++] : b[j++])
+  }
+  while (i < a.length) merged.push(a[i++])
+  while (j < b.length) merged.push(b[j++])
+  return merged
 }
 
 /**
@@ -298,15 +445,7 @@ export function mergeWithUserMessages(agentItems: ConversationItem[], userMessag
     ts: m.ts,
     eventIds: m.eventIds,
   }))
-  const merged = [...agentItems, ...userItems]
-  merged.sort((a, b) => {
-    const ta = a.ts ?? ''
-    const tb = b.ts ?? ''
-    if (ta === tb) return 0
-    if (!ta) return 1
-    if (!tb) return -1
-    return ta < tb ? -1 : 1
-  })
+  const merged = mergeSortedByTs(agentItems, userItems)
 
   // Close any text item still marked `streaming` that predates the most
   // recent user message. The user taking another turn is a hard signal
@@ -319,11 +458,19 @@ export function mergeWithUserMessages(agentItems: ConversationItem[], userMessag
       if (!latestUserTs || it.ts > latestUserTs) latestUserTs = it.ts
     }
   }
+  // Copy-on-write, like the fold cache: publishing a new object is what makes
+  // the already-rendered card notice that the spinner has to stop. The source
+  // list (the fold cache's own `items`) is realigned on the same object so the
+  // next merge is a no-op and the reference stays stable from then on.
   if (latestUserTs) {
-    for (const it of merged) {
-      if (it.type === 'text' && it.streaming && (!it.ts || it.ts < latestUserTs)) {
-        it.streaming = false
-      }
+    for (let i = 0; i < merged.length; i++) {
+      const it = merged[i]
+      if (it.type !== 'text' || !it.streaming) continue
+      if (it.ts && it.ts >= latestUserTs) continue
+      const closed: ConversationItem = { ...it, streaming: false }
+      merged[i] = closed
+      const sourceIndex = agentItems.indexOf(it)
+      if (sourceIndex !== -1) agentItems[sourceIndex] = closed
     }
   }
 

--- a/src/client/src/services/conversation-turns.ts
+++ b/src/client/src/services/conversation-turns.ts
@@ -65,3 +65,56 @@ export function groupIntoTurns(items: ConversationItem[]): Turn[] {
 
   return turns
 }
+
+/**
+ * Stable identity for a single conversation item, usable as a Vue list key.
+ *
+ * Index keys break as soon as older history is prepended on scroll-up: every
+ * index shifts, so Vue rebuilds each card instead of moving it — and the local
+ * state of the children (a tool card's `expanded` flag) follows the index, not
+ * the data. Concretely, an expanded tool call ends up expanded on a different
+ * tool. The prefix per type guarantees no cross-type collision.
+ */
+export function itemKey(item: ConversationItem): string {
+  switch (item.type) {
+    case 'text':
+      return `text:${item.messageId}`
+    case 'thinking':
+      // A message id can carry several thinking blocks, so the event id (or,
+      // failing that, the timestamp) disambiguates them.
+      return `thinking:${item.messageId}:${item.eventIds?.[0] ?? item.ts ?? ''}`
+    case 'tool':
+      return `tool:${item.toolCallId}`
+    case 'session':
+      return `session:${item.kind}:${item.eventIds?.[0] ?? item.ts ?? ''}`
+    case 'user':
+      return `user:${item.eventIds?.[0] ?? `${item.sender}:${item.ts ?? ''}`}`
+    case 'error':
+      return `error:${item.eventIds?.[0] ?? `${item.category}:${item.ts ?? ''}`}`
+  }
+}
+
+/**
+ * Stable identity for a turn card. A turn always holds at least one item
+ * (groupIntoTurns never creates an empty one), and the first item of a turn is
+ * unique across the conversation, so it identifies the turn.
+ */
+export function turnKey(turn: Turn): string {
+  const first = turn.items[0]
+  return `${turn.speaker}:${first ? itemKey(first) : 'empty'}`
+}
+
+/**
+ * Index of the last `user` turn strictly before `fromIndex`, or -1.
+ *
+ * Replaces the DOM walk that measured every rendered user card's bounding
+ * rectangle: with a virtualised feed most cards are not in the DOM at all, and
+ * an index is both cheaper and exact.
+ */
+export function findPreviousUserTurnIndex(turns: readonly { speaker: string }[], fromIndex: number): number {
+  const start = Math.min(fromIndex, turns.length) - 1
+  for (let i = start; i >= 0; i--) {
+    if (turns[i]?.speaker === 'user') return i
+  }
+  return -1
+}

--- a/src/client/src/services/inline-diff.ts
+++ b/src/client/src/services/inline-diff.ts
@@ -4,21 +4,72 @@ export interface DiffLine {
 }
 
 /**
+ * Above this many changed lines on either side, the quadratic LCS table would
+ * allocate tens of megabytes and block the main thread. 800 caps the flat
+ * Int32Array at 801 × 801 × 4 ≈ 2.5 MB.
+ */
+export const INLINE_DIFF_MAX_LINES = 800
+
+/**
  * Compute a line-by-line diff using the Longest Common Subsequence algorithm.
  * Shared lines become `context`, differing lines are split into `del` (from
  * `oldText`) and `add` (from `newText`).
+ *
+ * The common prefix and suffix are trimmed first: a three-line edit inside a
+ * two-thousand-line file collapses to a three-by-three table instead of a
+ * two-thousand-square one. Past INLINE_DIFF_MAX_LINES of remaining difference
+ * the LCS walk is skipped entirely and the change is rendered as a wholesale
+ * replacement — which is what a reviewer gets from `git diff` on a rewrite
+ * anyway, and what this UI showed after freezing the tab for a second.
  */
 export function computeInlineDiff(oldText: string, newText: string): DiffLine[] {
   const a = oldText.split('\n')
   const b = newText.split('\n')
+
+  let start = 0
+  while (start < a.length && start < b.length && a[start] === b[start]) start++
+  let endA = a.length
+  let endB = b.length
+  while (endA > start && endB > start && a[endA - 1] === b[endB - 1]) {
+    endA--
+    endB--
+  }
+
+  const head: DiffLine[] = a.slice(0, start).map((content) => ({ type: 'context', content }))
+  const tail: DiffLine[] = a.slice(endA).map((content) => ({ type: 'context', content }))
+  const midA = a.slice(start, endA)
+  const midB = b.slice(start, endB)
+
+  if (midA.length > INLINE_DIFF_MAX_LINES || midB.length > INLINE_DIFF_MAX_LINES) {
+    return [
+      ...head,
+      ...midA.map((content): DiffLine => ({ type: 'del', content })),
+      ...midB.map((content): DiffLine => ({ type: 'add', content })),
+      ...tail,
+    ]
+  }
+
+  return [...head, ...lcsDiff(midA, midB), ...tail]
+}
+
+/** LCS walk over two already-trimmed, already-bounded line lists. */
+function lcsDiff(a: readonly string[], b: readonly string[]): DiffLine[] {
   const m = a.length
   const n = b.length
+  if (m === 0 && n === 0) return []
+  if (m === 0) return b.map((content) => ({ type: 'add', content }))
+  if (n === 0) return a.map((content) => ({ type: 'del', content }))
 
-  const lcs: number[][] = Array.from({ length: m + 1 }, () => new Array(n + 1).fill(0))
+  const width = n + 1
+  // One flat typed array instead of (m+1) JavaScript arrays: same values,
+  // a quarter of the memory and no per-row allocation.
+  const lcs = new Int32Array((m + 1) * width)
   for (let i = m - 1; i >= 0; i--) {
     for (let j = n - 1; j >= 0; j--) {
-      if (a[i] === b[j]) lcs[i][j] = lcs[i + 1][j + 1] + 1
-      else lcs[i][j] = Math.max(lcs[i + 1][j], lcs[i][j + 1])
+      lcs[i * width + j] =
+        a[i] === b[j]
+          ? lcs[(i + 1) * width + (j + 1)] + 1
+          : Math.max(lcs[(i + 1) * width + j], lcs[i * width + (j + 1)])
     }
   }
 
@@ -30,7 +81,7 @@ export function computeInlineDiff(oldText: string, newText: string): DiffLine[] 
       result.push({ type: 'context', content: a[i] })
       i++
       j++
-    } else if (lcs[i + 1][j] >= lcs[i][j + 1]) {
+    } else if (lcs[(i + 1) * width + j] >= lcs[i * width + (j + 1)]) {
       result.push({ type: 'del', content: a[i] })
       i++
     } else {

--- a/src/client/src/stores/agent-stream.ts
+++ b/src/client/src/stores/agent-stream.ts
@@ -27,46 +27,82 @@ export const useAgentStreamStore = defineStore('agent-stream', () => {
   // part of the persisted event stream — driven by ephemeral session:compacting
   // events and cleared when compaction ends. Reactive via `version`.
   const compacting = ref<Map<string, boolean>>(new Map())
-  const version = ref(0)
+  // Per-workspace index of persisted ws_events ids. `append` used to scan the
+  // whole id array (`idList.includes`) on EVERY event: with Codex emitting 50
+  // to 200 deltas per message on a 5 000-entry buffer, that is up to a million
+  // comparisons per message. A Set makes it O(1). `merge` already built one —
+  // it just threw it away on every call.
+  const eventIdIndex = ref<Map<string, Set<string>>>(new Map())
+
+  // Per-workspace reactive counter. A single global counter meant a burst on a
+  // background workspace invalidated every computed value of the workspace on
+  // screen — and WorkspaceList subscribes to ALL workspaces, so that happened
+  // constantly. Vue tracks `Map.get(key)` per key, so reading this counter
+  // establishes a dependency scoped to exactly one workspace.
+  const versions = ref<Map<string, number>>(new Map())
+
+  /** Register a reactive dependency on THIS workspace's stream. */
+  function track(workspaceId: string): void {
+    versions.value.get(workspaceId)
+  }
+
+  /** Invalidate every consumer of THIS workspace's stream. */
+  function touch(workspaceId: string): void {
+    versions.value.set(workspaceId, (versions.value.get(workspaceId) ?? 0) + 1)
+  }
+
+  /** Current counter of a workspace. Exposed so tests can assert isolation. */
+  function versionFor(workspaceId: string): number {
+    return versions.value.get(workspaceId) ?? 0
+  }
+
+  function idIndexFor(workspaceId: string): Set<string> {
+    let set = eventIdIndex.value.get(workspaceId)
+    if (!set) {
+      set = new Set<string>()
+      eventIdIndex.value.set(workspaceId, set)
+    }
+    return set
+  }
 
   function isCompacting(workspaceId: string): boolean {
-    version.value
+    track(workspaceId)
     return compacting.value.get(workspaceId) ?? false
   }
 
   function setCompacting(workspaceId: string, value: boolean): void {
     if ((compacting.value.get(workspaceId) ?? false) === value) return
     compacting.value.set(workspaceId, value)
-    version.value++
+    touch(workspaceId)
   }
 
   function eventsFor(workspaceId: string): AgentEvent[] {
-    version.value
+    track(workspaceId)
     return events.value.get(workspaceId) ?? []
   }
 
   function timestampsFor(workspaceId: string): string[] {
-    version.value
+    track(workspaceId)
     return timestamps.value.get(workspaceId) ?? []
   }
 
   function sessionIdsFor(workspaceId: string): Array<string | null> {
-    version.value
+    track(workspaceId)
     return sessionIds.value.get(workspaceId) ?? []
   }
 
   function eventIdsFor(workspaceId: string): Array<string | null> {
-    version.value
+    track(workspaceId)
     return eventIds.value.get(workspaceId) ?? []
   }
 
   function oldestIdFor(workspaceId: string): string | undefined {
-    version.value
+    track(workspaceId)
     return oldestIds.value.get(workspaceId)
   }
 
   function hasMoreOlderFor(workspaceId: string): boolean {
-    version.value
+    track(workspaceId)
     return hasMoreOlder.value.get(workspaceId) ?? true
   }
 
@@ -81,12 +117,14 @@ export const useAgentStreamStore = defineStore('agent-stream', () => {
     const tsList = timestamps.value.get(workspaceId) ?? []
     const sList = sessionIds.value.get(workspaceId) ?? []
     const idList = eventIds.value.get(workspaceId) ?? []
-    if (eventId && idList.includes(eventId)) return
+    const known = idIndexFor(workspaceId)
+    if (eventId && known.has(eventId)) return
     const isFirst = list.length === 0
     list.push(event)
     tsList.push(ts ?? new Date().toISOString())
     sList.push(sessionId ?? null)
     idList.push(eventId ?? null)
+    if (eventId) known.add(eventId)
     events.value.set(workspaceId, list)
     timestamps.value.set(workspaceId, tsList)
     sessionIds.value.set(workspaceId, sList)
@@ -95,7 +133,7 @@ export const useAgentStreamStore = defineStore('agent-stream', () => {
       oldestIds.value.set(workspaceId, eventId)
     }
     trimOldestLiveEvents(workspaceId, list, tsList, sList, idList)
-    version.value++
+    touch(workspaceId)
   }
 
   function trimOldestLiveEvents(
@@ -107,6 +145,11 @@ export const useAgentStreamStore = defineStore('agent-stream', () => {
   ): void {
     const overflow = list.length - MAX_LIVE_EVENTS_PER_WORKSPACE
     if (overflow <= 0) return
+    // Capture the ids BEFORE splicing: they have to leave the index too, or a
+    // re-delivered old event could never be appended again after a reconnect.
+    const removedIds = idList.slice(0, overflow)
+    const known = idIndexFor(workspaceId)
+    for (const id of removedIds) if (id) known.delete(id)
     list.splice(0, overflow)
     tsList.splice(0, overflow)
     sList.splice(0, overflow)
@@ -128,18 +171,18 @@ export const useAgentStreamStore = defineStore('agent-stream', () => {
     const tsList = timestamps.value.get(workspaceId) ?? []
     const sList = sessionIds.value.get(workspaceId) ?? []
     const idList = eventIds.value.get(workspaceId) ?? []
-    const knownIds = new Set(idList.filter((id): id is string => typeof id === 'string'))
+    const known = idIndexFor(workspaceId)
     const addedIndexes: number[] = []
     for (let i = 0; i < incomingEvents.length; i++) {
       const event = incomingEvents[i]
       if (!event) continue
       const eventId = meta.eventIds[i] ?? null
-      if (eventId && knownIds.has(eventId)) continue
+      if (eventId && known.has(eventId)) continue
       list.push(event)
       tsList.push(incomingTimestamps[i] ?? new Date().toISOString())
       sList.push(meta.sessionIds[i] ?? null)
       idList.push(eventId)
-      if (eventId) knownIds.add(eventId)
+      if (eventId) known.add(eventId)
       addedIndexes.push(i)
     }
     if (addedIndexes.length === 0) return addedIndexes
@@ -152,7 +195,7 @@ export const useAgentStreamStore = defineStore('agent-stream', () => {
       if (firstPersistedId) oldestIds.value.set(workspaceId, firstPersistedId)
     }
     trimOldestLiveEvents(workspaceId, list, tsList, sList, idList)
-    version.value++
+    touch(workspaceId)
     return addedIndexes
   }
 
@@ -170,12 +213,18 @@ export const useAgentStreamStore = defineStore('agent-stream', () => {
     events.value.set(workspaceId, [...list])
     timestamps.value.set(workspaceId, tsList ? [...tsList] : list.map(() => new Date().toISOString()))
     sessionIds.value.set(workspaceId, meta?.sessionIds ? [...meta.sessionIds] : list.map(() => null))
-    eventIds.value.set(workspaceId, meta?.eventIds ? [...meta.eventIds] : list.map(() => null))
+    const resetIds = meta?.eventIds ? [...meta.eventIds] : list.map(() => null)
+    eventIds.value.set(workspaceId, resetIds)
+    // Rebuild the index from scratch: a reset replaces the whole window, so a
+    // stale id left behind would silently block a legitimate new event.
+    const known = idIndexFor(workspaceId)
+    known.clear()
+    for (const id of resetIds) if (id) known.add(id)
     if (meta?.oldestId) oldestIds.value.set(workspaceId, meta.oldestId)
     else oldestIds.value.delete(workspaceId)
     if (meta && typeof meta.hasMoreOlder === 'boolean') hasMoreOlder.value.set(workspaceId, meta.hasMoreOlder)
     else hasMoreOlder.value.delete(workspaceId)
-    version.value++
+    touch(workspaceId)
   }
 
   function prepend(
@@ -191,7 +240,7 @@ export const useAgentStreamStore = defineStore('agent-stream', () => {
   ): void {
     if (olderEvents.length === 0) {
       hasMoreOlder.value.set(workspaceId, meta.hasMoreOlder)
-      version.value++
+      touch(workspaceId)
       return
     }
     const list = events.value.get(workspaceId) ?? []
@@ -204,9 +253,11 @@ export const useAgentStreamStore = defineStore('agent-stream', () => {
     timestamps.value.set(workspaceId, [...olderTimestamps, ...tsList])
     sessionIds.value.set(workspaceId, [...olderSids, ...sList])
     eventIds.value.set(workspaceId, [...olderIds, ...idList])
+    const known = idIndexFor(workspaceId)
+    for (const id of olderIds) if (id) known.add(id)
     if (meta.oldestId) oldestIds.value.set(workspaceId, meta.oldestId)
     hasMoreOlder.value.set(workspaceId, meta.hasMoreOlder)
-    version.value++
+    touch(workspaceId)
   }
 
   /**
@@ -227,7 +278,8 @@ export const useAgentStreamStore = defineStore('agent-stream', () => {
     idList.splice(idx, 1)
     if (tsList) tsList.splice(idx, 1)
     if (sList) sList.splice(idx, 1)
-    version.value++
+    idIndexFor(workspaceId).delete(eventId)
+    touch(workspaceId)
   }
 
   function clear(workspaceId: string): void {
@@ -238,7 +290,10 @@ export const useAgentStreamStore = defineStore('agent-stream', () => {
     oldestIds.value.delete(workspaceId)
     hasMoreOlder.value.delete(workspaceId)
     compacting.value.delete(workspaceId)
-    version.value++
+    eventIdIndex.value.delete(workspaceId)
+    // Bump rather than delete: consumers still tracking this workspace need a
+    // trigger to re-read an empty stream.
+    touch(workspaceId)
   }
 
   return {
@@ -246,7 +301,8 @@ export const useAgentStreamStore = defineStore('agent-stream', () => {
     timestamps,
     sessionIds,
     eventIds,
-    version,
+    versions,
+    versionFor,
     eventsFor,
     timestampsFor,
     sessionIdsFor,

--- a/src/client/src/utils/build-path-tree.ts
+++ b/src/client/src/utils/build-path-tree.ts
@@ -73,3 +73,28 @@ export function countLeaves<T>(nodes: readonly PathTreeNode<T>[]): number {
   }
   return n
 }
+
+/**
+ * Folder node keys of a path tree, down to `maxDepth` levels.
+ *
+ * `default-expand-all` on a two-hundred-file diff mounts every node — each with
+ * its header template, its badges and its context menu — before the user has
+ * clicked anything. Feeding q-tree an explicit, bounded expansion list keeps
+ * small diffs fully open and large ones shallow.
+ */
+export function collectFolderKeys<T>(
+  nodes: readonly PathTreeNode<T>[],
+  maxDepth: number = Number.POSITIVE_INFINITY,
+): string[] {
+  const keys: string[] = []
+  const walk = (level: readonly PathTreeNode<T>[], depth: number): void => {
+    if (depth > maxDepth) return
+    for (const node of level) {
+      if (!node.isFolder) continue
+      keys.push(node.nodeKey)
+      if (node.children) walk(node.children, depth + 1)
+    }
+  }
+  walk(nodes, 1)
+  return keys
+}

--- a/src/client/src/utils/form-fields-equal.ts
+++ b/src/client/src/utils/form-fields-equal.ts
@@ -1,0 +1,37 @@
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function valuesEqual(a: unknown, b: unknown): boolean {
+  if (a === b) return true
+  if (Array.isArray(a) || Array.isArray(b)) {
+    if (!Array.isArray(a) || !Array.isArray(b) || a.length !== b.length) return false
+    for (let i = 0; i < a.length; i++) {
+      if (!valuesEqual(a[i], b[i])) return false
+    }
+    return true
+  }
+  if (isPlainObject(a) && isPlainObject(b)) return formFieldsEqual(a, b)
+  return false
+}
+
+/**
+ * Compare two form snapshots field by field, short-circuiting on the first
+ * difference.
+ *
+ * The settings page used to detect changes by JSON-serialising 76 variables and
+ * comparing the two strings — recomputed on every keystroke, and five of those
+ * fields hold multi-kilobyte shell scripts. Typing in a large script was
+ * visibly stuttering. In the common case (one field edited, 75 untouched) this
+ * costs 75 reference comparisons and stops at the one that differs.
+ */
+export function formFieldsEqual(a: Record<string, unknown>, b: Record<string, unknown>): boolean {
+  const keysA = Object.keys(a)
+  const keysB = Object.keys(b)
+  if (keysA.length !== keysB.length) return false
+  for (const key of keysA) {
+    if (!Object.hasOwn(b, key)) return false
+    if (!valuesEqual(a[key], b[key])) return false
+  }
+  return true
+}

--- a/src/client/src/utils/form-snapshot.ts
+++ b/src/client/src/utils/form-snapshot.ts
@@ -1,0 +1,41 @@
+/**
+ * Deep-copy plain form data, reading THROUGH Vue's reactive proxies.
+ *
+ * `structuredClone` is not usable here: the settings form is `reactive()` /
+ * `ref()` state, so its arrays and nested objects are Proxy exotic objects, and
+ * the structured-clone algorithm refuses them outright
+ * (`DataCloneError: #<Object> could not be cloned`) — it takes the whole page
+ * down at `setup()` time. Walking the value with `Object.entries` / `map` goes
+ * through the proxy traps and yields plain, detached data.
+ *
+ * Only what a settings form actually holds is supported: primitives, arrays,
+ * plain objects and dates. That is also exactly the shape `formFieldsEqual`
+ * knows how to compare.
+ */
+function deepClonePlain(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(deepClonePlain)
+  if (value instanceof Date) return new Date(value.getTime())
+  if (value !== null && typeof value === 'object') {
+    const cloned: Record<string, unknown> = {}
+    for (const [key, entry] of Object.entries(value)) cloned[key] = deepClonePlain(entry)
+    return cloned
+  }
+  return value
+}
+
+/**
+ * Take a snapshot of a form's fields that is fully DETACHED from the live
+ * values it was read from.
+ *
+ * A shallow copy (`{ ...form }`) is not enough: the settings form holds arrays
+ * (tags, branch prefixes) and nested objects (devServer, e2e, finalization)
+ * that are edited **in place** — `push`, `splice`, or a `v-model` on a nested
+ * field. A shallow snapshot shares those references with the live form, so the
+ * snapshot changes at the same time as the value it is supposed to be compared
+ * against: the dirty check compares the snapshot to itself, concludes nothing
+ * changed, and the unsaved-changes bar never shows up. The edit is then lost
+ * silently when the user leaves the page.
+ */
+export function captureFormSnapshot<T extends Record<string, unknown>>(fields: T): Record<string, unknown> {
+  return deepClonePlain(fields) as Record<string, unknown>
+}

--- a/src/client/src/utils/fuzzy-match.ts
+++ b/src/client/src/utils/fuzzy-match.ts
@@ -47,3 +47,37 @@ export function fuzzyRank(query: string, items: string[]): string[] {
     .sort((a, b) => b.score - a.score)
     .map((r) => r.item)
 }
+
+/**
+ * Rank `items` and keep only the best `limit`, in one pass.
+ *
+ * `fuzzyRank` scored every entry, allocated one wrapper object per entry, then
+ * sorted the whole list before the caller sliced fifty results off it. On a
+ * forty-thousand-file monorepo that ran on every keystroke, inside a
+ * synchronous watcher. This keeps a bounded, sorted array of at most `limit`
+ * entries: same results, same order, no full sort and no forty-thousand-entry
+ * intermediate.
+ *
+ * `score` is injectable so tests can count how many times each item is scored.
+ */
+export function fuzzyRankTop(
+  query: string,
+  items: readonly string[],
+  limit: number,
+  score: (query: string, text: string) => number | null = fuzzyMatch,
+): string[] {
+  if (limit <= 0) return []
+  const best: Array<{ item: string; score: number }> = []
+  for (const item of items) {
+    const value = score(query, item)
+    if (value === null) continue
+    // At capacity, anything not strictly better than the current worst is
+    // dropped — `<=` keeps the earlier item on a tie, matching the stable sort.
+    if (best.length === limit && value <= best[limit - 1].score) continue
+    let i = best.length
+    while (i > 0 && best[i - 1].score < value) i--
+    best.splice(i, 0, { item, score: value })
+    if (best.length > limit) best.pop()
+  }
+  return best.map((entry) => entry.item)
+}

--- a/src/client/src/utils/latest-request.ts
+++ b/src/client/src/utils/latest-request.ts
@@ -1,0 +1,41 @@
+/**
+ * Single-flight guard for a UI that fires one request per click.
+ *
+ * Three quick clicks in the diff file tree used to race: whichever response
+ * landed last won the display, regardless of which file the user actually
+ * asked for — and the sha/base snapshot taken alongside it belonged to the
+ * wrong file, which made the next save inconsistent.
+ *
+ * `begin()` aborts the previous request and returns the new one's signal;
+ * `isCurrent()` lets a resolved handler check whether it is still the one that
+ * matters before touching any shared state.
+ */
+export interface LatestRequest {
+  begin(): AbortSignal
+  isCurrent(signal: AbortSignal): boolean
+  abort(): void
+}
+
+export function createLatestRequest(): LatestRequest {
+  let controller: AbortController | null = null
+  return {
+    begin(): AbortSignal {
+      controller?.abort()
+      controller = new AbortController()
+      return controller.signal
+    },
+    isCurrent(signal: AbortSignal): boolean {
+      return controller !== null && controller.signal === signal && !signal.aborted
+    },
+    abort(): void {
+      controller?.abort()
+      controller = null
+    },
+  }
+}
+
+/** True when an error is the AbortError produced by cancelling a fetch. */
+export function isAbortError(err: unknown): boolean {
+  if (err instanceof DOMException) return err.name === 'AbortError'
+  return typeof err === 'object' && err !== null && (err as { name?: unknown }).name === 'AbortError'
+}

--- a/src/client/src/utils/raf-coalesce.ts
+++ b/src/client/src/utils/raf-coalesce.ts
@@ -1,0 +1,33 @@
+/**
+ * Collapse a burst of calls into a single call on the next animation frame.
+ *
+ * Monaco fires `onDidScrollChange` once per frame while the user drags, and
+ * the handler mutated a deeply reactive array — one write per comment zone —
+ * so every frame triggered a full re-render, in cascade with the per-folder
+ * comment counts. Coalescing turns N writes per frame into one.
+ *
+ * `schedule` and `cancel` are injectable so tests can drive frames
+ * deterministically instead of waiting on a real animation frame.
+ */
+export function coalesceFrames(
+  fn: () => void,
+  schedule: (cb: () => void) => number = requestAnimationFrame,
+  cancel: (id: number) => void = cancelAnimationFrame,
+): { request(): void; cancel(): void } {
+  let pending: number | null = null
+  const run = (): void => {
+    pending = null
+    fn()
+  }
+  return {
+    request(): void {
+      if (pending !== null) return
+      pending = schedule(run)
+    },
+    cancel(): void {
+      if (pending === null) return
+      cancel(pending)
+      pending = null
+    },
+  }
+}

--- a/src/client/src/utils/render-chat-markdown.ts
+++ b/src/client/src/utils/render-chat-markdown.ts
@@ -45,3 +45,57 @@ export function sanitizeChatHtml(html: string, options: RenderChatMarkdownOption
   ensureHook()
   return DOMPurify.sanitize(html, options.addAttr ? { ADD_ATTR: options.addAttr } : undefined)
 }
+
+/** Upper bound on memoised message renders. A feed shows a few hundred
+ *  messages at most; past that, the oldest entry is evicted. */
+export const RENDER_CACHE_LIMIT = 400
+
+const renderCache = new Map<string, string>()
+
+/**
+ * Memoised markdown → HTML conversion for chat messages.
+ *
+ * Folding the event stream recreates a fresh ConversationItem object per token,
+ * so every message on screen looked "new" on every delta and the whole
+ * parse → link-injection → sanitize pipeline re-ran for messages frozen minutes
+ * ago. Forty messages × one hundred fifty deltas is roughly six thousand
+ * sanitize passes for ONE agent message, each instantiating a DOM.
+ *
+ * The cache key is `${cacheKey}::${raw.length}`: a chat message only ever grows
+ * by appending, so its length is a sound content fingerprint and a frozen
+ * message hits the cache forever. `cacheKey` must therefore carry everything
+ * else the render depends on (the message id AND the known document paths).
+ */
+export function renderChatMarkdownCached(
+  cacheKey: string,
+  raw: string,
+  render: (raw: string) => string = (text) => renderChatMarkdown(text),
+): string {
+  const key = `${cacheKey}::${raw.length}`
+  const hit = renderCache.get(key)
+  if (hit !== undefined) return hit
+  const html = render(raw)
+  renderCache.set(key, html)
+  if (renderCache.size > RENDER_CACHE_LIMIT) {
+    // Map preserves insertion order, so the first key is the oldest one.
+    const oldest = renderCache.keys().next().value
+    if (oldest !== undefined) renderCache.delete(oldest)
+  }
+  return html
+}
+
+/** Empty the memo. Tests only — production never needs to invalidate. */
+export function resetChatMarkdownCache(): void {
+  renderCache.clear()
+}
+
+/**
+ * Escape a still-streaming message for direct display. While the engine types,
+ * the text is a truncated markdown fragment anyway (an unterminated code fence,
+ * half a table row), so parsing it is both wasted work and visually unstable.
+ * Escaped plain text with <br> line breaks is what the reader actually wants
+ * until the message closes and the full pipeline runs once.
+ */
+export function escapeStreamingText(raw: string): string {
+  return raw.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/\n/g, '<br>')
+}

--- a/src/client/src/utils/review-comment-counts.ts
+++ b/src/client/src/utils/review-comment-counts.ts
@@ -1,0 +1,34 @@
+export interface CommentPath {
+  filePath: string
+}
+
+/**
+ * Count review comments per file AND per ancestor folder in one pass.
+ *
+ * The previous per-folder count re-scanned the whole comment list for every
+ * folder node of the tree, and the template asked for it twice per node — so a
+ * two-hundred-file diff with fifty comments did twenty thousand string
+ * comparisons per render, and it re-rendered on every scroll frame.
+ */
+export function countCommentsByPath(comments: readonly CommentPath[]): {
+  byFile: Map<string, number>
+  byFolder: Map<string, number>
+} {
+  const byFile = new Map<string, number>()
+  const byFolder = new Map<string, number>()
+
+  for (const comment of comments) {
+    const path = comment.filePath
+    byFile.set(path, (byFile.get(path) ?? 0) + 1)
+
+    const parts = path.split('/')
+    let current = ''
+    // The last segment is the file itself — never a folder.
+    for (let i = 0; i < parts.length - 1; i++) {
+      current = current === '' ? parts[i] : `${current}/${parts[i]}`
+      byFolder.set(current, (byFolder.get(current) ?? 0) + 1)
+    }
+  }
+
+  return { byFile, byFolder }
+}

--- a/src/client/src/utils/wait-for.ts
+++ b/src/client/src/utils/wait-for.ts
@@ -1,0 +1,49 @@
+import { type WatchSource, watch } from 'vue'
+
+/**
+ * Resolve as soon as `source` satisfies `predicate`, or after `timeoutMs`.
+ *
+ * Replaces the `while (…) await sleep(50)` busy loops: those woke the event
+ * loop twenty to fifty times a second for up to fifteen seconds, and could
+ * never react faster than their own polling interval. Returns true when the
+ * predicate was met, false on timeout.
+ */
+export function waitForCondition<T>(
+  source: WatchSource<T>,
+  predicate: (value: T) => boolean,
+  timeoutMs: number,
+): Promise<boolean> {
+  return new Promise<boolean>((resolve) => {
+    let settled = false
+    let timer: ReturnType<typeof setTimeout> | null = null
+    let stop: (() => void) | null = null
+
+    const finish = (met: boolean): void => {
+      if (settled) return
+      settled = true
+      if (timer !== null) clearTimeout(timer)
+      timer = null
+      // `stop` may still be undefined when the predicate holds on the
+      // immediate run — the guard below unwatches in that case.
+      stop?.()
+      resolve(met)
+    }
+
+    stop = watch(
+      source,
+      (value) => {
+        if (predicate(value)) finish(true)
+      },
+      { immediate: true },
+    )
+
+    if (settled) {
+      // The immediate run already matched: the watcher we just created has to
+      // go, since `finish` ran before `stop` was assigned.
+      stop()
+      return
+    }
+
+    timer = setTimeout(() => finish(false), timeoutMs)
+  })
+}

--- a/src/server/routes/git.ts
+++ b/src/server/routes/git.ts
@@ -25,15 +25,22 @@ app.get('/branches', (c) => {
   }
 })
 
-// GET /api/git/files?path=<worktreePath> — list a worktree's files (tracked +
-// untracked-but-not-ignored) for the chat's `@file` autocomplete.
+/** Hard ceiling on the worktree listing. `listWorktreeFiles` already truncates
+ *  at this value; exposing it lets a caller ask for LESS, never for more. */
+const MAX_WORKTREE_FILES = 5000
+
+// GET /api/git/files?path=<worktreePath>&limit=<n> — list a worktree's files
+// (tracked + untracked-but-not-ignored) for the chat's `@file` autocomplete.
 app.get('/files', (c) => {
   try {
     const repoPath = c.req.query('path')
     if (!repoPath) {
       return c.json({ error: 'Missing required query parameter: path' }, 400)
     }
-    return c.json({ files: listWorktreeFiles(repoPath) })
+    const requested = Number.parseInt(c.req.query('limit') ?? '', 10)
+    const limit =
+      Number.isFinite(requested) && requested > 0 ? Math.min(requested, MAX_WORKTREE_FILES) : MAX_WORKTREE_FILES
+    return c.json({ files: listWorktreeFiles(repoPath, limit) })
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err)
     return c.json({ error: message }, 500)


### PR DESCRIPTION
## Summary
- Fixes the dominant perceived-speed cost: chat markdown was re-parsed and re-sanitized for every message on screen on every token any message received (~6,000 DOM sanitization passes per agent message). Streaming text now renders as escaped plain text and pays the full pipeline once, on close; a finished message is memoized by id and length.
- Incremental folding replaces only the items that actually changed, reusing every untouched item's reference — the property the markdown memo and the live feed's Vue rendering both depend on. Getting this backwards silently freezes the feed; two review passes were needed to land it correctly (mutate to preserve identity, but publish a new reference on every real change).
- Background polling stops while the tab is hidden and catches up instantly when visible again; Monaco no longer loads four unused language-server workers; list keys are stable, diff computation prunes identical prefixes/suffixes before the quadratic walk, and the file-mention popup ranks top-K without a full sort.
- A diff load, file click, or comment count no longer risks a stale response overwriting what the user already moved on to.
- Fixes a second frozen-content bug and a settings save-bar regression where mutating a nested field in place changed the saved snapshot along with the live value, so an edit could go unsaved without warning.

## Test plan
- [x] `make ci` passes locally (install, audit, lint, tsc, backend + client test suites)
- [x] Backend 2391 -> 2396 tests, client 740 -> 838 tests, all green